### PR TITLE
R2L: Post-processing functions to create fully abstracted version

### DIFF
--- a/opencog/nlp/scm/relex-to-logic-post-processing.scm
+++ b/opencog/nlp/scm/relex-to-logic-post-processing.scm
@@ -107,9 +107,9 @@
 		(define triplet (assoc candidate other-name-triplets))
 		; if this candidate is either a link or does not need to be replaced
 		(if (not new)
-			(if (cog-link? candidate)
-				(rebuild candidate old-new-pairs other-name-triplets)
-				(begin
+			(cond ((cog-link? candidate) (rebuild candidate old-new-pairs other-name-triplets))
+				((not triplet) candidate)
+				(else
 					(if (equal? 'PredicateNode (cog-type candidate))
 						(ImplicationLink (cog-new-node (cog-type candidate) (cadr triplet)) (caddr triplet))
 						(InheritanceLink (cog-new-node (cog-type candidate) (cadr triplet)) (caddr triplet))


### PR DESCRIPTION
"The woman softly kisses the smelly frog."  will create:

``` scheme
((EvaluationLink
   (PredicateNode "kiss@a3f6ccf5-33ae-4bba-a510-f83986d7e02a")
   (ListLink
      (ConceptNode "woman" (stv 0.001 0.99000001))
      (ConceptNode "frog@7ef074c3-6c14-4af8-b6ff-63c895879dcf")
   )
)
 (InheritanceLink
   (SatisfyingSetLink
      (PredicateNode "kiss@a3f6ccf5-33ae-4bba-a510-f83986d7e02a")
   )
   (ConceptNode "softly" (stv 0.001 0.99000001))
)
 (InheritanceLink
   (ConceptNode "frog@7ef074c3-6c14-4af8-b6ff-63c895879dcf")
   (ConceptNode "smelly" (stv 0.001 0.99000001))
)
)
```

"The woman kisses the frog." will create:

``` scheme
((EvaluationLink
   (PredicateNode "kiss" (stv 0.001 0.99000001))
   (ListLink
      (ConceptNode "woman" (stv 0.001 0.99000001))
      (ConceptNode "frog" (stv 0.001 0.99000001))
   )
)
)
```

Currently, "The woman kisses a frog." will generate the same thing as "The woman kisses the frog."  It is not yet clear how they should be distinguished.
