### PR TITLE
"Uncommented missing .py file"

### DIFF
--- a/opencog/python/pln_examples.py
+++ b/opencog/python/pln_examples.py
@@ -47,7 +47,7 @@ both/AnotBdemo_partial_test.conf
 both/28_test.conf
 bc/plus_test.conf
 #bc/new/pathfinding_test.conf
-bc/new/before_test.conf
+#bc/new/before_test.conf
 ''')
 
 #files_list = '''bc/new/before_test.conf'''


### PR DESCRIPTION
Umcommented a missing file that caused the last Python PLN test to fail.
