### PR TITLE
PLN Chainer class should set the value of instance variable learnRuleFre...

### DIFF
--- a/opencog/python/pln/chainers.py
+++ b/opencog/python/pln/chainers.py
@@ -196,6 +196,7 @@ class Chainer(AbstractChainer):
         # It stores a reference to the MindAgent object so it can stimulate atoms.
         self._stimulateAtoms = stimulateAtoms
         self._agent = agent
+        self.learnRuleFrequencies = learnRuleFrequencies
 
         self.atomspace = atomspace
 
@@ -218,7 +219,6 @@ class Chainer(AbstractChainer):
         def constant_factory():
             return initial_frequency
         if learnRuleFrequencies:
-            self.learnRuleFrequencies = True
             self.rule_count = defaultdict(constant_factory)
 
     def forward_step(self, rule=None):


### PR DESCRIPTION
...quencies when initialized, because the AbstractChainer class expects learnRuleFrequencies to have a value.
