### PR TITLE
Removing extra mutex lock in ClassServer::getNumberOfClasses() - not needed

### DIFF
--- a/opencog/atomspace/ClassServer.cc
+++ b/opencog/atomspace/ClassServer.cc
@@ -120,7 +120,6 @@ boost::signal<void (Type)>& ClassServer::addTypeSignal()
 
 unsigned int ClassServer::getNumberOfClasses()
 {
-    boost::mutex::scoped_lock l(type_mutex);
     return nTypes;
 }
 

--- a/opencog/persist/sql/AtomStorage.cc
+++ b/opencog/persist/sql/AtomStorage.cc
@@ -831,7 +831,8 @@ void AtomStorage::setup_typemap(void)
 	rp.rs->foreach_row(&Response::type_cb, &rp);
 	rp.rs->release();
 
-	for (Type t=0; t<classserver().getNumberOfClasses(); t++)
+	unsigned int numberOfTypes = classserver().getNumberOfClasses();
+	for (Type t=0; t<numberOfTypes; t++)
 	{
 		int sqid = storing_typemap[t];
 		/* If this typename is not yet known, record it */

--- a/opencog/persist/xml/NMXmlExporter.cc
+++ b/opencog/persist/xml/NMXmlExporter.cc
@@ -109,7 +109,8 @@ std::string NMXmlExporter::toXML(const UnorderedHandleSet *elements)
     }
     sprintf(aux, "<%s>\n", TAG_DESCRIPTION_TOKEN);
     result += aux;
-    for (unsigned int i = 0 ; i < classserver().getNumberOfClasses(); i++) {
+    unsigned int numberOfTypes = classserver().getNumberOfClasses();
+    for (unsigned int i = 0 ; i < numberOfTypes; i++) {
         if (typesUsed[i]) {
             sprintf(aux, "<%s %s=\"%s\" %s=\"%s\" />\n", TAG_TOKEN, NAME_TOKEN, classserver().getTypeName(i).c_str(), VALUE_TOKEN, classserver().getTypeName(i).c_str());
             result += aux;


### PR DESCRIPTION
Removing extra mutex lock in ClassServer::getNumberOfClasses() - not needed
Two calls to it in loops were changed, just in case. Anyway, maybe these should be marked as todo, because the number of classes may change while the loop executes.
