### PR TITLE
simplify get-instance-name when word-index is string

### DIFF
--- a/opencog/nlp/scm/relex-to-logic.scm
+++ b/opencog/nlp/scm/relex-to-logic.scm
@@ -91,10 +91,9 @@
 	(cond	((number? word-index)
 			(cog-name (list-ref (get-word-inst-nodes word parse-node) (- word-index 1)))
 		)
+		; in case word-index is a string, word-index is already the name we want to use
 		((and (string? word-index) (check-name? word-index 'WordInstanceNode))
-			(cog-name (list-ref
-					(get-word-inst-nodes word parse-node)
-					(- (get-word-inst-index (WordInstanceNode word-index)) 1)))
+			word-index
 		)
 	)
 )


### PR DESCRIPTION
Doesn't need those codes when word-index is a string.
