### PR TITLE
RelEx2Logic that-rule post-processing version 1

### DIFF
--- a/opencog/nlp/scm/relex-to-logic-post-processing.scm
+++ b/opencog/nlp/scm/relex-to-logic-post-processing.scm
@@ -33,29 +33,6 @@
 )
 
 ; -----------------------------------------------------------------------
-; Get the root link with no incoming set
-(define (cog-get-root atom)
-	(define iset (cog-incoming-set atom))
-	(if (null? iset)
-		(list atom)
-		(append-map cog-get-root iset))
-)
-
-; -----------------------------------------------------------------------
-; Get all the nodes within a hypergraph
-(define (cog-get-all-nodes link)
-	(define oset (cog-outgoing-set link))
-	(define (recursive-helper atom)
-		(if (cog-link? atom)
-			(cog-get-all-nodes atom)
-			(list atom)
-		)
-	)
-
-	(append-map recursive-helper oset)
-)
-
-; -----------------------------------------------------------------------
 ; Create all possible pairwise combination of the items
 (define (pairwise-combination sets)
 	(define (create-with-index index rest)

--- a/opencog/scm/utilities.scm
+++ b/opencog/scm/utilities.scm
@@ -18,6 +18,8 @@
 ; -- cog-prt-atomspace -- Prints all atoms in the atomspace
 ; -- cog-count-atoms -- Count of the number of atoms of given type.
 ; -- cog-report-counts -- Return an association list of counts.
+; -- cog-get-root -- Return all hypergraph roots containing 'atom'
+; -- cog-get-all-nodes -- Get all the nodes within a link and its sublinks
 ; -- cog-get-partner -- Return other atom of a link conecting two atoms.
 ; -- cog-pred-get-partner -- Get the partner in an EvaluationLink.
 ; -- cog-filter -- return a list of atoms of given type.
@@ -279,6 +281,37 @@
 		)
 		(filter-map rpt tlist)
 	)
+)
+
+; -----------------------------------------------------------------------
+; cog-get-root -- Return all hypergraph roots containing 'atom'
+;
+; Return the root links of a specific 'atom'; basically get the root link
+; with no incoming set.
+;
+(define (cog-get-root atom)
+	(define iset (cog-incoming-set atom))
+	(if (null? iset)
+		(list atom)
+		(append-map cog-get-root iset))
+)
+
+; -----------------------------------------------------------------------
+; cog-get-all-nodes -- Get all the nodes within a link and its sublinks
+;
+; Get all the nodes (non-link atoms) within a hypergraph, and return as
+; a list.
+;
+(define (cog-get-all-nodes link)
+	(define oset (cog-outgoing-set link))
+	(define (recursive-helper atom)
+		(if (cog-link? atom)
+			(cog-get-all-nodes atom)
+			(list atom)
+		)
+	)
+
+	(append-map recursive-helper oset)
 )
 
 ; -----------------------------------------------------------------------
@@ -828,8 +861,11 @@
 'clear
 'count-all
 'cog-get-atoms
+'cog-prt-atomspace
 'cog-count-atoms
 'cog-report-counts
+'cog-get-root
+'cog-get-all-nodes
 'cog-get-partner
 'cog-pred-get-partner
 'cog-filter


### PR DESCRIPTION
that-rule post-processing for object clause, content clause, complement clause, etc, but **not** adjective clause.

"I think that dogs can fly." will create:

``` scheme
((EvaluationLink
   (PredicateNode "that")
   (ListLink
      (PredicateNode "think@e72e4195-705d-41ec-8483-73f2117baf84" (stv 0.001 0.99000001))
      (EvaluationLink (stv 0.99000001 0.99000001)
         (PredicateNode "fly@0bc3c609-c5cb-4207-8de2-eec026006342" (stv 0.001 0.99000001))
         (ConceptNode "dogs@371b3370-62b6-4327-8003-54d06c93d301" (stv 0.001 0.99000001))
      )
   )
)
)
```

