### PR TITLE
Fully working Vagrant config for creating OpenCog development environment

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+# Documentation: http://wiki.opencog.org/w/Setup_OpenCog_development_environment_VM_using_Vagrant
+
 Vagrant.configure("2") do |config|
   # All Vagrant configuration is done here. For a complete reference of
   # available configuration options, please see the online documentation
@@ -56,7 +58,7 @@ Vagrant.configure("2") do |config|
                    "--memory", "1550",
                    "--name", "opencog-dev-vm",
                    # When the VM isn't running, you can change the "1" below to the number of host cores you want to assign to VM:
-                   "--cpus", "2"
+                   "--cpus", "1"
                    ]
   end
 end

--- a/vagrant-configs/vagrant-vm-setup.sh
+++ b/vagrant-configs/vagrant-vm-setup.sh
@@ -4,6 +4,8 @@
 # TODO: 
 # 1. Automatically detect if user's computer has 32-bit or 64-bit OS
 #    installed. And boot Ubuntu precise32 or precise64 accordingly.
+#
+# Documentation: http://wiki.opencog.org/w/Setup_OpenCog_development_environment_VM_using_Vagrant
 
 echo "==========================================================="
 echo "[vagrant-vm-setup.sh] Setting up vagrant VM, please wait..."


### PR DESCRIPTION
Automatically sets up a Ubuntu 12.04 (precise) VM, installs OpenCog build dependencies and builds OpenCog in /vagrant directory

Documentation at http://wiki.opencog.org/w/Setup_OpenCog_development_environment_VM_using_Vagrant

If you face any errors/problems, feel free to comment here or on email.
