### PR TITLE
Fix regression introduced by commit 49aec20d

### DIFF
--- a/opencog/nlp/scm/relex-to-logic.scm
+++ b/opencog/nlp/scm/relex-to-logic.scm
@@ -137,7 +137,6 @@
 
 (define (negative-rule verb instance)
 	(ImplicationLink (PredicateNode instance df-node-stv) (NotLink (PredicateNode verb df-node-stv) df-link-stv) df-link-stv)
-	)
 )
 
 (define (possessive-rule noun noun_instance word word_instance)


### PR DESCRIPTION
Fix regression introduced by commit https://github.com/opencog/opencog/commit/49aec20db4bc2f5c9ac0b3fcd3e812e06e662581#diff-0141897e92401b447418eef495135e7eL142

```
Warning file /home/ceefour/git/opencog/opencog/nlp/scm/relex-to-logic.scm ended with unterminated input begun at line 140
scm_unprotect_object called on unprotected object
[2014-07-13 06:18:09:507] [ERROR] Caught signal 6 (Aborted) on thread 140628137334784
        Stack Trace:
        2: opencog/server/cogserver (opencog::Logger::Base::~Base() +0x7c) [0x41743e]
```

cc @sebastianruder
