### PR TITLE
Fix cppcheck reports (part2):

### DIFF
--- a/opencog/embodiment/Control/PerceptionActionInterface/PAI.cc
+++ b/opencog/embodiment/Control/PerceptionActionInterface/PAI.cc
@@ -3336,8 +3336,6 @@ Handle PAI::addOwnershipRelation(const Handle owner, const Handle owned, bool is
 // This function is called by PsiActionSelectionAgent, when an action is timeout 
 void PAI::setPendingActionPlansFailed()
 {
-    ActionPlanMap::iterator it;
-
     // Note: use empty() rather than iterator directly, since setActionPlanStatus 
     //       will erase action plans in  pendingActionPlans if necessary. 
     while ( !pendingActionPlans.empty() ) {

--- a/opencog/embodiment/Learning/PetaverseHC/hillclimber.h
+++ b/opencog/embodiment/Learning/PetaverseHC/hillclimber.h
@@ -264,9 +264,8 @@ struct hillclimber {
             _current_program = oni->second;
             _used_for_owner.insert(_current_program);
 
-            _ordered_best_estimates.erase(oni);
-
             fitness_t cur_est_fit = oni->first;
+            _ordered_best_estimates.erase(oni);
 
             if (cur_est_fit >= _best_fitness_estimated) {
                 _best_fitness_estimated = cur_est_fit;

--- a/opencog/guile/SchemeSmobTV.cc
+++ b/opencog/guile/SchemeSmobTV.cc
@@ -68,7 +68,6 @@ static TruthValue *get_tv_from_kvp(SCM kvp, const char * subrname, int pos)
 		pos ++;
 		if (!scm_is_pair(kvp))
 		{
-			free(key);
 			scm_wrong_type_arg_msg(subrname, pos, kvp, "value following keyword");
 		}
 

--- a/opencog/learning/statistics/Entropy.cc
+++ b/opencog/learning/statistics/Entropy.cc
@@ -37,7 +37,7 @@ void Entropy::calculateEntropies(DataProvider<Metadata>* data)
 
     for (int n = 1; n <= data->n_gram; ++n )
     {
-        for( it = data->mDataMaps[n].begin(); it < data->mDataMaps[n].end(); ++it)
+        for( it = data->mDataMaps[n].begin(); it != data->mDataMaps[n].end(); ++it)
         {
             StatisticData& pieceData = (StatisticData)(it->second);
             pieceData.entropy = (-1.0f) * pieceData.probability * log2(pieceData.probability);
@@ -54,7 +54,7 @@ void Entropy::calculateProbabilityAndEntropies(DataProvider<Metadata>* data)
 
     for (int n = 1; n <= data->n_gram; ++n )
     {
-        for( it = data->mDataMaps[n].begin(); it < data->mDataMaps[n].end(); ++it)
+        for( it = data->mDataMaps[n].begin(); it != data->mDataMaps[n].end(); ++it)
         {
             StatisticData& pieceData = (StatisticData)(it->second);
             pieceData.probability = ((float)(pieceData.count))/((float)(data->mRawDataNumbers[n]));

--- a/opencog/learning/statistics/InteractionInformation.cc
+++ b/opencog/learning/statistics/InteractionInformation.cc
@@ -191,7 +191,7 @@ void InteractionInformation::calculateInteractionInformations(DataProvider<Metad
 
     for (int n = 1; n <= data->n_gram; ++n )
     {
-        for( it = data->mDataMaps[n].begin(); it < data->mDataMaps[n].end(); ++it)
+        for( it = data->mDataMaps[n].begin(); it != data->mDataMaps[n].end(); ++it)
         {
             StatisticData& pieceData = (StatisticData)(it->second);
             pieceData.interactionInformation = calculateInteractionInformation((string)(it->first), data);

--- a/opencog/learning/statistics/Probability.cc
+++ b/opencog/learning/statistics/Probability.cc
@@ -35,7 +35,7 @@ void Probability::calculateProbabilities(DataProvider<Metadata>* data)
 
     for (int n = 1; n <= data->n_gram; ++n )
     {
-        for( it = data->mDataMaps[n].begin(); it < data->mDataMaps[n].end(); ++it)
+        for( it = data->mDataMaps[n].begin(); it != data->mDataMaps[n].end(); ++it)
         {
             StatisticData& pieceData = (StatisticData)(it->second);
             pieceData.probability = ((float)(pieceData.count))/((float)(data->mRawDataNumbers[n]));

--- a/opencog/util/cluster.c
+++ b/opencog/util/cluster.c
@@ -2493,9 +2493,10 @@ void kcluster (int nclusters, int nrows, int ncolumns,
   if (transpose==0) ok = makedatamask(nclusters, ndata, &cdata, &cmask);
   else ok = makedatamask(ndata, nclusters, &cdata, &cmask);
   if(!ok)
-  { free(counts);
+  {
     if(npass>1)
     { free(tclusterid);
+      free(counts);
       free(mapping);
       return;
     }


### PR DESCRIPTION
- (error) Iterator 'oni' used after element has been erased
- (error) Dangerous iterator comparison using operator< on 'std::map'
- (style) Unused variable: it
- (error) Memory pointed to by 'counts' is freed twice
- (error) Memory pointed to by 'key' is freed twice
