### PR TITLE
Removed superfluous ListLink

### DIFF
--- a/opencog/learning/RuleEngine/rules/pln/deduction.scm
+++ b/opencog/learning/RuleEngine/rules/pln/deduction.scm
@@ -18,22 +18,18 @@
                 (InheritanceLink
                     (VariableNode "$B")
                     (VariableNode "$C")))
-            (ListLink
-                (InheritanceLink
-                    (VariableNode "$A")
-                    (VariableNode "$C"))
-                (ExecutionLink
-                    (GroundedSchemaNode "scm: pln-formula-simple-deduction")
-                    (ListLink
-                        (InheritanceLink
-                            (VariableNode "$A")
-                            (VariableNode "$B"))
-                        (InheritanceLink
-                            (VariableNode "$B")
-                            (VariableNode "$C"))
-                        (InheritanceLink
-                            (VariableNode "$A")
-                            (VariableNode "$C"))))))))
+            (ExecutionLink
+                (GroundedSchemaNode "scm: pln-formula-simple-deduction")
+                (ListLink
+                    (InheritanceLink
+                        (VariableNode "$A")
+                        (VariableNode "$B"))
+                    (InheritanceLink
+                        (VariableNode "$B")
+                        (VariableNode "$C"))
+                    (InheritanceLink
+                        (VariableNode "$A")
+                        (VariableNode "$C")))))))
 
 ; -----------------------------------------------------------------------------
 ; Deduction Formula


### PR DESCRIPTION
Hi @cosmoharrigan, I noticed that what we discussed in https://github.com/opencog/opencog/issues/844#issuecomment-45509872 also applies to the deduction-rule: Because the consequence of the ImplicationLink is a ListLink, this ListLink is put into the ListLink produced as the result of `cog-bind` and consists now of two identical atoms, the first one the first item of the ListLink, the second one the output of the ExecutionLink (as performed on [this input](https://github.com/sebastianruder/opencog/blob/master/tests/learning/RuleEngine/simple-assertions.scm)):

```
(ListLink (stv 1.000000 0.000000)
  (ListLink (stv 1.000000 0.000000)
    (InheritanceLink (stv inf 0.900000)
      (ConceptNode "Peirce") ; [266]
      (ConceptNode "human") ; [269]
    ) ; [286]
    (InheritanceLink (stv inf 0.900000)
      (ConceptNode "Peirce") ; [266]
      (ConceptNode "human") ; [269]
    ) ; [286]
  ) ; [288]
) ; [289]
```

If we remove the ListLink and the first InheritanceLink, we get a much nicer output:

```
(ListLink
   (InheritanceLink (stv inf 0.89999998)
      (ConceptNode "Peirce")
      (ConceptNode "human")
   )
)
```
