### PR TITLE
R2L: negative rule post-processing, version 1

### DIFF
--- a/opencog/nlp/relex2logic/rule-helpers.scm
+++ b/opencog/nlp/relex2logic/rule-helpers.scm
@@ -237,8 +237,21 @@
 	)
 )
 
-(define (negative-rule verb instance)
-	(list (ImplicationLink (PredicateNode instance df-node-stv) (NotLink (PredicateNode verb df-node-stv) df-link-stv) df-link-stv))
+; Examples:
+; "I do not eat injera." instance = eat@1111, instance_pos = verb
+; "The cat is not small." instance = small@1111, instance_pos = adj
+(define (negative-rule instance instance_pos)
+	(list
+		(EvaluationLink df-link-stv
+			(PredicateNode "negativemarker" df-node-stv)
+			(ListLink df-link-stv
+				(if (string=? instance_pos "verb")
+					(PredicateNode instance df-node-stv)
+					(ConceptNode instance df-node-stv)
+				)
+			)
+		)
+	)
 )
 
 (define (definite-rule word word_instance)


### PR DESCRIPTION
Given a `negativemarker`

```
EvaluationLink
   PredicateNode "negativemarker"
   ListLink
      word_instance
```

generate

```
NotLink
   AndLink
      ** links involving word_instance **
```

For example, in "I do not eat injera.", `word_instance` will be `eat@1111`, while "The cat is not small.", `word_instance` will be `small@1111`

Refer to
opencog/relex#87
opencog/relex#117
