### PR TITLE
Second part of #533. Add filter parameter to AtomAPI to include incoming...

### DIFF
--- a/opencog/python/web/api/apiatomcollection.py
+++ b/opencog/python/web/api/apiatomcollection.py
@@ -37,7 +37,9 @@ class AtomCollectionAPI(Resource):
     def get(self):
         """
         Returns a list of atoms matching the specified criteria
-        Uri: atoms?type=[type]&name=[name]&filterby=[filterby]&callback=[callback]
+        Uri: atoms?type=[type]&name=[name]&filterby=[filterby]&tvStrengthMin=[tvStrengthMin]
+            &tvConfidenceMin=[tvConfidenceMin]&tvCountMin=[tvCountMin]&includeIncoming=[includeIncoming]
+            &includeOutgoing=[includeOutgoing]&callback=[callback]
 
         :param type: (optional) Atom type, see http://wiki.opencog.org/w/OpenCog_Atom_types
         :param name: (optional, string, not allowed for Link types) Atom name
@@ -145,12 +147,10 @@ class AtomCollectionAPI(Resource):
             atoms = [atom for atom in atoms if atom.tv.count >= tv_count_min]
 
         # Optionally, include the incoming set
-        print 'Include incoming: {0}'.format(include_incoming)
         if include_incoming in ['True', 'true', '1']:
             atoms = self.atomspace.include_incoming(atoms)
 
         # Optionally, include the outgoing set
-        print 'Include incoming: {0}'.format(include_outgoing)
         if include_outgoing in ['True', 'true', '1']:
             atoms = self.atomspace.include_outgoing(atoms)
 

--- a/opencog/python/web/api/apimain.py
+++ b/opencog/python/web/api/apimain.py
@@ -19,10 +19,10 @@ class RESTAPI(object):
     Prerequisites:
     Flask, mock, flask-restful, six
 
-    Default endpoint: http://127.0.0.1:5000/api/v1.0/
+    Default endpoint: http://127.0.0.1:5000/api/v1.1/
     (Replace 127.0.0.1 with the IP address of the server if necessary)
 
-    Example request: http://127.0.0.1:5000/api/v1.0/atoms?type=ConceptNode
+    Example request: http://127.0.0.1:5000/api/v1.1/atoms?type=ConceptNode
 
     See: opencog/python/web/api/exampleclient.py for detailed examples of usage, and review
     the method definitions in each resource for request/response specifications.
@@ -37,9 +37,9 @@ class RESTAPI(object):
         atom_api = AtomAPI.new(self.atomspace)
         atom_collection_api = AtomCollectionAPI.new(self.atomspace)
         atom_types_api = TypesAPI()
-        self.api.add_resource(atom_collection_api, '/api/v1.0/atoms', endpoint='atoms')
-        self.api.add_resource(atom_api, '/api/v1.0/atoms/<int:id>', endpoint='atom')
-        self.api.add_resource(atom_types_api, '/api/v1.0/types', endpoint='types')
+        self.api.add_resource(atom_collection_api, '/api/v1.1/atoms', endpoint='atoms')
+        self.api.add_resource(atom_api, '/api/v1.1/atoms/<int:id>', endpoint='atom')
+        self.api.add_resource(atom_types_api, '/api/v1.1/types', endpoint='types')
 
     def run(self, host='127.0.0.1', port=5000):
         """

--- a/opencog/python/web/api/exampleclient.py
+++ b/opencog/python/web/api/exampleclient.py
@@ -14,7 +14,7 @@ import json
 # Define the API Endpoint - replace 127.0.0.1 with the server IP address if necessary
 IP_ADDRESS = '127.0.0.1'
 PORT = '5000'
-uri = 'http://' + IP_ADDRESS + ':' + PORT + '/api/v1.0/'
+uri = 'http://' + IP_ADDRESS + ':' + PORT + '/api/v1.1/'
 headers = {'content-type': 'application/json'}
 
 # Pretty print function for displaying JSON request/response information
