### PR TITLE
PKGBUILD for arch linux ABS - shared libraries not being installed (?)

### DIFF
--- a/opencog/comboreduct/combo/CMakeLists.txt
+++ b/opencog/comboreduct/combo/CMakeLists.txt
@@ -20,7 +20,6 @@ INSTALL(FILES
 	procedure_repository.h
 	simple_nn.h
 	tree_generation.h
-	using.h
 	variable_unifier.h	
 	vertex.h
 

--- a/opencog/comboreduct/reduct/CMakeLists.txt
+++ b/opencog/comboreduct/reduct/CMakeLists.txt
@@ -47,7 +47,6 @@ INSTALL(FILES
 	perception_rules.h
         fold_rules.h
 	reduct.h
-	using.h
 
 	DESTINATION
 

--- a/opencog/cython/opencog/CMakeLists.txt
+++ b/opencog/cython/opencog/CMakeLists.txt
@@ -230,6 +230,6 @@ ELSE (WIN32)
 ENDIF (WIN32)
 
 INSTALL (FILES 
-	opencog/__init__.py
+	__init__.py
 	DESTINATION "${DATADIR}/python/opencog")
 

--- a/opencog/learning/moses/moses/CMakeLists.txt
+++ b/opencog/learning/moses/moses/CMakeLists.txt
@@ -6,7 +6,6 @@ INSTALL(FILES
 	mpi_moses.h
 	partial.h
 	types.h
-	using.h
 
 	DESTINATION
 

--- a/opencog/scm/CMakeLists.txt
+++ b/opencog/scm/CMakeLists.txt
@@ -1,6 +1,5 @@
 INSTALL (FILES
 	apply.scm
-	debug.scm
 	file-utils.scm
 	example-dbi.scm
 	persistence.scm


### PR DESCRIPTION
I'm trying to put together a PKGBUILD for arch linux.

I adapted the opencog-bzr ABS PKGBUILD for arch linux to building from this github repo. Had to remove a few lines from CMakeLists.txt files in order to run `make install` successfully. However I think some of built libraries are not being installed with `make install`.

The bzr PKGBUILD was last updated in 2011 and I'm also unsure if this is still an appropriate way of building opencog. The adapted PKGBUILD is here https://github.com/sveitser/pkgbuilds/blob/master/opencog-git/PKGBUILD

Output of the `makepkg` command is here https://gist.github.com/sveitser/3e4c890859ba18a13661 .

After installing the built package and running cogserver I get

```
cogserver: error while loading shared libraries: libserver.so: cannot open shared object file: No such file or directory
```

The `libserver.so` file is built at `build/opencog/server/libserver.so` but not istalled during the make install step.
