### PR TITLE
Set discriminating_bscore::_full_bscore to true

### DIFF
--- a/opencog/learning/moses/scoring/scoring.cc
+++ b/opencog/learning/moses/scoring/scoring.cc
@@ -333,7 +333,7 @@ discriminating_bscore::discriminating_bscore(const CTable& ct,
       _min_threshold(min_threshold),
       _max_threshold(max_threshold),
       _hardness(hardness),
-      full_bscore(false)
+      _full_bscore(true)
 {
     logger().info("Discriminating scorer, hardness = %f, "
                   "min_threshold = %f, "


### PR DESCRIPTION
I compared learning using prerec given some table with 251 features
for discriminating_bscore::_full_bscore set to true and false about
measured no difference. So I set discriminating_bscore::_full_bscore
to true as it's makes diversity work better (2x better according to my
measurements).
