### PR TITLE
Enable X-Forwarding in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,6 +51,9 @@ Vagrant.configure("2") do |config|
   # Configure port for telnet access to shell
   config.vm.network "forwarded_port", guest: 17001, host: 17001
 
+  # Enable X-Forwarding
+  config.ssh.forward_x11 = true
+
   config.vm.provider :virtualbox do |vb|
       vb.name = "cogbox"
       vb.customize [


### PR DESCRIPTION
Documentation: http://wiki.opencog.org/w/Building_OpenCog_in_a_Linux_Virtual_Machine_on_Windows#Optional_-_Enabling_X-Windows
