### PR TITLE
combo: avoid divide by zero

### DIFF
--- a/opencog/comboreduct/table/table.h
+++ b/opencog/comboreduct/table/table.h
@@ -599,7 +599,11 @@ double mutualInformation(const CTable& ctable, const FeatureSet& fs)
         }
 
         // Compute H(Y)
-        yentropy =  binaryEntropy(oc/total);
+        if (0.0 < total) {
+            yentropy = binaryEntropy(oc/total);
+        } else {
+            yentropy = 0.0;
+        }
     }
     else if (id::enum_type == otype)
     {


### PR DESCRIPTION
This caused a quiet NaN, which then triggered OC_ASSERT in binaryEntropy.