"I think that small dogs can fly." will create:

``` scheme
((EvaluationLink
   (PredicateNode "that")
   (ListLink
      (PredicateNode "think@df58440b-10a8-439b-8b72-8fda7d4e2570" (stv 0.001 0.99000001))
      (AndLink
         (EvaluationLink (stv 0.99000001 0.99000001)
            (PredicateNode "fly@71b4ca54-91a4-4f2a-9859-f40829511862" (stv 0.001 0.99000001))
            (ConceptNode "dogs@b8ab7e7f-8e9b-45a9-b4e6-a41aa415fcd9" (stv 0.001 0.99000001))
         )
         (InheritanceLink (stv 0.99000001 0.99000001)
            (ConceptNode "dogs@b8ab7e7f-8e9b-45a9-b4e6-a41aa415fcd9" (stv 0.001 0.99000001))
            (ConceptNode "small@624fb92c-ac95-46ba-94a0-258ecbe91de3" (stv 0.001 0.99000001))
         )
      )
   )
)
)
```

"I know that he stupidly thinks that she bought the huge cake." create:

``` scheme
((EvaluationLink
   (PredicateNode "that")
   (ListLink
      (PredicateNode "thinks@e9bcd2fe-3f3f-4026-8662-daa5c4b9390a" (stv 0.001 0.99000001))
      (AndLink
         (EvaluationLink (stv 0.99000001 0.99000001)
            (PredicateNode "bought@59b1e871-3fe0-4882-94d2-66b51d072d71" (stv 0.001 0.99000001))
            (ListLink (stv 0.99000001 0.99000001)
               (ConceptNode "she@b0f6d6b4-b383-45b4-9235-77b1703766ce" (stv 0.001 0.99000001))
               (ConceptNode "cake@c1d25205-0f7a-4c17-a041-1c94646cf0fd" (stv 0.001 0.99000001))
            )
         )
         (InheritanceLink (stv 0.99000001 0.99000001)
            (ConceptNode "cake@c1d25205-0f7a-4c17-a041-1c94646cf0fd" (stv 0.001 0.99000001))
            (ConceptNode "huge@5c565c74-01b2-49da-98e0-6e31f1b58c69" (stv 0.001 0.99000001))
         )
      )
   )
)
 (EvaluationLink
   (PredicateNode "that")
   (ListLink
      (PredicateNode "know@30e56cb6-55ac-40bf-94b0-c13824223b30" (stv 0.001 0.99000001))
      (AndLink
         (EvaluationLink (stv 0.99000001 0.99000001)
            (PredicateNode "thinks@e9bcd2fe-3f3f-4026-8662-daa5c4b9390a" (stv 0.001 0.99000001))
            (ConceptNode "he@50035fd4-7a04-405b-885c-70fba0036f29" (stv 0.001 0.99000001))
         )
         (InheritanceLink (stv 0.99000001 0.99000001)
            (SatisfyingSetLink (stv 0.99000001 0.99000001)
               (PredicateNode "thinks@e9bcd2fe-3f3f-4026-8662-daa5c4b9390a" (stv 0.001 0.99000001))
            )
            (ConceptNode "stupidly@f0c64fa7-05e9-44b3-a0e5-8e794bf9be5d" (stv 0.001 0.99000001))
         )
      )
   )
)
)
```

~~I still need to verify whether "PredicateNode that" needs to be instanced or not.~~ Ben verified that "that" does not need to be instanced, so this is OK.

Now, for the sentence _"I know that you know that I know that you know that that is a dialogue between Confucius and Chuang Tzu."_ there is a problem.  The last "that" from RelEx is **that(know, be)**.  Right now, the **that-rule** needs to use the words linked in **that(know, be)** to find what it needs.  However, **be-inheritance-rule** does not include the word "be", so in the atomspace, there's no way to find the link, and **that(know, be)** cannot be post-processed!!
