### PR TITLE
guile evaluator: use pipe instead of a string port

### DIFF
--- a/opencog/guile/SchemeEval.h
+++ b/opencog/guile/SchemeEval.h
@@ -54,6 +54,7 @@ class SchemeEval : public GenericEval
 		std::condition_variable _wait_done;
 		std::string poll_port();
 		SCM _pipe;
+		int _pipeno;
 
 		// Straight-up evaluation
 		static SCM thunk_scm_eval(void *);


### PR DESCRIPTION
What was I thinking? A pipe was the right thing to use, all along.  Slower, maybe, but race-free.
