### PR TITLE
Re-enable rnrs io ports. It shouldn't have been disabled. Fixes #483.

### DIFF
--- a/opencog/scm/file-utils.scm
+++ b/opencog/scm/file-utils.scm
@@ -17,7 +17,7 @@
 (use-modules (ice-9 rdelim))
 (use-modules (ice-9 popen))
 (use-modules (ice-9 rw))
-; (use-modules (rnrs io ports))
+(use-modules (rnrs io ports))
 
 ; ---------------------------------------------------------------------
 (define (list-files dir)


### PR DESCRIPTION
Note that OpenCog now requires guile-2.0 and guile-2.0-dev.
