### PR TITLE
Attention Allocation experiment using Socrates demo

### DIFF
--- a/opencog/python/pln/examples/relex2logic/socrates_attention_allocation.py
+++ b/opencog/python/pln/examples/relex2logic/socrates_attention_allocation.py
@@ -1,0 +1,50 @@
+from __future__ import print_function
+from pln.examples.relex2logic import evaluation_to_member_agent
+from opencog.atomspace import types, AtomSpace, TruthValue
+from opencog.scheme_wrapper import load_scm, scheme_eval, scheme_eval_h, __init__
+from pln.examples.interactive_agent import InteractiveAgent
+from attention_interface import *
+from time import sleep
+
+__author__ = 'Sebastian Ruder'
+
+atomspace = AtomSpace()
+__init__(atomspace)
+
+coreTypes = "opencog/atomspace/core_types.scm"
+utilities = "opencog/scm/utilities.scm"
+data = "opencog/python/pln/examples/relex2logic/r2l-output-test.scm"
+
+for item in [coreTypes, utilities, data]:
+    load_scm(atomspace, item)
+
+# Configurable parameters:
+num_steps = 10                            # Number of time steps
+output_filename = 'ecan-timeseries.csv'   # Output filename
+
+timeseries = []
+
+# Run num_steps cycles, capturing the contents of the attentional focus
+# at each discrete timestep, and then export the dataset
+
+all_atoms = atomspace.get_atoms_by_type(t=types.Atom)
+print("Number of atoms in atomspace: %d" %len(all_atoms))
+for atom in all_atoms:
+    print(atom)
+
+for t in range(0, num_steps):
+    point_in_time = get_attentional_focus(timestep=t)
+    timeseries.append(point_in_time)
+    importance_diffusion()
+    atoms = point_in_time.get_atoms()
+    for atom in atoms:
+        print(atom)
+        print(atom.get_sti())
+
+    print(point_in_time)
+    sleep(.1)
+
+write_timeseries(timeseries, output_filename)
+
+all_atoms = atomspace.get_atoms_by_type(t=types.Atom)
+print("Number of atoms in atomspace after inference: %d" %len(all_atoms))


### PR DESCRIPTION
@cosmoharrigan, I created this pull request to discuss the use of attention allocation at the example of the Socrates demo.
Cosmo, you specified an attention interface [here](https://github.com/sebastianruder/external-tools/blob/master/attention/attention_interface.py) to which I submitted a [pull request](https://github.com/opencog/external-tools/pull/20) where we can also concentrate on working on that interface.
As the REST API is used to track the attention allocation, the atoms need to be specified in the CogServer. So just importing them in the atomspace in Python won't work. Is that correct? The EvaluationToMemberAgent would need to be loaded in the CogServer and would need to be called with `agents-step` to only perform one step at a time.
Is the setting in the beginning of every inference process always that all atoms have an sti of 0? Just so I completely understand the process, the MindAgent then selects atoms (how does it select them at the beginning? Arbitrarily?) and gives them an -- at the moment -- (arbitrary) stimulus of 10 (which doesn't seem yet to be compatible with ECAN). After every step of the MindAgent, the ImportanceDiffusionAgent sets in and splits the stis of the atoms across all relevant links. Then the MindAgent selects the atoms with the highest sti. I don't remember if we already talked about this before, but does that current implementation of the MindAgent possess a selection criterion for leveraging atoms with high stis? I haven't found such a feature yet. But this is key to see whether the inference path is positively influenced by AttentionAllocation.
Please correct me wherever I have erred.
