### PR TITLE
Fix cogserver crash on boost:asio race condition

### DIFF
--- a/opencog/server/NetworkServer.cc
+++ b/opencog/server/NetworkServer.cc
@@ -126,7 +126,8 @@ bool NetworkServer::removeListener(const unsigned short port)
         logger().warn("unable to remove listener from port %d", port);
         return false;
     }
-    delete *l;
+    SocketPort* sp = *l;
     _listeners.erase(l);
+    delete sp;
     return true;
 }

--- a/opencog/server/NetworkServer.h
+++ b/opencog/server/NetworkServer.h
@@ -110,7 +110,8 @@ public:
      * successful and 'false' otherwise.
      */
     template<class _Socket>
-    bool addListener(const unsigned int port) {
+    bool addListener(const unsigned int port)
+    {
         logger().debug("adding listener to port %d", port);
         SocketListener<_Socket>* sl = new SocketListener<_Socket>(io_service, port);
         //TODO: Error handling (what if bind does not work?)

--- a/opencog/server/README
+++ b/opencog/server/README
@@ -67,9 +67,13 @@ ToDo/Bugs:
   MindAgents can be loaded directly (and the CogServer will load the
   appropriate module(s) first).
 
-* Need to create classes to handle the specia commands ctrl-D (0x04)
+* Need to create classes to handle the special commands ctrl-D (0x04)
   and ctrl-C (0xff 0xf4 0xff 0xfd  0x06) which is a sequence of telent
   commands and also to handle "quit" as a synonym for "exit".
   The ctrl-C and etc can be handled just like any other command... 
 
-
+* The boost:asio API is insane. Its buggy, it leaks memory, and frankly,
+  I just don't understand it. It needs to be vastly simplified. The
+  thing here is over-engineered and undebuggable.  Right now, there's
+  some race condition where the asio is deleting an instance of the
+  console socket, which is still in use, resulting in a crash. WTF.

--- a/opencog/server/Request.cc
+++ b/opencog/server/Request.cc
@@ -37,16 +37,21 @@ Request::Request(CogServer& cs) :
 Request::~Request()
 {
     logger().debug("[Request] destructor");
-    if (_requestResult) _requestResult->OnRequestComplete();
+    if (_requestResult) {
+        _requestResult->OnRequestComplete();
+        _requestResult->put();  // dec use count we are doe with it.
+    }
 }
 
 void Request::setRequestResult(RequestResult* rr)
 {
     logger().debug("[Request] setting requestResult: %p", rr);
     if (NULL == _requestResult) {
+        rr->get();  // inc use count -- we plan to use the req res
         _requestResult = rr;
         _mimeType = _requestResult->mimeType();
     } else if (NULL == rr) {
+        if (_requestResult) _requestResult->put();  // dec use count we are doe with it.
         _requestResult = NULL;  // used by exit/quit commands to not send any result.
     } else
         throw RuntimeException(TRACE_INFO,


### PR DESCRIPTION
cogserver is crashing because boost:asio was prematurely calling
destructors on classes that were still in use.  This was effing
painful to debug.

```
// Some details: basically, the remote end of the socket "fires and
// forgets" a bunch of commands, and then closes the socket before
// these requests have completed.  boost:asio notices that the
// remote socket has closed, and so decides its a good day to call
// destructors. But of course, its not ...
```
