### PR TITLE
Fix paths in import statements in monitor_changes.py

### DIFF
--- a/opencog/python/monitor_changes.py
+++ b/opencog/python/monitor_changes.py
@@ -1,15 +1,8 @@
 from opencog.atomspace import AtomSpace, types, Atom, Handle, TruthValue, types as t
 import opencog.cogserver
-from tree import *
-import adaptors
-from util import *
-from itertools import *
-from collections import namedtuple
-import sys
-import time
 import random
-from time      import sleep
-from threading import Thread
+from time import sleep
+
 
 def monitor_changes(atomspace):    
     tv_delta = 0.1 


### PR DESCRIPTION
Fixes #342. Since the recent PLN code organized some files into subdirectories, monitor_changes.py failed to run due to an unused import statement referencing files that no longer existed in their previous location.
