### PR TITLE
Fixing output directory for documentation

### DIFF
--- a/doc/doxygen.conf.in
+++ b/doc/doxygen.conf.in
@@ -38,7 +38,7 @@ PROJECT_NUMBER         = "Branch: @BZR_NICK@, revision @BZR_REVNO@"
 # If a relative path is entered, it will be relative to the location 
 # where doxygen was started. If left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = @CMAKE_CURRENT_BINARY_DIR@/doc
+OUTPUT_DIRECTORY       = @CMAKE_CURRENT_BINARY_DIR@
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create 
 # 4096 sub-directories (in 2 levels) under the output directory of each output 
@@ -551,7 +551,7 @@ WARN_FORMAT            = "$file:$line: $text"
 # and error messages should be written. If left blank the output is written 
 # to stderr.
 
-WARN_LOGFILE           = @CMAKE_CURRENT_BINARY_DIR@/doc/doxygen.warnings
+WARN_LOGFILE           = @CMAKE_CURRENT_BINARY_DIR@/doxygen.warnings
 
 #---------------------------------------------------------------------------
 # configuration options related to the input files


### PR DESCRIPTION
In order to make the css work I've changed in a previous commit the working directory for doxygen to CMAKE_CURRENT_SOURCE_DIR; the output is placed in CMAKE_CURRENT_BINARY_DIR, and that changed as a result of my change.

This caused the http://buildbot.opencog.org/doxygen/index.html page to be forbidden even if the build succeded. My bad, then.

Long story short, the output is now back where it should be.
