### PR TITLE
Fixed subset evaluation rule unit test

### DIFF
--- a/tests/python/test_pln/new_scm_tests/SubsetAS_new.scm
+++ b/tests/python/test_pln/new_scm_tests/SubsetAS_new.scm
@@ -15,8 +15,6 @@
 ; define default confidence
 (define dc 0.5)
 
-(define target (SubsetLink sub super))
-
 (EvaluationLink (PredicateNode "inputs") 
 	(ListLink 
 		(MemberLink (stv 0.1 dc) e0 sub)
@@ -58,7 +56,7 @@
 		(MemberLink (stv 0.4 dc) e6 super)
 		(MemberLink (stv 0.6 dc) e8 super)
 		(MemberLink (stv 0.0 dc) e9 super)
-		(SubsetLink sub super)
+		(SubsetLink (stv 1.0 0.001248) sub super)
 	)
 )
 

--- a/tests/python/test_pln/test_rules_new.py
+++ b/tests/python/test_pln/test_rules_new.py
@@ -27,6 +27,7 @@ class PLNUnitTester(TestCase):
         self.chainer = None
 
         # Works:
+        self.addTestFile("SubsetAS_new.scm")
         self.addTestFile("AndRule_new.scm")
         self.addTestFile("BooleanTransformationRule_new.scm")
         self.addTestFile("DeductionRule_InheritanceLink.scm")
@@ -64,9 +65,6 @@ class PLNUnitTester(TestCase):
         #self.addTestFile("AndBulkEvaluationRuleEvaluationLinks_new.scm")
         #self.addTestFile("AndBulkEvaluationRulePredicates_new.scm")
         #self.addTestFile("NegatedAndBulkEvaluationRule3EvaluationLinks_new.scm")
-
-        # Doesn't work, not sure yet why.
-        #self.addTestFile("SubsetAS_new.scm")
 
         # Doesn't work, as the unit test setup doesn't allow for changing TV's (YET)
         # self.addTestFile("AndBreakdownRule.scm")


### PR DESCRIPTION
Small fix for PLN unit test that didn't work so far.