@@ -32,7 +32,7 @@ post_response = post(uri + 'atoms', data=json.dumps(atom), headers=headers)
 post_result = post_response.json()['atoms']
 pprint(post_response, post_result)
 '''
-POST /api/v1.0/atoms:
+POST /api/v1.1/atoms:
 {
   "outgoing": [],
   "incoming": [],
@@ -58,10 +58,10 @@ POST /api/v1.0/atoms:
 # GET the newly created node
 handle_node_1 = post_result['handle']
 get_response = get(uri + 'atoms/' + str(handle_node_1))
-get_result = get_response.json()['atoms']
+get_result = get_response.json()['result']['atoms']
 pprint(get_response, get_result)
 '''
-GET /api/v1.0/atoms/57:
+GET /api/v1.1/atoms/57:
 {
   "outgoing": [],
   "incoming": [],
@@ -90,7 +90,7 @@ get_response = get(uri + 'atoms', params={'name': name})
 get_result = get_response.json()['result']['atoms'][0]
 pprint(get_response, get_result)
 '''
-GET /api/v1.0/atoms?name=giant_frog:
+GET /api/v1.1/atoms?name=giant_frog:
 {
   "outgoing": [],
   "incoming": [],
@@ -120,7 +120,7 @@ get_response = get(uri + 'atoms', params={'name': name, 'type': type})
 get_result = get_response.json()['result']['atoms'][0]
 pprint(get_response, get_result)
 '''
-GET /api/v1.0/atoms?name=giant_frog&type=ConceptNode:
+GET /api/v1.1/atoms?name=giant_frog&type=ConceptNode:
 {
   "outgoing": [],
   "incoming": [],
@@ -151,7 +151,7 @@ post_result = post_response.json()['atoms']
 handle_node_2 = post_result['handle']
 pprint(post_response, post_result)
 '''
-POST /api/v1.0/atoms:
+POST /api/v1.1/atoms:
 {
   "outgoing": [],
   "incoming": [],
@@ -181,7 +181,7 @@ post_response = post(uri + 'atoms', data=json.dumps(atom), headers=headers)
 post_result = post_response.json()['atoms']
 pprint(post_response, post_result)
 '''
-POST /api/v1.0/atoms:
+POST /api/v1.1/atoms:
 {
   "outgoing": [
     57,
@@ -218,7 +218,7 @@ put_response = put(uri + 'atoms/' + str(handle_node_1), data=json.dumps(atom_upd
 put_result = put_response.json()['atoms']
 pprint(put_response, put_result)
 '''
-PUT /api/v1.0/atoms/76:
+PUT /api/v1.1/atoms/76:
 {
   "outgoing": [],
   "incoming": [
@@ -251,7 +251,7 @@ delete_response = delete(uri + 'atoms/' + str(handle_node_1))
 delete_result = delete_response.json()['result']
 pprint(delete_response, delete_result)
 '''
-DELETE /api/v1.0/atoms/76:
+DELETE /api/v1.1/atoms/76:
 {
   "handle": 76,
   "success": true

--- a/opencog/python/web/api/restapi.py
+++ b/opencog/python/web/api/restapi.py
@@ -32,8 +32,8 @@ class Start(opencog.cogserver.Request):
     "Starts the OpenCog REST API. This will provide a REST interface to the Atomspace,\n" \
     "allowing you to create, read, update and delete atoms across the network using\n" \
     "HTTP requests/responses with JSON-formatted data.\n\n" \
-    "Default endpoint: http://127.0.0.1:5000/api/v1.0/\n" \
-    "Example request: http://127.0.0.1:5000/api/v1.0/atoms?type=ConceptNode"
+    "Default endpoint: http://127.0.0.1:5000/api/v1.1/\n" \
+    "Example request: http://127.0.0.1:5000/api/v1.1/atoms?type=ConceptNode"
 
     def run(self, args, atomspace):
         """


### PR DESCRIPTION
... and outgoing sets. Increment REST API version to v1.1. Tested with upgraded version 0.9 of atomspace visualizer.
