### PR TITLE
fixed xerces xml base64 decode, by typecasting length correctly

### DIFF
--- a/opencog/embodiment/Control/PerceptionActionInterface/PAI.cc
+++ b/opencog/embodiment/Control/PerceptionActionInterface/PAI.cc
@@ -2651,7 +2651,7 @@ void PAI::processMapInfo(DOMElement* element, HandleSeq &toUpdateHandles, bool u
 
         // Decode the base64 string into binary
         unsigned long length = (unsigned long)msg.size();
-        XMLByte* binary = Base64::decode((XMLByte*)msg.c_str(), &length);
+        XMLByte* binary = Base64::decode((XMLByte*)msg.c_str(),(XMLSize_t*) &length);
 
         MapInfoSeq mapinfoSeq;
         mapinfoSeq.ParseFromArray((void*)binary, length);
@@ -3521,7 +3521,7 @@ void PAI::processTerrainInfo(DOMElement * element,HandleSeq &toUpdateHandles)
 
         // Decode the base64 string into binary
         unsigned long length = (unsigned long)msg.size();
-        XMLByte* binary = Base64::decode((XMLByte*)msg.c_str(), &length);
+        XMLByte* binary = Base64::decode((XMLByte*)msg.c_str(),(XMLSize_t*) &length);
 
         Chunk chunk;
         chunk.ParseFromArray((void*)binary, length);


### PR DESCRIPTION
Fixed a bug that caused compile error in 32 bit virtual machine. The error was due to not typecasting unsigned long pointer to (XMLSize_t*) , which is a type of size_t , both are 32 bit integers. 
Bug existed in two lines of the same type calling Base64::decode
