### PR TITLE
Corrected module name, added file path

### DIFF
--- a/opencog/persist/zmq/events/README.md
+++ b/opencog/persist/zmq/events/README.md
@@ -46,7 +46,7 @@ These will be installed automatically if you are using [ocpkg](https://github.co
 Module
 ------
 
-This is implemented as a module named *libatomspacepublisher.so* which must be enabled in the *opencog.conf* file.
+This is implemented as *opencog/persist/zmq/events/libatomspacepublishermodule.so* which must be enabled in the *opencog.conf* file.
 
 When loaded, it will be enabled by default. The module supports the following CogServer commands:
 


### PR DESCRIPTION
Hi @cosmoharrigan,
While configuring AttentionAllocation, I noticed that the module is called `libatomspacepublishermodule.so` rather than `libatomspacepublisher.so`. I corrected this and added the file path so it can be added more easily to the opencog.conf file.
