### PR TITLE
Changed r2l negative helper function to create PLN suitable output

### DIFF
--- a/opencog/nlp/scm/relex-to-logic.scm
+++ b/opencog/nlp/scm/relex-to-logic.scm
@@ -135,9 +135,8 @@
 	)
 )
 
-(define (negative-rule verb instance) 
-	(list (ImplicationLink (PredicateNode instance df-node-stv) (PredicateNode verb df-node-stv) df-link-stv)
-	(NotLink (PredicateNode instance df-node-stv) df-link-stv)
+(define (negative-rule verb instance)
+	(ImplicationLink (PredicateNode instance df-node-stv) (NotLink (PredicateNode verb df-node-stv) df-link-stv) df-link-stv)
 	)
 )
 


### PR DESCRIPTION
@amebel, I changed the output of the negative rule so that the output is in a more suitable form to be used by PLN as discussed in this issue: https://github.com/opencog/relex/issues/87. Could you review this?
