### PR TITLE
Hush Python build errors

### DIFF
--- a/opencog/cython/PyIncludeWrapper.h
+++ b/opencog/cython/PyIncludeWrapper.h
@@ -1,0 +1,16 @@
+
+// XXX Cython currently conflicts with standard C library defintions.
+// The push/pop below should hush it, for now. (needed for cython
+// 0.15.1 and maybe other versions)  FIXME someday...
+#ifdef _GNU_SOURCE
+#pragma push_macro("_POSIX_C_SOURCE")
+#pragma push_macro("_XOPEN_SOURCE")
+#undef _POSIX_C_SOURCE
+#undef _XOPEN_SOURCE
+#endif
+#include <Python.h>
+#ifdef _GNU_SOURCE
+#pragma pop_macro("_POSIX_C_SOURCE")
+#pragma pop_macro("_XOPEN_SOURCE")
+#endif
+

--- a/opencog/cython/PyMindAgent.h
+++ b/opencog/cython/PyMindAgent.h
@@ -25,7 +25,7 @@
 
 #include <string>
 
-#include <Python.h>
+#include "PyIncludeWrapper.h"
 
 #include <opencog/server/Agent.h>
 #include <opencog/server/Factory.h>

--- a/opencog/cython/PyRequest.h
+++ b/opencog/cython/PyRequest.h
@@ -25,7 +25,7 @@
 
 #include <string>
 
-#include <Python.h>
+#include "PyIncludeWrapper.h"
 
 #include <opencog/server/Request.h>
 #include <opencog/server/Factory.h>

--- a/opencog/cython/PythonEval.h
+++ b/opencog/cython/PythonEval.h
@@ -38,7 +38,7 @@
 #ifndef OPENCOG_PYTHON_EVAL_H
 #define OPENCOG_PYTHON_EVAL_H
 
-#include <Python.h>
+#include "PyIncludeWrapper.h"
 
 #include <string>
 

--- a/opencog/cython/PythonModule.h
+++ b/opencog/cython/PythonModule.h
@@ -4,7 +4,7 @@
 #ifndef _OPENCOG_PYTHON_MODULE_H
 #define _OPENCOG_PYTHON_MODULE_H
 
-#include <Python.h>
+#include "PyIncludeWrapper.h"
 
 #include <string>
 


### PR DESCRIPTION
Wrapper the Cython header file, which conflicts with standard
C library includes.
