### PR TITLE
Remove references to redundant definition ...

### DIFF
--- a/opencog/python/atom_tracking.py
+++ b/opencog/python/atom_tracking.py
@@ -1,4 +1,4 @@
-from opencog.atomspace import AtomSpace, types, Atom, TruthValue, get_type_name, confidence_to_count
+from opencog.atomspace import AtomSpace, types, Atom, TruthValue, get_type_name
 import opencog.cogserver
 
 class AtomTrackingMindAgent(opencog.cogserver.MindAgent):

--- a/opencog/python/examples/blocksworld.py
+++ b/opencog/python/examples/blocksworld.py
@@ -1,8 +1,8 @@
 try:
-    from opencog.atomspace import AtomSpace, types, Atom, TruthValue, get_type_name, confidence_to_count
+    from opencog.atomspace import AtomSpace, types, Atom, TruthValue, get_type_name
     import opencog.cogserver
 except ImportError:
-    from atomspace_remote import AtomSpace, types, Atom, TruthValue, get_type_name, confidence_to_count
+    from atomspace_remote import AtomSpace, types, Atom, TruthValue, get_type_name
 
 from rules import evaluation_link_template, execution_link_template, actionDone_template
 
@@ -65,7 +65,7 @@ def new_rule(atomspace, action_str, pre_str, post_str):
             postconditions
         )
     )
-    atom_from_tree(pil, atomspace).tv = TruthValue(1, confidence_to_count(1))
+    atom_from_tree(pil, atomspace).tv = TruthValue(1, TruthValue().confidence_to_count(1))
 
     print pil
     return pil
@@ -152,7 +152,7 @@ def blocksworld_rules(atomspace):
         parse_conditions_list(blocks, 'ontable C | handempty | ontable A | ontable B | clear B | clear C')
     )
     atom = atom_from_tree(initial_conditions_and, atomspace)
-    atom.tv = TruthValue(1,confidence_to_count(1))
+    atom.tv = TruthValue(1, TruthValue().confidence_to_count(1))
 
 def blocksworld_test(atomspace):
     import blocksworld

--- a/opencog/python/pln/formulas.py
+++ b/opencog/python/pln/formulas.py
@@ -1,4 +1,4 @@
-from opencog.atomspace import count_to_confidence, confidence_to_count, TruthValue
+from opencog.atomspace import TruthValue
 
 import operator, functools, itertools
 

--- a/opencog/python/utility/load_scm_file.py
+++ b/opencog/python/utility/load_scm_file.py
@@ -4,7 +4,7 @@
 # @author Dingjie.Wang
 # @version 1.0
 # @date 2012-08-04
-from opencog.atomspace import types, TruthValue, AtomSpace, confidence_to_count
+from opencog.atomspace import types, TruthValue, AtomSpace
 from viz_graph import Viz_Graph
 from types_inheritance import name_type_dict, is_a
 from m_util import Logger, dict_sub
@@ -131,7 +131,7 @@ def load_scm_file(a, filename):
                         mean = float(temp[1])
                         confidence = float(temp[2])
                         # the value to stv!
-                        stv = TruthValue(mean,confidence_to_count(confidence))
+                        stv = TruthValue(mean, TruthValue().confidence_to_count(confidence))
 
                 if third:
                     third = third.strip()
@@ -145,7 +145,7 @@ def load_scm_file(a, filename):
                         mean = float(temp[1])
                         confidence = float(temp[2])
                         # the value to stv!
-                        stv = TruthValue(mean,confidence_to_count(confidence))
+                        stv = TruthValue(mean, TruthValue().confidence_to_count(confidence))
                 try:
                     t = first[0:first.index(' ')]
                     name = first[first.index(' ') + 1: -1].strip('"')


### PR DESCRIPTION
... of confidence_to_count, count_to_confidence from Python files, to fix Buildbot error
