### PR TITLE
Add sequence numbering to edges

### DIFF
--- a/opencog/python/graph_description/dot.py
+++ b/opencog/python/graph_description/dot.py
@@ -64,10 +64,6 @@ def get_dot_representation(atomset, duplicated_types=DEFAULT_DUPLICATED_TYPES):
     (processed_vertices,
      processed_edges) = process_graph(vertices, edges, duplicated_types)
 
-    #(dot_vertices,
-    # dot_edges) = dot_from_graph(processed_vertices, processed_edges)
-
-    #dot_output = make_dot_output(dot_vertices, dot_edges)
     dot_output = dot_from_graph(processed_vertices, processed_edges)
 
     return dot_output
@@ -115,12 +111,15 @@ def edges_from_atomset(atomset):
     """
     edges = []
     for atom in atomset:
+        sequence_number = 0
         for outgoing_atom in atom.out:
             edge = {
                 'source': atom.h.value(),
-                'target': outgoing_atom.h.value()
+                'target': outgoing_atom.h.value(),
+                'sequence_number': sequence_number
             }
             edges.append(edge)
+            sequence_number += 1
     return edges
 
 
@@ -175,6 +174,7 @@ def process_graph(vertices, edges, duplicated_types):
             processed_edge['target'] = target['handle']
             processed_vertices.append(target)
 
+        processed_edge['sequence_number'] = edge['sequence_number']
         processed_edges.append(processed_edge)
 
     return processed_vertices, processed_edges
@@ -228,4 +228,6 @@ def make_dot_edge(dot, edge):
     """
     Creates an edge in DOT syntax.
     """
-    dot.edge(str(edge['source']), str(edge['target']))
+    dot.edge(str(edge['source']),
+             str(edge['target']),
+             label=str(edge['sequence_number']))

--- a/opencog/python/graph_description/example-visualization.py
+++ b/opencog/python/graph_description/example-visualization.py
@@ -13,4 +13,4 @@ with open('example.dot', 'w') as outfile:
     outfile.write(example.dot_output)
 
 from subprocess import check_call
-check_call(['dot', '-Tsvg', 'example.dot', '-o', 'example.svg'])
+check_call(['dot', '-Tpng', 'example.dot', '-o', 'example.png'])

--- a/opencog/python/graph_description/example.py
+++ b/opencog/python/graph_description/example.py
@@ -15,8 +15,10 @@ __init__(atomspace)
 
 data = ["opencog/atomspace/core_types.scm",
         "opencog/scm/utilities.scm",
-        "opencog/python/pln/examples/tuffy/smokes/smokes.scm"]#,
-#        "opencog/python/pln/examples/tuffy/smokes/extra-data.scm"]
+        "opencog/python/pln/examples/tuffy/smokes/smokes.scm"]
+
+# Optionally, you could also include this file for a larger graph sample:
+#   "opencog/python/pln/examples/tuffy/smokes/extra-data.scm"
 
 for item in data:
     load_scm(atomspace, item)


### PR DESCRIPTION
It is important to have sequence numbering on edges; for example, that allows you to understand which arguments of an ImplicationLink are the antecedent and consequent.
