### PR TITLE
Put back the opencog-test.conf file that was deleted in #298

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -3,5 +3,5 @@ CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/lib/opencog-chatbot.conf
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/lib/opencog.conf
     ${PROJECT_BINARY_DIR}/lib/opencog.conf)
 # Create a test configuration file by copying the default configuration file
-CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/lib/opencog.conf
+CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/lib/opencog-test.conf
     ${PROJECT_BINARY_DIR}/lib/opencog-test.conf)

--- a/lib/opencog-test.conf
+++ b/lib/opencog-test.conf
@@ -1,0 +1,36 @@
+# This is an example config file for various opencog unit tests.
+# You should fill in the appropriate details.
+#
+# This config file is used by various opencog unit tests.
+# Of particular importance is the test database name and login credentials.
+#
+SERVER_PORT           = 17001
+LOG_FILE              = opencog-test.log
+
+LOG_LEVEL             = debug
+LOG_TO_STDOUT         = true
+SERVER_CYCLE_DURATION = 100
+IDLE_CYCLES_PER_TICK  = 3
+STARTING_STI_FUNDS    = 10000
+STARTING_LTI_FUNDS    = 10000
+STI_FUNDS_BUFFER      = 10000
+LTI_FUNDS_BUFFER      = 10000
+MIN_STI               = -400
+PROMPT                = "opencog> "
+MODULES               = opencog/server/libbuiltinreqs.so,
+                        opencog/persist/sql/libpersist.so,
+                        opencog/nlp/types/libnlp-types.so,
+                        opencog/query/libquery.so,
+                        opencog/shell/libscheme-shell.so
+
+# Used in the PLNUTest
+PLN_LOG_LEVEL         = 2
+PLN_PRINT_REAL_ATOMS  = true
+
+# IMPORTANT!
+# Database login credentials. Uncomment and change these to reflect your actual
+# setup!
+#
+TEST_DB_NAME          = "opencog_test"
+TEST_DB_USERNAME      = "opencog"
+TEST_DB_PASSWD        = "cheese"


### PR DESCRIPTION
The file opencog-test.conf already existed under the name opencog-test.conf.example in acf88c1652d9591f8339af7c20a974025c316396. It was deleted in #298. Adding it back again.
