### PR TITLE
moses: update extraction scripts to use cogutil

### DIFF
--- a/scripts/learning/moses/extract_moses/OC2MOSES.sh
+++ b/scripts/learning/moses/extract_moses/OC2MOSES.sh
@@ -159,8 +159,8 @@ echo "ADD_SUBDIRECTORY(feature-selection)" >> "$ABS_MOSES_DIR/$PROJECT/learning/
 
 # ----------
 # util CMakeLists.txt
-echo "ADD_LIBRARY(util STATIC algorithm based_variant digraph dorepeat exceptions functional.h iostreamContainer lazy_normal_selector lazy_random_selector lazy_selector random oc_assert Config Logger log_prog_name lru_cache mt19937ar platform tree oc_omp Counter KLD MannWhitneyU ranking)" > "$ABS_MOSES_DIR/$PROJECT/util/CMakeLists.txt"
-echo "TARGET_LINK_LIBRARIES(util \${Boost_FILESYSTEM_LIBRARY} \${Boost_SYSTEM_LIBRARY} \${Boost_REGEX_LIBRARY} \${Boost_THREAD_LIBRARY})" >> "$ABS_MOSES_DIR/$PROJECT/util/CMakeLists.txt"
+echo "ADD_LIBRARYcogutil STATIC algorithm based_variant digraph dorepeat exceptions functional.h iostreamContainer lazy_normal_selector lazy_random_selector lazy_selector random oc_assert Config Logger log_prog_name lru_cache mt19937ar platform tree oc_omp Counter KLD MannWhitneyU ranking)" > "$ABS_MOSES_DIR/$PROJECT/util/CMakeLists.txt"
+echo "TARGET_LINK_LIBRARIES(cogutil \${Boost_FILESYSTEM_LIBRARY} \${Boost_SYSTEM_LIBRARY} \${Boost_REGEX_LIBRARY} \${Boost_THREAD_LIBRARY})" >> "$ABS_MOSES_DIR/$PROJECT/util/CMakeLists.txt"
 echo "INSTALL(FILES ${UTIL_FILES[@]} DESTINATION \"include/\${PROJECT_NAME}/util\")" >> "$ABS_MOSES_DIR/$PROJECT/util/CMakeLists.txt"
 
 ###############

--- a/scripts/learning/moses/extract_moses/moses.spec
+++ b/scripts/learning/moses/extract_moses/moses.spec
@@ -1,5 +1,5 @@
 %define name moses
-%define version 3.2.13
+%define version 3.4.0
 %define release 1
 
 Summary: MOSES automated program learning system


### PR DESCRIPTION
Failed to update this file during the previous util->cogutil rename.
That's because this script is infrequently run.  Update the RPM spec too.
