### PR TITLE
R2L: Create partially abstracted + fully abstracted

### DIFF
--- a/opencog/nlp/scm/relex-to-logic-post-processing.scm
+++ b/opencog/nlp/scm/relex-to-logic-post-processing.scm
@@ -178,27 +178,21 @@
 		)
 	)
 
-	; get the head links that include a lone word
-	(define lone-word-involvement-list
-		(delete-duplicates 
-			(filter-map (lambda (links cnt) (if (= cnt 1) (car links) #f))
-				word-involvement-cleaned-list
-				word-involvement-cnt
-			)
-		)
+	(define all-links
+		(delete-duplicates (apply append word-involvement-cleaned-list))
 	)
 
 	; do the main creation for the partially abstract version
 	(define partial
 		(map (lambda (a-link) (rebuild a-link lone-word-assoc-list non-lone-word-assoc-list))
-			lone-word-involvement-list
+			all-links
 		)
 	)
 
 	; do the main creation for the fully abstract version
 	(define full
 		(map (lambda (a-link) (rebuild a-link word-assoc-list '()))
-			(delete-duplicates (apply append word-involvement-cleaned-list))
+			all-links
 		)
 	)
 


### PR DESCRIPTION
"The woman softly kisses the smelly frog." will create:

``` scheme
((InheritanceLink
   (SatisfyingSetLink
      (PredicateNode "kiss@7625140e-02a5-4e19-989f-33ed97f9edc6")
   )
   (ConceptNode "softly" (stv 0.001 0.99000001))
)
 (InheritanceLink
   (ConceptNode "frog@04f1ccb8-36b3-429d-ac9f-edd6b8148141")
   (ConceptNode "smelly" (stv 0.001 0.99000001))
)
 (EvaluationLink
   (PredicateNode "kiss@7625140e-02a5-4e19-989f-33ed97f9edc6")
   (ListLink
      (ConceptNode "woman@c62fec7c-91cf-4fb8-b245-f757d8ff964e")
      (ConceptNode "frog@04f1ccb8-36b3-429d-ac9f-edd6b8148141")
   )
)
 (EvaluationLink
   (PredicateNode "kiss" (stv 0.001 0.99000001))
   (ListLink
      (ConceptNode "woman" (stv 0.001 0.99000001))
      (ConceptNode "frog" (stv 0.001 0.99000001))
   )
)
 (InheritanceLink
   (SatisfyingSetLink
      (PredicateNode "kiss" (stv 0.001 0.99000001))
   )
   (ConceptNode "softly" (stv 0.001 0.99000001))
)
 (InheritanceLink
   (ConceptNode "frog" (stv 0.001 0.99000001))
   (ConceptNode "smelly" (stv 0.001 0.99000001))
)
)
```

"The woman kisses the frog." will create:

``` scheme
((EvaluationLink
   (PredicateNode "kiss" (stv 0.001 0.99000001))
   (ListLink
      (ConceptNode "woman@a32897f4-da1d-4c93-a8c7-499b0bd5b57d")
      (ConceptNode "frog@5b523323-9c62-493e-8d54-b453ecb94575")
   )
)
 (EvaluationLink
   (PredicateNode "kiss" (stv 0.001 0.99000001))
   (ListLink
      (ConceptNode "woman" (stv 0.001 0.99000001))
      (ConceptNode "frog" (stv 0.001 0.99000001))
   )
)
)
```

"The woman kisses a frog." will create:

``` scheme
((EvaluationLink
   (PredicateNode "kiss" (stv 0.001 0.99000001))
   (ListLink
      (ConceptNode "woman@443daa18-c617-4965-9646-7dc57c7b58f6")
      (ConceptNode "frog" (stv 0.001 0.99000001))
   )
)
 (EvaluationLink
   (PredicateNode "kiss" (stv 0.001 0.99000001))
   (ListLink
      (ConceptNode "woman" (stv 0.001 0.99000001))
      (ConceptNode "frog" (stv 0.001 0.99000001))
   )
)
)
```

Note that on each case, the words with UUID are completely new instances (in addition to the one created during pre-processing).  For example, for the sentence "The woman softly kisses the smelly frog.", there will already be another

``` scheme
(EvaluationLink (stv 0.99000001 0.99000001)
   (PredicateNode "kisses@4520518f-4800-401d-89d7-dc80cdd0afec" (stv 0.001 0.99000001))
   (ListLink (stv 0.99000001 0.99000001)
      (ConceptNode "woman@c80fe289-f75e-4eae-8c99-f17dd9bc555e" (stv 0.001 0.99000001))
      (ConceptNode "frog@26d0a85c-d88b-43a9-b74a-36baeb103bd4" (stv 0.001 0.99000001))
   )
)
```

with instances number actually be the one used in the sentence.

Old version: #885 
