### PR TITLE
Nmxmlparser.cc compile issue fix with boost 1.53

### DIFF
--- a/opencog/persist/xml/NMXmlParser.cc
+++ b/opencog/persist/xml/NMXmlParser.cc
@@ -245,7 +245,7 @@ throw (RuntimeException, InconsistenceException)
             boost::shared_ptr<Atom> currentAtom = top(ud->stack);
             if (currentAtom) {
                 logger().fine("Getting link element inside currentAtom = %p", currentAtom.get());
-                boost::shared_ptr<Link> link = boost::shared_dynamic_cast<Link>(currentAtom);
+                boost::shared_ptr<Link> link = boost::dynamic_pointer_cast<Link>(currentAtom);
                 if (link) {
                     if (r) {
                         NMXmlParser::addOutgoingAtom(link,Handle::UNDEFINED);
@@ -295,7 +295,7 @@ throw (RuntimeException, InconsistenceException)
             logger().fine(" => h = %p", h.value());
             if (ud->atomSpace->isValidHandle(h)) {
                 logger().fine(ud->atomSpace->atomAsString(h).c_str());
-                boost::shared_ptr<Link> link = boost::shared_dynamic_cast<Link>(currentAtom);
+                boost::shared_ptr<Link> link = boost::dynamic_pointer_cast<Link>(currentAtom);
                 if (link) {
                     logger().fine("adding atom %s to link %s", ud->atomSpace->atomAsString(h,true).c_str(), link->toShortString().c_str());
                     NMXmlParser::addOutgoingAtom(link,h);
@@ -345,7 +345,7 @@ throw (InconsistenceException)
                     if (classserver().isA(type, UNORDERED_LINK)) {
                         // Forces the sorting of outgoing by calling setOutgoingSet
                         // TODO: implement a sortOutgoingSet for doing the same thing more efficiently...
-                        boost::shared_ptr<Link> link = boost::shared_dynamic_cast<Link>(currentAtom);
+                        boost::shared_ptr<Link> link = boost::dynamic_pointer_cast<Link>(currentAtom);
                         if (link) {
                             std::vector<Handle> outgoing = link->getOutgoingSet();
                             NMXmlParser::setOutgoingSet(link, outgoing);
@@ -383,7 +383,7 @@ throw (InconsistenceException)
                         logger().fine("(3) Pushing currentAtom = %p", currentAtom.get());
                         push(ud->stack, currentAtom);
 
-                        boost::shared_ptr<Link> nextlink = boost::shared_dynamic_cast<Link>(nextUd);
+                        boost::shared_ptr<Link> nextlink = boost::dynamic_pointer_cast<Link>(nextUd);
                         if (nextlink) {
                             int arity = nextlink->getArity();
                             std::vector<Handle> outgoingSet = nextlink->getOutgoingSet();
@@ -431,7 +431,7 @@ NMXmlParser::~NMXmlParser()
 
 void NMXmlParser::setNodeName(boost::shared_ptr<Atom> node, const char* name)
 {
-    boost::shared_ptr<Node> n = boost::shared_dynamic_cast<Node>(node);
+    boost::shared_ptr<Node> n = boost::dynamic_pointer_cast<Node>(node);
     n->setName(name);
 }
 


### PR DESCRIPTION
I've replaced occurrences of shared_dynamic_cast with dynamic_pointer_cast to support compilation when boost 1.53.0 is being used. The file affected is nmxmlparser.cc. There may also be other source files having the same issue, but I've not come across them yet!
