### PR TITLE
Another Cxxtest fix! Aiii!

### DIFF
--- a/lib/FindCxxtest.cmake
+++ b/lib/FindCxxtest.cmake
@@ -14,7 +14,11 @@
 # for the Python version.
 FIND_PACKAGE(PythonInterp)
 IF (PYTHONINTERP_FOUND)
-	FIND_PATH(CXXTEST_PYTHON_BIN_DIR cxxtestgen
+	# Look for the .py version first.  Some versions of cxxtest have a
+	# non-py version, but it crashes and burns, so, use the .py version
+	# preferentially, in order to maintain compatibility across (all??)
+	# versions of cxxtest
+	FIND_PATH(CXXTEST_PYTHON_BIN_DIR cxxtestgen.py
 		$ENV{CXXTEST_BIN_DIR}
 		/usr/bin
 		/usr/local/bin
@@ -22,13 +26,13 @@ IF (PYTHONINTERP_FOUND)
 	)
 	IF (CXXTEST_PYTHON_BIN_DIR)
 		SET(CXXTEST_FOUND 1)
-		SET(CXXTEST_GEN "${CXXTEST_PYTHON_BIN_DIR}/cxxtestgen" CACHE FILEPATH "CxxTest binary filepath")
+		SET(CXXTEST_GEN "${CXXTEST_PYTHON_BIN_DIR}/cxxtestgen.py" CACHE FILEPATH "CxxTest binary filepath")
 	ENDIF (CXXTEST_PYTHON_BIN_DIR)
 
 	# Sometimes, the python version doesn't have a .py extension.
 	# repeat the above search, without the extension.
 	IF (NOT CXXTEST_FOUND)
-		FIND_PATH(CXXTEST_PYTHON_BIN_DIR cxxtestgen.py
+		FIND_PATH(CXXTEST_PYTHON_BIN_DIR cxxtestgen
 			$ENV{CXXTEST_BIN_DIR}
 			/usr/bin
 			/usr/local/bin
@@ -36,7 +40,7 @@ IF (PYTHONINTERP_FOUND)
 		)
 		IF (CXXTEST_PYTHON_BIN_DIR)
 			SET(CXXTEST_FOUND 1)
-			SET(CXXTEST_GEN "${CXXTEST_PYTHON_BIN_DIR}/cxxtestgen.py" CACHE FILEPATH "CxxTest binary filepath")
+			SET(CXXTEST_GEN "${CXXTEST_PYTHON_BIN_DIR}/cxxtestgen" CACHE FILEPATH "CxxTest binary filepath")
 		ENDIF (CXXTEST_PYTHON_BIN_DIR)
 	ENDIF (NOT CXXTEST_FOUND)
 ENDIF (PYTHONINTERP_FOUND)


### PR DESCRIPTION
Look for the .py version first.  Some versions of cxxtest have a
non-py version, but it crashes and burns, so, use the .py version
preferentially, in order to maintain compatibility across (all??)
versions of cxxtest
