### PR TITLE
Make REST API documentation easier to use using Swagger

### DIFF
--- a/opencog/python/web/api/apimain.py
+++ b/opencog/python/web/api/apimain.py
@@ -6,6 +6,7 @@ from apiatomcollection import *
 from apitypes import *
 from apishell import *
 from apischeme import *
+from flask_restful_swagger import swagger
 
 
 class RESTAPI(object):
@@ -18,7 +19,7 @@ class RESTAPI(object):
     http://wiki.opencog.org/w/REST_API
 
     Prerequisites:
-    Flask, mock, flask-restful, six
+    Flask, mock, flask-restful, six, flask-restful-swagger
 
     Default endpoint: http://127.0.0.1:5000/api/v1.1/
     (Replace 127.0.0.1 with the IP address of the server if necessary)
@@ -35,12 +36,12 @@ class RESTAPI(object):
 
         # Initialize the web server and set the routing
         self.app = Flask(__name__, static_url_path="")
-        self.api = Api(self.app)
+        self.api = swagger.docs(Api(self.app), apiVersion='1.1', api_spec_url='/api/v1.1/spec')
 
         # Create and add each resource
         atom_collection_api = AtomCollectionAPI.new(self.atomspace)
-        atom_types_api = TypesAPI()
-        shell_api = ShellAPI()
+        atom_types_api = TypesAPI
+        shell_api = ShellAPI
         scheme_api = SchemeAPI.new(self.atomspace)
 
         self.api.add_resource(atom_collection_api,

--- a/opencog/python/web/api/apischeme.py
+++ b/opencog/python/web/api/apischeme.py
@@ -3,6 +3,7 @@ __author__ = 'Cosmo Harrigan'
 from flask import abort, jsonify
 from flask.ext.restful import Resource, reqparse
 from opencog.scheme_wrapper import scheme_eval, __init__
+from flask_restful_swagger import swagger
 
 COGSERVER_PORT = 17001
 
@@ -25,32 +26,53 @@ class SchemeAPI(Resource):
 
         super(SchemeAPI, self).__init__()
 
+    @swagger.operation(
+	notes='''
+Include a JSON object with the POST request containing the command
+in a field named "command"
+
+<p>Example command:
+
+<pre>
+{'command': '(cog-set-af-boundary! 100)'}
+</pre>
+
+<p>Returns:
+
+<p>A JSON object containing the Scheme-formatted result of the command in
+a field named "response".
+
+<p>Example response:
+
+<pre>
+{'response': '100\n'}
+</pre>
+
+<p>Note that in this API, the request is processed synchronously. It
+blocks until the request has finished.
+
+<p>This functionality is implemented as a POST method because it can
+cause side-effects.''',
+	responseClass='response',
+	nickname='post',
+	parameters=[
+	    {
+		'name': 'command',
+		'description': 'Scheme command',
+		'required': True,
+		'allowMultiple': False,
+		'dataType': 'string',
+		'paramType': 'body'
+	    }
+	],
+	responseMessages=[
+	    {'code': 200, 'message': 'Scheme command executed successfully'},
+	    {'code': 400, 'message': 'Invalid request: Required parameter command missing'}
+	]
+    )
     def post(self):
         """
         Send a command to the Scheme interpreter
-        Uri: scheme
-
-        Include a JSON object with the POST request containing the command
-        in a field named "command"
-
-        Example command:
-
-        {'command': '(cog-set-af-boundary! 100)'}
-
-        Returns:
-
-        A JSON object containing the Scheme-formatted result of the command in
-        a field named "response".
-
-        Example response:
-
-        {'response': '100\n'}
-
-        Note that in this API, the request is processed synchronously. It
-        blocks until the request has finished.
-
-        This functionality is implemented as a POST method because it can
-        cause side-effects.
         """
 
         # Validate, parse and send the command

--- a/opencog/python/web/api/apishell.py
+++ b/opencog/python/web/api/apishell.py
@@ -3,6 +3,7 @@ __author__ = 'Cosmo Harrigan'
 from flask import abort, jsonify
 from flask.ext.restful import Resource, reqparse
 import socket
+from flask_restful_swagger import swagger
 
 COGSERVER_PORT = 17001
 
@@ -31,18 +32,37 @@ class ShellAPI(Resource):
 
         super(ShellAPI, self).__init__()
 
+    @swagger.operation(
+	notes='''
+Include a JSON object with the POST request containing the command
+in a field named "command"
+
+<p>Examples:
+
+<pre>
+{'command': 'agents-step'}
+{'command': 'agents-step opencog::SimpleImportanceDiffusionAgent'}
+</pre>''',
+	responseClass='response',
+	nickname='post',
+	parameters=[
+	    {
+		'name': 'command',
+		'description': 'OpenCog Shell command',
+		'required': True,
+		'allowMultiple': False,
+		'dataType': 'string',
+		'paramType': 'body'
+	    }
+	],
+	responseMessages=[
+	    {'code': 200, 'message': 'OpenCog Shell command executed successfully'},
+	    {'code': 400, 'message': 'Invalid request: Required parameter command missing'}
+	]
+    )
     def post(self):
         """
         Send a shell command to the cogserver
-        Uri: shell
-
-        Include a JSON object with the POST request containing the command
-        in a field named "command"
-
-        Examples:
-
-        {'command': 'agents-step'}
-        {'command': 'agents-step opencog::SimpleImportanceDiffusionAgent'}
         """
 
         # Validate, parse and send the command

--- a/opencog/python/web/api/apitypes.py
+++ b/opencog/python/web/api/apitypes.py
@@ -4,6 +4,7 @@ from flask import json, current_app
 from flask.ext.restful import Resource, reqparse
 from mappers import *
 from flask.ext.restful.utils import cors
+from flask_restful_swagger import swagger
 
 class TypesAPI(Resource):
     def __init__(self):
@@ -14,18 +15,28 @@ class TypesAPI(Resource):
     # Set CORS headers to allow cross-origin access
     # (https://github.com/twilio/flask-restful/pull/131):
     @cors.crossdomain(origin='*')
+    @swagger.operation(
+	notes='''
+Returns a JSON representation of a list of valid atom types
+
+<p>Example:
+
+<pre>
+{"types": ["TrueLink", "NumberNode", "OrLink",
+  "PrepositionalRelationshipNode"]}
+</pre>
+''',
+	responseClass='response',
+	nickname='get',
+	parameters=[
+	],
+	responseMessages=[
+	    {'code': 200, 'message': 'Returned list of valid atom types'},
+	]
+    )
     def get(self):
         """
         Returns a list of valid atom types
-        Uri: types
-
-        :return types: Returns a JSON representation of a list of valid atom
-            types
-
-        Example:
-
-        {"types": ["TrueLink", "NumberNode", "OrLink",
-          "PrepositionalRelationshipNode"]}
         """
 
         json_data = \

--- a/opencog/python/web/api/install_dependencies.sh
+++ b/opencog/python/web/api/install_dependencies.sh
@@ -14,3 +14,6 @@ pip install graphviz
 
 # Optional:
 pip install requests
+
+# Experimental:
+pip install flask-restful-swagger


### PR DESCRIPTION
Make [REST API](http://wiki.opencog.org/w/REST_API) easier to use using [Swagger](http://petstore.swagger.wordnik.com).

Can be accessed at:
- http://127.0.0.1:5000/api/v1.1/spec.html for human-friendly UI
- http://127.0.0.1:5000/api/v1.1/spec.json for JSON descriptor

![image](https://cloud.githubusercontent.com/assets/24123/3565412/c2746740-0ab8-11e4-84a7-b806b994bd1c.png)

![selection_419](https://cloud.githubusercontent.com/assets/24123/3565211/4bd83c78-0aaf-11e4-8ded-2153053882fe.png)

Additional dependency is needed in `opencog/python/web/api/install_dependencies.sh` :

```
pip install flask-restful-swagger
```

@cosmoharrigan I hope this is acceptable. Thanks! :)

Fixed #927.
