### PR TITLE
Added helper function for all-SVP-rule

### DIFF
--- a/opencog/nlp/scm/relex-to-logic.scm
+++ b/opencog/nlp/scm/relex-to-logic.scm
@@ -277,7 +277,7 @@
 ; combination of all-rule and SVP-rule for testing syllogisms
 ; Example: "All Canadians are right-handed."
 (define (all-SVP-rule concept instance predicative predicative_instance)
-    (ForAllLink
+    (list (ForAllLink
         (VariableNode "$X")
         (ImplicationLink
             (InheritanceLink (VariableNode "$X") (ConceptNode instance df-node-stv) df-link-stv)
@@ -285,6 +285,7 @@
         )
     )
     (SVP-rule concept instance predicative predicative_instance)
+    )
 )
 
 (define (entity-rule word word_instance) 


### PR DESCRIPTION
Rule combines all-rule and SVP-rule and is required for syllogism testing; together with https://github.com/opencog/relex/pull/115. @AmeBel, could you review this?
