### PR TITLE
Fix cppcheck reports "Prefer prefix ++/-- operators for non-primitive ty...

### DIFF
--- a/examples/hopfield/HopfieldDemo.cc
+++ b/examples/hopfield/HopfieldDemo.cc
@@ -129,7 +129,7 @@ std::vector< Pattern > getCuePatterns(std::vector< Pattern > ps)
     } else {
         // otherwise, just copy imprint patterns.
         for (std::vector< Pattern >::iterator i = ps.begin();
-                i != ps.end(); i++) {
+                i != ps.end(); ++i) {
             // Cue patterns shouldn't be mutated unless cueGenerateOnce is set.
             cs.push_back( (*i) );
         }
@@ -138,7 +138,7 @@ std::vector< Pattern > getCuePatterns(std::vector< Pattern > ps)
     // (they won't be mutated later)
     if (o->cueGenerateOnce) {
         for (std::vector< Pattern >::iterator i = cs.begin();
-            i != cs.end(); i++) {
+            i != cs.end(); ++i) {
             (*i) = (*i).mutatePattern(o->cueErrorRate);
         }
     }

--- a/examples/hopfield/HopfieldServer.cc
+++ b/examples/hopfield/HopfieldServer.cc
@@ -534,7 +534,7 @@ void HopfieldServer::updateKeyNodeLinks(Handle keyHandle, float density)
         HandleSeq eligibleForRemoval;
         // loop through keyNodes
         for (HandleSeq::iterator i = keyNodes.begin();
-            i != keyNodes.end(); i++) {
+            i != keyNodes.end(); ++i) {
             if (*i == keyHandle) continue;
             HandleSeq out = a.getOutgoing(*i);
             eligibleForRemoval.insert(eligibleForRemoval.end(),
@@ -562,7 +562,7 @@ std::map<Handle,Handle> HopfieldServer::getDestinationsFrom(Handle src, Type lin
     std::map<Handle,Handle> result;
     HandleSeq links = getAtomSpace().getIncoming(src);
     HandleSeq::iterator j;
-    for(j = links.begin(); j != links.end(); j++) {
+    for(j = links.begin(); j != links.end(); ++j) {
         Handle lh = *j;
         if (!classserver().isA(getAtomSpace().getType(lh),linkType))
             continue;
@@ -570,7 +570,7 @@ std::map<Handle,Handle> HopfieldServer::getDestinationsFrom(Handle src, Type lin
         HandleSeq lseq = getAtomSpace().getOutgoing(lh);
         // get handle at other end of the link
         for (HandleSeq::iterator k=lseq.begin();
-                k < lseq.end() && destH == Handle::UNDEFINED; k++) {
+                k < lseq.end() && destH == Handle::UNDEFINED; ++k) {
             if (*k != src) {
                 destH = *k; 
             }
@@ -595,13 +595,13 @@ Handle HopfieldServer::findKeyNode()
         // find closest matching key node (or unused key node)
         HandleSeq::iterator i;
         float maxSim = -1;
-        for(i = keyNodes.begin(); i != keyNodes.end(); i++) {
+        for(i = keyNodes.begin(); i != keyNodes.end(); ++i) {
             float sim = 0.0f;
             Handle iHandle = *i;
             //get all Hebbian links from keyHandle
             HandleSeq links = a.getIncoming(iHandle);
             HandleSeq::iterator j;
-            for(j = links.begin(); j != links.end(); j++) {
+            for(j = links.begin(); j != links.end(); ++j) {
                 Handle lh = *j;
                 Handle patternH;
                 Type lt = a.getType(lh); 
@@ -610,7 +610,7 @@ Handle HopfieldServer::findKeyNode()
                 // TODO: create AtomSpace utility method that returns a map
                 // between link and destination, see getDestinationsFrom
                 for (HandleSeq::iterator k=lseq.begin();
-                        k < lseq.end() && patternH == Handle::UNDEFINED; k++) {
+                        k < lseq.end() && patternH == Handle::UNDEFINED; ++k) {
                     if (*k != iHandle) {
                         patternH = *k; 
                     }
@@ -897,7 +897,7 @@ std::vector<stim_t> HopfieldServer::getGridStimVector()
     std::vector<stim_t> out;
     std::vector<Handle>::iterator i;
 
-    for (i = hGrid.begin(); i != hGrid.end(); i++) {
+    for (i = hGrid.begin(); i != hGrid.end(); ++i) {
         Handle h = *i;
         stim_t val;
         val = imprintAgent->getAtomStimulus(h); // / getAtomSpace()->getRecentMaxSTI();

--- a/examples/hopfield/HopfieldServer.h
+++ b/examples/hopfield/HopfieldServer.h
@@ -199,7 +199,7 @@ public:
                 ss << std::endl;
                 col = 0;
             }
-            it++;
+            ++it;
         }
         return ss.str();
     }

--- a/examples/hopfield/Pattern.cc
+++ b/examples/hopfield/Pattern.cc
@@ -64,10 +64,10 @@ Pattern Pattern::binarisePattern(AttentionValue::sti_t vizThreshold)
     Pattern::iterator out_i = out.begin();
     Pattern::iterator i;
 
-    for (i = begin(); i != end(); i++) {
+    for (i = begin(); i != end(); ++i) {
         int val = *i;
         *out_i = (int) (val >= vizThreshold) ;
-        out_i++;
+        ++out_i;
     }
     return out;
 }
@@ -112,7 +112,7 @@ std::vector< Pattern > Pattern::mutatePatterns(std::vector< Pattern > &patterns,
     std::vector< Pattern >::iterator i;
     std::vector< Pattern > mutants;
 
-    for (i = patterns.begin(); i != patterns.end(); i++) {
+    for (i = patterns.begin(); i != patterns.end(); ++i) {
         Pattern p = (*i).mutatePattern(error);
         mutants.push_back(p);
     }
@@ -132,7 +132,7 @@ Pattern Pattern::mutatePattern(float error)
     // nodes are active makes no sense so avoid it.
     int maxToRemove = activity() - 1;
 
-    for (p = begin(); p != end(); p++) {
+    for (p = begin(); p != end(); ++p) {
         int val = *p;
         // Flip bit with error probability
         if (rng->randfloat() < error) {
@@ -145,7 +145,7 @@ Pattern Pattern::mutatePattern(float error)
                 val = !val;
             }
         }
-        *r_i = val; r_i++;
+        *r_i = val; ++r_i;
     }
     return result;
 }

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -884,7 +884,7 @@ public:
         // Loop over all handles in the handle set.
         std::list<Handle>::iterator i = handle_set.begin();
         std::list<Handle>::iterator iend = handle_set.end();
-        for (; i != iend; i++) {
+        for (; i != iend; ++i) {
             bool rc = (data->*cb)(*i);
             if (rc) return rc;
         }

--- a/opencog/atomspace/AtomSpaceImpl.cc
+++ b/opencog/atomspace/AtomSpaceImpl.cc
@@ -315,7 +315,7 @@ HandleSeq AtomSpaceImpl::getNeighbors(Handle h, bool fanin,
     HandleSeq iset;
     h->getIncomingSet(back_inserter(iset));
     for (HandleSeq::iterator it = iset.begin();
-         it != iset.end(); it++)
+         it != iset.end(); ++it)
     {
         LinkPtr link(LinkCast(*it));
         Type linkType = link->getType();

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -82,7 +82,7 @@ AtomTable::~AtomTable()
     getHandlesByType(back_inserter(all), ATOM, true);
 
     // remove all atoms from AtomTable
-    for (HandleSeq::const_iterator it = all.begin(); it != all.end(); it++)
+    for (HandleSeq::const_iterator it = all.begin(); it != all.end(); ++it)
     {
         DPRINTF("Removing atom %s\n", (*it)->toString().c_str());
         remove(*it, true);

--- a/opencog/atomspace/FixedIntegerIndex.cc
+++ b/opencog/atomspace/FixedIntegerIndex.cc
@@ -62,7 +62,7 @@ void FixedIntegerIndex::remove(bool (*filter)(Handle))
 		while (i != s->end())
 		{
 			j = i;
-			i++;
+			++i;
 			if (filter(Handle(*j)))
 				s->erase(*j);
 		}

--- a/opencog/atomspace/IncomingIndex.cc
+++ b/opencog/atomspace/IncomingIndex.cc
@@ -41,7 +41,7 @@ void IncomingIndex::insertAtom(AtomPtr a)
 
 	Handle hin = a->getHandle();
 	const std::vector<Handle>& oset = l->getOutgoingSet();
-	for (std::vector<Handle>::const_iterator it = oset.begin(); it != oset.end(); it++)
+	for (std::vector<Handle>::const_iterator it = oset.begin(); it != oset.end(); ++it)
 	{
 		Handle h = *it;
 		
@@ -52,7 +52,7 @@ void IncomingIndex::insertAtom(AtomPtr a)
 		// of a link, in which case we should ignore the second
 		// (and other) instances.
 		UnorderedHandleSet::const_iterator oit = oldset.begin();
-		for (; oit != oldset.end(); oit++)
+		for (; oit != oldset.end(); ++oit)
 		{
 			// OC_ASSERT(*oit != hin, "Same atom seems to be getting inserted twice!");
 			if (*oit == hin) break;
@@ -74,7 +74,7 @@ void IncomingIndex::removeAtom(AtomPtr a)
 
 	Handle hin = a->getHandle();
 	const std::vector<Handle>& oset = l->getOutgoingSet();
-	for (std::vector<Handle>::const_iterator it = oset.begin(); it != oset.end(); it++)
+	for (std::vector<Handle>::const_iterator it = oset.begin(); it != oset.end(); ++it)
 	{
 		Handle h = *it;
 		
@@ -82,7 +82,7 @@ void IncomingIndex::removeAtom(AtomPtr a)
 		UnorderedHandleSet inset = oldset;
 
 		UnorderedHandleSet::iterator oit = inset.begin();
-		for (; oit != inset.end(); oit++)
+		for (; oit != inset.end(); ++oit)
 		{
 			if (*oit == hin) break;
 		}
@@ -175,7 +175,7 @@ IncomingIndex::iterator& IncomingIndex::iterator::operator++()
 
 IncomingIndex::iterator& IncomingIndex::iterator::operator++(int i)
 {
-	while (0 < i and  _s != _e) { _s++; i--; }
+	while (0 < i and  _s != _e) { ++_s; --i; }
 	return *this;
 }
 

--- a/opencog/atomspace/Intersect.cc
+++ b/opencog/atomspace/Intersect.cc
@@ -139,7 +139,7 @@ opencog::intersection(const std::vector<UnorderedHandleSet>& sets)
         // linked-list linearization
         UnorderedHandleSet::const_iterator it;
         int j = 0;
-        for (it = sets[i].begin(); it != sets[i].end(); it++) {
+        for (it = sets[i].begin(); it != sets[i].end(); ++it) {
             v[i][j++] = *it;
         }
 

--- a/opencog/atomspace/TypeIndex.cc
+++ b/opencog/atomspace/TypeIndex.cc
@@ -67,7 +67,7 @@ TypeIndex::iterator TypeIndex::begin(Type t, bool sub) const
 			if (it.se != it.s->end()) return it;
 		}
 		it.currtype++;
-		it.s++;
+		++it.s;
 	}
 
 	return it;
@@ -128,12 +128,12 @@ TypeIndex::iterator& TypeIndex::iterator::operator++(int i)
 {
 	if (s == send) return *this;
 
-	se++;
+	++se;
 	if (se == s->end())
 	{
 		do
 		{
-			s++;
+			++s;
 			currtype++;
 
 			// Find the first type which is a subtype, and start iteration there.

--- a/opencog/comboreduct/combo/enum_type.cc
+++ b/opencog/comboreduct/combo/enum_type.cc
@@ -39,7 +39,7 @@ enum_t enum_t::get_random_enum()
 
     map<string, unsigned>::iterator entry = enum_map.begin();
     while (r) {
-       r--; entry ++;
+       --r; entry ++;
     }
     return enum_t(entry->first, entry->second);
 }

--- a/opencog/comboreduct/combo/similarity.cc
+++ b/opencog/comboreduct/combo/similarity.cc
@@ -152,7 +152,7 @@ static void tree_flatten_rec(tree_branch_vector& ctr, combo_tree::iterator root)
 	// that approximately captures the general structure of the tree.
 	combo_tree::sibling_iterator first = root.begin();
 	size_t i = 0;
-	for (; i < numch-2; first++, i++)
+	for (; i < numch-2; ++first, ++i)
 	{
 		std::stringstream ss;
 		ss << *root << "(" << *first << " " << *root << ")";

--- a/opencog/comboreduct/interpreter/eval.cc
+++ b/opencog/comboreduct/interpreter/eval.cc
@@ -69,7 +69,7 @@ combo_tree eval_procedure_tree(const vertex_seq& bmap,
 
     // evaluate the arguments to the function (their variables are in
     // the current scope, i.e. bmap)
-    for (combo_tree::sibling_iterator arg_it = it.begin(); arg_it != it.end(); arg_it++) {
+    for (combo_tree::sibling_iterator arg_it = it.begin(); arg_it != it.end(); ++arg_it) {
         combo_tree arg_result(eval_throws_tree(bmap, arg_it));
 
         OC_ASSERT(arg_it.number_of_children() == 0, "functions cannot have list arguments");
@@ -338,7 +338,7 @@ combo_tree eval_throws_tree(const vertex_seq& bmap,
             combo_tree tr(id::list);
             pre_it loc = tr.begin();
 
-            for (sib_it sib = it.begin(); sib != it.end(); sib++) {
+            for (sib_it sib = it.begin(); sib != it.end(); ++sib) {
                 // tr.append_child(loc, eval_throws_tree(bmap, sib).begin());
                 combo_tree rr = eval_throws_tree(bmap, sib);
                 tr.append_child(loc, rr.begin());
@@ -385,7 +385,7 @@ combo_tree eval_throws_tree(const vertex_seq& bmap,
 
             combo_tree tr(id::list);
             pre_it loc = tr.begin();
-            for (; sib != top.end(); sib++) {
+            for (; sib != top.end(); ++sib) {
                 combo_tree rest = eval_throws_tree(bmap, sib);
                 tr.append_child(loc, rest.begin());
             }
@@ -406,11 +406,11 @@ combo_tree eval_throws_tree(const vertex_seq& bmap,
             combo_tree ht = eval_throws_tree(bmap, head);
             tr.append_child(loc, ht.begin());
 
-            head++;
+            ++head;
             combo_tree rest = eval_throws_tree(bmap, head);
 
             sib_it lst = rest.begin();
-            for (sib_it sib = lst.begin(); sib != lst.end(); sib++)
+            for (sib_it sib = lst.begin(); sib != lst.end(); ++sib)
                 // tr.append_child(loc, eval_throws_tree(bmap, sib).begin());
                 tr.append_child(loc, (pre_it) sib);
 
@@ -423,9 +423,9 @@ combo_tree eval_throws_tree(const vertex_seq& bmap,
             // base case: foldr(f v list) = v
             // i.e. list is empty list.
             sib_it itend = tr.begin().end();
-            itend--;
+            --itend;
             if (itend.begin() == itend.end()) {
-                itend--;
+                --itend;
                 return eval_throws_tree(bmap, itend);
             }
 
@@ -474,9 +474,9 @@ combo_tree eval_throws_tree(const vertex_seq& bmap,
             // base case: foldl(f v list) = v
             // i.e. list is empty list.
             sib_it itend = tr.begin().end();
-            itend--;
+            --itend;
             if (itend.begin() == itend.end()) {
-                itend--;
+                --itend;
                 return eval_throws_tree(bmap, itend);
             }
 
@@ -486,7 +486,7 @@ combo_tree eval_throws_tree(const vertex_seq& bmap,
             sib_it lst_it = lst.begin();
             sib_it tr_it = tr.begin();
             tr.erase(itend);
-            itend--;
+            --itend;
             tr.erase(itend);
 	    
             combo_tree rec(f);
@@ -528,8 +528,8 @@ combo_tree eval_throws_tree(const vertex_seq& bmap,
             combo_tree exp_tr(lambda_it);
 
             vector<vertex> al; // list of arguments
-            tr_it++;
-            for(; tr_it!=tr.begin().end(); tr_it++){
+            ++tr_it;
+            for(; tr_it!=tr.begin().end(); ++tr_it){
                 al.push_back(*tr_it);
             }
             //set_bindings(exp_tr, exp_tr.begin(), al, explicit_arity(exp_tr));

--- a/opencog/comboreduct/reduct/branch_rules.cc
+++ b/opencog/comboreduct/reduct/branch_rules.cc
@@ -41,8 +41,8 @@ void reduce_cond_arg::operator()(combo_tree& tr, combo_tree::iterator it) const
     size_t nc = tr.number_of_children(it);
     for (sib_it sib = it.begin(); 3 <= nc; nc -= 2) {
         logical_reduce(reduct_effort, tr, sib, ignore_ops);
-        sib++;
-        sib++;
+        ++sib;
+        ++sib;
     }
 }
 
@@ -110,7 +110,7 @@ void reduce_cond_adjacent::operator()(combo_tree& tr,
         tr.move_after(por.begin(), q);
 
         sib = x2;
-        sib++;
+        ++sib;
         sz -= 2;
 
         tr.erase(x2);
@@ -149,7 +149,7 @@ void reduce_cond_const::operator()(combo_tree& tr,
             num --;
 
             // Erase everything else that follows.
-            for (; sib != it.end(); sib++) {
+            for (; sib != it.end(); ++sib) {
                 tr.erase(sib);
                 num --;
             }

--- a/opencog/comboreduct/reduct/contin_rules.cc
+++ b/opencog/comboreduct/reduct/contin_rules.cc
@@ -465,7 +465,7 @@ void reduce_distribute::operator()(combo_tree& tr,combo_tree::iterator it) const
         if(plus_it != it.end()) {
             unsigned int idx = 0;
             for(sib_it fac_it = it.begin();
-                fac_it != it.end(); fac_it++, ++idx) {
+                fac_it != it.end(); ++fac_it, ++idx) {
                 if(*fac_it != id::plus) { // found a factor to distribute
                     combo_tree tr_copy(it);
                     unsigned int size_before_reduct = tr_copy.size();

--- a/opencog/comboreduct/reduct/fold_rules.cc
+++ b/opencog/comboreduct/reduct/fold_rules.cc
@@ -19,9 +19,9 @@ void fold_unrolling::operator()(combo_tree& tr,combo_tree::iterator it) const {
         tr.erase_children(it);
         sib_it sib = cb_tr.begin().begin();    // *sib = f
         vertex f = *sib;  
-        sib++;    // *sib = v
+        ++sib;    // *sib = v
         vertex v = *sib;
-        sib++;    // *sib = list(a b c)
+        ++sib;    // *sib = list(a b c)
         combo_tree lst_tr(sib);
         sib_it lst = lst_tr.begin();
         sib_it lst_it = lst.end();
@@ -29,7 +29,7 @@ void fold_unrolling::operator()(combo_tree& tr,combo_tree::iterator it) const {
         do{
             *it = f;
             tr.append_child(it, id::null_vertex);
-            lst_it--;
+            --lst_it;
             tr.append_child(it, *lst_it);
             it = it.begin();
         } while(lst_it != lst.begin());
@@ -41,13 +41,13 @@ void fold_unrolling::operator()(combo_tree& tr,combo_tree::iterator it) const {
         tr.erase_children(it);
         sib_it sib = cb_tr.begin().begin();    // *sib = f
         vertex f = *sib; 
-        sib++;    // *sib = v
+        ++sib;    // *sib = v
         vertex v = *sib;
-        sib++;    // *sib = list(a b c)
+        ++sib;    // *sib = list(a b c)
         combo_tree lst_tr(sib);
         sib_it lst = lst_tr.begin();
 
-        for(sib_it lst_it = lst.begin(); lst_it != lst.end(); lst_it++){
+        for(sib_it lst_it = lst.begin(); lst_it != lst.end(); ++lst_it){
             *it = f;
             tr.append_child(it, *lst_it);
             tr.append_child(it, id::null_vertex);

--- a/opencog/comboreduct/reduct/logical_rules.cc
+++ b/opencog/comboreduct/reduct/logical_rules.cc
@@ -737,7 +737,7 @@ subtree_to_enf::reduce_to_enf::reduce_and(sib_it current,
                 subtree_set res;
                 if (!is_predicate(child.last_child())) {
                     for (sib_it pit = child.last_child().begin();
-                         pit != child.last_child().end(); pit++)
+                         pit != child.last_child().end(); ++pit)
                     {
                         res.insert(pit);
                     }
@@ -833,7 +833,7 @@ void reduce_remove_subtree_equal_tt::operator()(combo_tree& tr,
     // Cannot construct complete truth tables of expressions containing
     // predicates, since arguments of predicates may range over contin
     // values, and who knows what those might be.
-    for (pre_it pit = tr.begin(); pit != tr.end(); pit++) {
+    for (pre_it pit = tr.begin(); pit != tr.end(); ++pit) {
         if (is_predicate(pit))
             return;
     }
@@ -847,7 +847,7 @@ void reduce_remove_subtree_equal_tt::operator()(combo_tree& tr,
             pit = tr.erase(pit);
         else { // remove only the previously added null_vertex
             pit = tr.erase(tr.flatten(pit));
-            pit++;
+            ++pit;
         }
     }
 }

--- a/opencog/comboreduct/table/table.h
+++ b/opencog/comboreduct/table/table.h
@@ -308,7 +308,7 @@ struct interpreter_visitor : public boost::static_visitor<vertex>
         mixed = false;
         combo_tree::iterator mit = tr.begin();
         combo_tree::iterator mend = tr.end();
-        for (; mit != mend; mit++ ) {
+        for (; mit != mend; ++mit ) {
             mixed = is_contin_expr(*mit);
             if (mixed) break;
             mixed = (id::greater_than_zero == *mit);

--- a/opencog/comboreduct/table/table_io.cc
+++ b/opencog/comboreduct/table/table_io.cc
@@ -576,10 +576,10 @@ istream& istreamSparseITable(istream& in, ITable& tab)
 
         // Infer the types of the fixed features.
         size_t off = 0;
-        for (; off < fixed_arity; off++, pit++) 
+        for (; off < fixed_arity; ++off, ++pit)
             types[off] = infer_type_from_token2(types[off], *pit);
 
-        for (; pit != chunks.end(); pit++) {
+        for (; pit != chunks.end(); ++pit) {
             // Rip out the key-value pairs
             auto key_val = parse_key_val(*pit);
             if (key_val == pair<string, string>())
@@ -641,8 +641,8 @@ vector<type_node> infer_column_types(const ITable& tab)
     // Skip the first line, it might be a header...
     // and that would confuse type inference.
     if (tab.size() > 1)
-        rowit++;
-    for (; rowit != tab.end(); rowit++)
+        ++rowit;
+    for (; rowit != tab.end(); ++rowit)
     {
         const string_seq& tokens = rowit->get_seq<string>();
         for (arity_t i=0; i<arity; i++)

--- a/opencog/comboreduct/type_checker/type_tree.cc
+++ b/opencog/comboreduct/type_checker/type_tree.cc
@@ -905,7 +905,7 @@ void reduce_type_tree(type_tree& tt, type_tree_pre_it it,
         // Usually, an arg_list will have only one type in it.
         // However, the cond statement can have a repeated list of two
         // alternating types.
-        for (type_tree_pre_it tit = it.begin(); tit != it.end(); tit++) {
+        for (type_tree_pre_it tit = it.begin(); tit != it.end(); ++tit) {
             reduce_type_tree(tt, tit, arg_types, tr, ct_it, proc_name);
         }
     }

--- a/opencog/dynamics/attention/SimpleImportanceDiffusionAgent.cc
+++ b/opencog/dynamics/attention/SimpleImportanceDiffusionAgent.cc
@@ -290,7 +290,7 @@ void SimpleImportanceDiffusionAgent::diffuseAtom(Handle source)
     // Perform diffusion from the source to each atom target
     typedef std::map<Handle, double>::iterator it_type;
     for(it_type iterator = probabilityVector.begin(); 
-        iterator != probabilityVector.end(); iterator++)
+        iterator != probabilityVector.end(); ++iterator)
     {
         DiffusionEventType diffusionEvent;
         
@@ -560,7 +560,7 @@ SimpleImportanceDiffusionAgent::combineIncidentAdjacentVectors(
     // available for allocation to any particular individual atom
     typedef std::map<Handle, double>::iterator it_type;
     for(it_type iterator = adjacentVector.begin(); 
-        iterator != adjacentVector.end(); iterator++)
+        iterator != adjacentVector.end(); ++iterator)
     {
         // iterator->second is the entry in the probability vector for this
         // handle
@@ -586,7 +586,7 @@ SimpleImportanceDiffusionAgent::combineIncidentAdjacentVectors(
     // Allocate the remaining diffusion amount to the incident atoms according
     // to the probability vector for the targets
     for(it_type iterator = incidentVector.begin(); 
-        iterator != incidentVector.end(); iterator++)
+        iterator != incidentVector.end(); ++iterator)
     {
         double diffusionAmount = 
                 diffusionAvailable * iterator->second;

--- a/opencog/embodiment/AtomSpaceExtensions/CompareAtomTreeTemplate.cc
+++ b/opencog/embodiment/AtomSpaceExtensions/CompareAtomTreeTemplate.cc
@@ -148,7 +148,7 @@ void does_fit_template::expandHandletree(bool fullVirtual, atom_tree& ret,
 
         if (h_ptr != NULL) {
             HandleSeq _hs = as->getOutgoing(*h_ptr);
-            for (HandleSeq::iterator child_h = _hs.begin(); child_h != _hs.end(); child_h++) {
+            for (HandleSeq::iterator child_h = _hs.begin(); child_h != _hs.end(); ++child_h) {
                 //foreach(Handle child_h, _hs) {
                 atom_tree_it next_i = ret.append_child(ret_top, *child_h);
                 expandHandletree(fullVirtual, ret, next_i, as);

--- a/opencog/embodiment/Control/MessagingSystem/MemoryMessageCentral.cc
+++ b/opencog/embodiment/Control/MessagingSystem/MemoryMessageCentral.cc
@@ -36,7 +36,7 @@ MemoryMessageCentral::~MemoryMessageCentral()
             delete msg;
         }
         delete map_itr->second;
-        map_itr++;
+        ++map_itr;
     }
 
 }

--- a/opencog/embodiment/Control/OperationalAvatarController/Pet.cc
+++ b/opencog/embodiment/Control/OperationalAvatarController/Pet.cc
@@ -510,10 +510,10 @@ void Pet::stopLearning(const std::vector<std::string> &commandStatement,
     //      commandStatement.front());
     std::vector<std::string> args;
     std::vector<std::string>::iterator it = learningSchema.begin();
-    it++;
+    ++it;
     while (it != learningSchema.end()) {
         args.push_back(*it);
-        it++;
+        ++it;
     }
 
 //  std::copy(learningSchema.begin()+1, learningSchema.end(), args.begin());
@@ -596,14 +596,14 @@ void Pet::endExemplar(const std::vector<std::string> &commandStatement, unsigned
     std::vector<std::string> args;
 
     std::vector<std::string>::iterator it = learningSchema.begin();
-    it++;
+    ++it;
     while (it != learningSchema.end()) {
         args.push_back(*it);
-        it++;
+        ++it;
     }
 
     for (std::vector<std::string>::iterator it = args.begin();
-            it != args.end(); it++)
+            it != args.end(); ++it)
         logger().debug(" args: %s", (*it).c_str());
     sender->sendExemplar(learningSchema.front(), args, ownerId,
             exemplarAvatarId, *atomSpace);
@@ -709,10 +709,10 @@ void Pet::trySchema(const std::vector<std::string> &commandStatement, unsigned
         std::vector<std::string> args;
 
         std::vector<std::string>::iterator it = learningSchema.begin();
-        it++;
+        ++it;
         while (it != learningSchema.end()) {
             args.push_back(*it);
-            it++;
+            ++it;
         }
 
 //    std::copy(learningSchema.begin()+1, learningSchema.end(), args.begin());
@@ -743,10 +743,10 @@ void Pet::reward(unsigned long timestamp)
         // are beging ignored
         std::vector<std::string> args;
         std::vector<std::string>::iterator it = learningSchema.begin();
-        it++;
+        ++it;
         while (it != learningSchema.end()) {
             args.push_back(*it);
-            it++;
+            ++it;
         }
 
 
@@ -779,10 +779,10 @@ void Pet::punish(unsigned long timestamp)
         // are beging ignored
         std::vector<std::string> args;
         std::vector<std::string>::iterator it = learningSchema.begin();
-        it++;
+        ++it;
         while (it != learningSchema.end()) {
             args.push_back(*it);
-            it++;
+            ++it;
         }
 
 //      std::copy(learningSchema.begin()+1, learningSchema.end(), args.begin());
@@ -952,7 +952,7 @@ void Pet::getHighLTIObjects(HandleSeq& highLTIObjects)
         AttentionValuePtr attentionValue = atomSpace->getAV(*it);
         if (attentionValue->getLTI() < AtomSpaceUtil::highLongTermImportance)
             it = highLTIObjects.erase(it);
-        else it++;
+        else ++it;
     }
 }
 
@@ -1045,10 +1045,10 @@ void Pet::restartLearning() throw (RuntimeException, std::bad_exception)
 
     std::vector<std::string> args;
     std::vector<std::string>::iterator it = learningSchema.begin();
-    it++;
+    ++it;
     while (it != learningSchema.end()) {
         args.push_back(*it);
-        it++;
+        ++it;
     }
 
 //  std::copy(learningSchema.begin()+1, learningSchema.end(), args.begin());

--- a/opencog/embodiment/Control/OperationalAvatarController/PsiRelationUpdaterAgent.cc
+++ b/opencog/embodiment/Control/OperationalAvatarController/PsiRelationUpdaterAgent.cc
@@ -330,7 +330,7 @@ void PsiRelationUpdaterAgent::updateEntityNovelty(opencog::CogServer * server)
 
     for ( iEntityNovelty = this->entityNovelty.begin(); 
            iEntityNovelty != this->entityNovelty.end(); 
-           iEntityNovelty++) {
+           ++iEntityNovelty) {
 
         // Update the novelty levels of the entities
         std::string entityId = iEntityNovelty->first;
@@ -377,7 +377,7 @@ void PsiRelationUpdaterAgent::updateEntityNovelty(opencog::CogServer * server)
 
     for ( iEntityNovelty = this->entityNovelty.begin(); 
            iEntityNovelty != this->entityNovelty.end(); 
-           iEntityNovelty++) {
+           ++iEntityNovelty) {
 
         // Get entitId and novelty instance
         std::string entityId = iEntityNovelty->first;

--- a/opencog/embodiment/Control/PerceptionActionInterface/ActionPlanDispatcher.cc
+++ b/opencog/embodiment/Control/PerceptionActionInterface/ActionPlanDispatcher.cc
@@ -35,7 +35,7 @@ void ActionPlanDispatcher::dispatch()
 {
     try {
         planId = pai.createActionPlan();
-        for (std::list<AvatarAction>::const_iterator itr = actionPlan.begin(); itr != actionPlan.end(); itr++) {
+        for (std::list<AvatarAction>::const_iterator itr = actionPlan.begin(); itr != actionPlan.end(); ++itr) {
             pai.addAction(planId, *itr);
         }
 

--- a/opencog/embodiment/Control/PerceptionActionInterface/ActionType.cc
+++ b/opencog/embodiment/Control/PerceptionActionInterface/ActionType.cc
@@ -587,7 +587,7 @@ void ActionType::printHelp()
 {
     opencog::logger().info(
                           "==================================== HELP OF PET ACTION TYPES ========================================");
-    for (Name2ActionTypeMap::const_iterator itr = nameMap.begin(); itr != nameMap.end(); itr++) {
+    for (Name2ActionTypeMap::const_iterator itr = nameMap.begin(); itr != nameMap.end(); ++itr) {
         const ActionType& t = *(itr->second);
         opencog::logger().info("    %s => %s", t.getName().c_str(), t.getHelpText().c_str());
     }

--- a/opencog/embodiment/Control/PerceptionActionInterface/AvatarAction.cc
+++ b/opencog/embodiment/Control/PerceptionActionInterface/AvatarAction.cc
@@ -147,8 +147,8 @@ std::string AvatarAction::validateParameters(const ActionType& actionType, const
             sprintf(buffer, "validateParameters(): Mandatory parameter type mismatch (param type = '%s', expected type = '%s')", paramItr->getType().getName().c_str(), paramTypeItr->getName().c_str());
             return buffer;
         }
-        paramTypeItr++;
-        paramItr++;
+        ++paramTypeItr;
+        ++paramItr;
     }
 
     // Optional parameters
@@ -158,8 +158,8 @@ std::string AvatarAction::validateParameters(const ActionType& actionType, const
             sprintf(buffer, "AvatarAction::containsValidParameters(): Optional parameter type mismatch (param type = '%s', expected type = '%s')", paramItr->getType().getName().c_str(), paramTypeItr->getName().c_str());
             return buffer;
         }
-        paramTypeItr++;
-        paramItr++;
+        ++paramTypeItr;
+        ++paramItr;
     }
 
     return "";
@@ -185,7 +185,7 @@ XERCES_CPP_NAMESPACE::DOMElement* AvatarAction::createPVPXmlElement(XERCES_CPP_N
 
 
     parent->appendChild(actionElement);
-    for (list<ActionParameter>::const_iterator itr = parameters.begin(); itr != parameters.end(); itr++) {
+    for (list<ActionParameter>::const_iterator itr = parameters.begin(); itr != parameters.end(); ++itr) {
         itr->createPVPXmlElement(doc, actionElement);
     }
     return actionElement;
@@ -284,7 +284,7 @@ std::string AvatarAction::stringRepresentation() const
     answer.append(getName());
     answer.append("(");
     unsigned int count = 1;
-    for (list<ActionParameter>::const_iterator it = parameters.begin(); it != parameters.end(); it++) {
+    for (list<ActionParameter>::const_iterator it = parameters.begin(); it != parameters.end(); ++it) {
         try {
             answer.append(it->stringRepresentation());
             if (count != parameters.size()) {

--- a/opencog/embodiment/Control/PerceptionActionInterface/PAI.cc
+++ b/opencog/embodiment/Control/PerceptionActionInterface/PAI.cc
@@ -297,7 +297,7 @@ void PAI::sendEmotionalFeelings(const std::string& petId, const std::map<std::st
 
     // adding all feelings
     std::map<std::string, float>::const_iterator it;
-    for (it = feelingsValueMap.begin(); it != feelingsValueMap.end(); it++) {
+    for (it = feelingsValueMap.begin(); it != feelingsValueMap.end(); ++it) {
 
         XMLString::transcode(FEELING_ELEMENT, tag, PAIUtils::MAX_TAG_LENGTH);
         DOMElement *feelingElement = doc->createElement(tag);
@@ -358,7 +358,7 @@ void PAI::sendDemandSatisfactions(const std::string& petId, const std::map<std::
 
     // adding all the demand satisfactions
     std::map<std::string, float>::const_iterator it;
-    for (it = demandsValueMap.begin(); it != demandsValueMap.end(); it++) {
+    for (it = demandsValueMap.begin(); it != demandsValueMap.end(); ++it) {
 
         XMLString::transcode(DEMAND_ELEMENT, tag, PAIUtils::MAX_TAG_LENGTH);
         DOMElement * demandElement = doc->createElement(tag);
@@ -419,7 +419,7 @@ void PAI::sendSingleActionCommand(std::string& actionName, std::vector<ActionPar
     // adding all parameters
     std::vector<ActionParamStruct>::iterator it;
 
-    for (it = paraList.begin(); it != paraList.end(); it++)
+    for (it = paraList.begin(); it != paraList.end(); ++it)
     {
         XMLString::transcode(PARAMETER_ELEMENT, tag, PAIUtils::MAX_TAG_LENGTH);
         DOMElement *paraElement = doc->createElement(tag);

--- a/opencog/embodiment/Control/Procedure/BuiltInProcedureRepository.cc
+++ b/opencog/embodiment/Control/Procedure/BuiltInProcedureRepository.cc
@@ -64,7 +64,7 @@ BuiltInProcedureRepository::BuiltInProcedureRepository(PAI& pai)
 
 BuiltInProcedureRepository::~BuiltInProcedureRepository()
 {
-    for (Name2ProcedureMap::iterator itr = _map.begin(); itr != _map.end(); itr++) {
+    for (Name2ProcedureMap::iterator itr = _map.begin(); itr != _map.end(); ++itr) {
 //  std::cout << itr->second->getName() << "\n";
         delete itr->second;
     }

--- a/opencog/embodiment/Control/Procedure/ComboInterpreter.cc
+++ b/opencog/embodiment/Control/Procedure/ComboInterpreter.cc
@@ -81,7 +81,7 @@ void ComboInterpreter::run(messaging::NetworkElement *ne)
     delete sel;
 #else
     
-    for (Vec::iterator it = _vec.begin(); it != _vec.end(); it++) {
+    for (Vec::iterator it = _vec.begin(); it != _vec.end(); ++it) {
         RunningComboProcedure& rp = (*it)->second;
         if (rp.isReady()) {
             logger().debug("Running procedure id '%d'.",  ((RunningProcedureId&) (*it)->first).getId());

--- a/opencog/embodiment/Control/Procedure/ComboProcedureRepository.cc
+++ b/opencog/embodiment/Control/Procedure/ComboProcedureRepository.cc
@@ -134,7 +134,7 @@ void ComboProcedureRepository::saveRepository(FILE* dump) const
 {
     logger().debug("Saving %s (%ld)\n", getId(), ftell(dump));
     fprintf(dump, "%zu", _repo.size());
-    for (str_proc_map_const_it itr = _repo.begin(); itr != _repo.end(); itr++) {
+    for (str_proc_map_const_it itr = _repo.begin(); itr != _repo.end(); ++itr) {
         const string &name = itr->first;
         int nameLength = name.length();
         fwrite(&nameLength, sizeof(int), 1, dump);

--- a/opencog/embodiment/Control/Procedure/ProcedureInterpreter.cc
+++ b/opencog/embodiment/Control/Procedure/ProcedureInterpreter.cc
@@ -44,7 +44,7 @@ void ProcedureInterpreter::run(NetworkElement *ne)
 
     Set toBeRemoved;
     // Runs each pending RunningBuildInProcedure and checks status of any procedure.
-    for (Map::iterator it = _map.begin(); it != _map.end(); it++) {
+    for (Map::iterator it = _map.begin(); it != _map.end(); ++it) {
         RunningBuiltInProcedure* rbp = get<RunningBuiltInProcedure>(&(it->second));
         if (rbp) {
             rbp->run();
@@ -69,7 +69,7 @@ void ProcedureInterpreter::run(NetworkElement *ne)
         }
 
     }
-    for (Set::iterator it = toBeRemoved.begin(); it != toBeRemoved.end(); it++) {
+    for (Set::iterator it = toBeRemoved.begin(); it != toBeRemoved.end(); ++it) {
         _map.erase(*it);
     }
 }

--- a/opencog/embodiment/Learning/behavior/BE.cc
+++ b/opencog/embodiment/Learning/behavior/BE.cc
@@ -99,7 +99,7 @@ bool less_combo_tree_it( const tree<Vertex> & lhs_t, const tree<Vertex> & rhs_t,
 
     for (tree<Vertex>::sibling_iterator lit = lhs_t.begin(ltop);
             lit != lhs_t.end  (ltop);
-            lit++, rit++)
+            ++lit, ++rit)
         if (less_combo_tree_it(lhs_t, rhs_t, lit, rit))
             return true;
         else if (less_combo_tree_it(lhs_t, rhs_t, rit, lit))

--- a/opencog/embodiment/WorldWrapper/PAIWorldWrapper.cc
+++ b/opencog/embodiment/WorldWrapper/PAIWorldWrapper.cc
@@ -744,7 +744,7 @@ bool PAIWorldWrapper::createNavigationPlanAction( opencog::pai::PAI& pai,SpaceSe
 
         }
         pai.addAction( _planID, action );
-        it_point++;
+        ++it_point;
 
         if ((!includingLastStep) && (it_point == endPointIter))
             break;

--- a/opencog/embodiment/WorldWrapper/WorldWrapperUtil.cc
+++ b/opencog/embodiment/WorldWrapper/WorldWrapperUtil.cc
@@ -1539,8 +1539,8 @@ combo::vertex WorldWrapperUtil::evalPerception(
             sib_it sibling_it = tree_it.begin();
 
             // skip the objects
-            sibling_it++;
-            sibling_it++;
+            ++sibling_it;
+            ++sibling_it;
 
             // get operator and value from the tree and remove them from tree. This is
             // necessary to avoid parsing the tree wrongly.
@@ -1595,7 +1595,7 @@ combo::vertex WorldWrapperUtil::evalPerception(
                 }
 
                 std::vector<std::string> arguments;
-                for (sib_it arg = tree_it.begin(); arg != tree_it.end(); arg++) {
+                for (sib_it arg = tree_it.begin(); arg != tree_it.end(); ++arg) {
                     arguments.push_back(get_definite_object(*arg));
                 }
 
@@ -1656,7 +1656,7 @@ combo::vertex WorldWrapperUtil::evalPerception(
 
                         // next predicate name and the two objects
                         std::vector<std::string> arguments;
-                        for (sib_it arg = tree_it.begin(); arg != tree_it.end(); arg++) {
+                        for (sib_it arg = tree_it.begin(); arg != tree_it.end(); ++arg) {
                             arguments.push_back(get_definite_object(*arg));
                         }
                         Predicate pred(name, arguments);
@@ -1904,7 +1904,7 @@ combo::vertex WorldWrapperUtil::evalPerception(
             std::string action_name = get_action_name(get_definite_object(vo2));
 
             std::vector<std::string> parameters;
-            for (++sib_arg; sib_arg != it.end(); sib_arg++) {
+            for (++sib_arg; sib_arg != it.end(); ++sib_arg) {
                 vertex v_temp = *sib_arg;
 
                 if (is_indefinite_object(v_temp)) {
@@ -2058,7 +2058,7 @@ combo::vertex WorldWrapperUtil::evalPerception(
             bool has_wild_card = false;
             std::vector<std::vector<combo::definite_object> > parameters;
 
-            for (++sib_arg; sib_arg != it.end(); sib_arg++) {
+            for (++sib_arg; sib_arg != it.end(); ++sib_arg) {
                 vertex v_temp = *sib_arg;
 
                 if (is_wild_card(v_temp) && !has_wild_card) {

--- a/opencog/guile/SchemePrimitive.h
+++ b/opencog/guile/SchemePrimitive.h
@@ -211,8 +211,8 @@ class SchemePrimitive : public PrimitiveEnviron
 					HandleSeq::iterator it = rHS.begin();
 					if (it != rHS.end())
 						rc = scm_list_1(SchemeSmob::handle_to_scm(*it));
-					it++;
-					for ( ; it != rHS.end(); it++)
+					++it;
+					for ( ; it != rHS.end(); ++it)
 					{
 						rc = scm_cons(SchemeSmob::handle_to_scm(*it), rc);
 					}
@@ -236,8 +236,8 @@ class SchemePrimitive : public PrimitiveEnviron
 					HandleSeq::iterator it = rHS.begin();
 					if (it != rHS.end())
 						rc = scm_list_1(SchemeSmob::handle_to_scm(*it));
-					it++;
-					for ( ; it != rHS.end(); it++)
+					++it;
+					for ( ; it != rHS.end(); ++it)
 					{
 						rc = scm_cons(SchemeSmob::handle_to_scm(*it), rc);
 					}

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -198,7 +198,7 @@ SCM SchemeSmob::ss_map_type (SCM proc, SCM stype)
 	// Call proc on each handle, in turn.
 	// Break out of the loop if proc returns anything other than #f
 	std::list<Handle>::iterator i;
-	for (i = handle_set.begin(); i != handle_set.end(); i++) {
+	for (i = handle_set.begin(); i != handle_set.end(); ++i) {
 		Handle h = *i;
 		SCM smob = handle_to_scm(h);
 		SCM rc = scm_call_1(proc, smob);

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -432,7 +432,7 @@ SchemeSmob::verify_handle_list (SCM satom_list, const char * subrname, int pos)
             const std::vector<Handle> &oset =
                 verify_handle_list(satom, subrname, pos);
             std::vector<Handle>::const_iterator it;
-            for (it = oset.begin(); it != oset.end(); it++) {
+            for (it = oset.begin(); it != oset.end(); ++it) {
                 outgoing_set.push_back(*it);
             }
         }

--- a/opencog/learning/PatternMiner/PatternMinerDF.cc
+++ b/opencog/learning/PatternMiner/PatternMinerDF.cc
@@ -233,7 +233,7 @@ void PatternMiner::extendAllPossiblePatternsForOneMoreGramDF(HandleSeq &instance
             bool alreadyExtracted = false;
 
             // check if these links have been extracted
-            for(newExtendIt = newConnectedLinksFoundThisGram.begin(); newExtendIt != newConnectedLinksFoundThisGram.end(); newExtendIt++)
+            for(newExtendIt = newConnectedLinksFoundThisGram.begin(); newExtendIt != newConnectedLinksFoundThisGram.end(); ++newExtendIt)
             {
                 set<Handle>& exitstingLinks = (set<Handle>&)(*newExtendIt);
                 if (exitstingLinks == originalLinksToSet)

--- a/opencog/learning/dimensionalembedding/DimEmbedModule.cc
+++ b/opencog/learning/dimensionalembedding/DimEmbedModule.cc
@@ -178,7 +178,7 @@ HandleSeq DimEmbedModule::kNearestNeighbors(Handle h, Type l, int k, bool fanin)
     }
     HandleSeq results;
     std::vector<CoverTreePoint>::const_iterator it;
-    for (it=points.begin(); it!=points.end(); it++) {
+    for (it=points.begin(); it!=points.end(); ++it) {
         results.push_back(it->getHandle());
     }
     return results;
@@ -1022,7 +1022,7 @@ void DimEmbedModule::handleAddSignal(Handle h)
         }
     }
     else {//h is a link
-        for (it=atomMaps.begin();it!=atomMaps.end();it++) {
+        for (it=atomMaps.begin();it!=atomMaps.end();++it) {
             //if the new link is a subtype of an existing embedding, add it
             if (classserver().isA(h->getType(), it->first))
                 addLink(h, it->first);
@@ -1040,7 +1040,7 @@ void DimEmbedModule::atomRemoveSignal(AtomPtr atom)
     if (NodeCast(atom)) {
         //for each link type embedding that exists, remove the node
         AtomEmbedMap::iterator it;
-        for (it=atomMaps.begin();it!=atomMaps.end();it++) {
+        for (it=atomMaps.begin();it!=atomMaps.end();++it) {
             removeNode(h,it->first);
         }
         AsymAtomEmbedMap::iterator it2;

--- a/opencog/learning/feature-selection/scorers/moses_optim.cc
+++ b/opencog/learning/feature-selection/scorers/moses_optim.cc
@@ -29,7 +29,7 @@ std::set<arity_t> get_feature_set(const field_set& fields,
 {
     std::set<arity_t> fs;
     field_set::const_bit_iterator bit = fields.begin_bit(inst);
-    for(arity_t i = 0; bit != fields.end_bit(inst); bit++, i++)
+    for(arity_t i = 0; bit != fields.end_bit(inst); ++bit, ++i)
         if(*bit)
             fs.insert(i);
     return fs;

--- a/opencog/learning/moses/example-progs/nmax.cc
+++ b/opencog/learning/moses/example-progs/nmax.cc
@@ -170,7 +170,7 @@ int main(int argc, char** argv)
     // cout << "Final population:\n" << population << endl;
     cout << "The final population was:" << endl;
     instance_set<int>::const_iterator it = population.begin();
-    for(; it != population.end(); it++) {
+    for(; it != population.end(); ++it) {
        cout << "Score: " << it->second
             << "\tindividual: " << population.fields().to_string(it->first)
             << endl;

--- a/opencog/learning/moses/example-progs/onemax.cc
+++ b/opencog/learning/moses/example-progs/onemax.cc
@@ -157,7 +157,7 @@ int main(int argc, char** argv)
     // cout << "Final population:\n" << population << endl;
     cout << "The final population was:" << endl;
     instance_set<int>::const_iterator it = population.begin();
-    for(; it != population.end(); it++) {
+    for(; it != population.end(); ++it) {
        cout << "Score: " << it->second
             << "\tindividual: " << population.fields().to_string(it->first)
             << endl;

--- a/opencog/learning/moses/example-progs/trap-bit.cc
+++ b/opencog/learning/moses/example-progs/trap-bit.cc
@@ -235,7 +235,7 @@ int main(int argc, char** argv)
     // cout << "Final population:\n" << population << endl;
     cout << "The final population was:" << endl;
     instance_set<int>::const_iterator it = population.begin();
-    for(; it != population.end(); it++) {
+    for(; it != population.end(); ++it) {
        cout << "Score: " << it->second
             << "\tindividual: " << population.fields().to_string(it->first)
             << endl;

--- a/opencog/learning/moses/example-progs/trap-uni.cc
+++ b/opencog/learning/moses/example-progs/trap-uni.cc
@@ -207,7 +207,7 @@ int main(int argc, char** argv)
     // cout << "Final population:\n" << population << endl;
     cout << "The final population was:" << endl;
     instance_set<int>::const_iterator it = population.begin();
-    for(; it != population.end(); it++) {
+    for(; it != population.end(); ++it) {
        cout << "Score: " << it->second
             << "\tindividual: " << population.fields().to_string(it->first)
             << endl;

--- a/opencog/learning/moses/main/demo-problems.cc
+++ b/opencog/learning/moses/main/demo-problems.cc
@@ -348,7 +348,7 @@ static contin_t largest_const_in_tree(const combo_tree &tr)
 {
     contin_t rc = 0.0;
     combo_tree::pre_order_iterator it;
-    for(it = tr.begin(); it != tr.end(); it++) {
+    for(it = tr.begin(); it != tr.end(); ++it) {
         if (is_contin(*it)) {
             contin_t val = get_contin(*it);
             if (rc < val) rc = val;

--- a/opencog/learning/moses/main/problem.cc
+++ b/opencog/learning/moses/main/problem.cc
@@ -125,7 +125,7 @@ using namespace combo;
 
 static bool contains_type(const type_tree_pre_it it, id::type_node ty)
 {
-    for (type_tree_sib_it tts = it.begin(); tts != it.end(); tts++)
+    for (type_tree_sib_it tts = it.begin(); tts != it.end(); ++tts)
         if (*tts == ty) return true;
     return false;
 }

--- a/opencog/learning/moses/metapopulation/merging.cc
+++ b/opencog/learning/moses/metapopulation/merging.cc
@@ -380,7 +380,7 @@ void metapopulation::resize_metapop()
     while (it != _scored_trees.end()) {
         score_t sc = it->get_penalized_score();
         if (sc < worst_score) break;
-        it++;
+        ++it;
     }
 
     while (it != _scored_trees.end()) {

--- a/opencog/learning/moses/moses/distributed_moses.cc
+++ b/opencog/learning/moses/moses/distributed_moses.cc
@@ -307,7 +307,7 @@ host_proc_map init(const jobs_t& jobs)
 proc_map::iterator remove_proc(proc_map& pm,  proc_map::iterator it)
 {
     proc_map::iterator next_it(it);
-    next_it++;
+    ++next_it;
     pm.erase(it);
     return next_it;
 }
@@ -413,7 +413,7 @@ void distributed_moses(metapopulation& mp,
                 it != hpmv.second.end(); )
             {
                 if (is_running(*it)) {
-                    it++;
+                    ++it;
                     continue;
                 }
 

--- a/opencog/learning/moses/moses/mpi_moses.cc
+++ b/opencog/learning/moses/moses/mpi_moses.cc
@@ -208,7 +208,7 @@ void moses_mpi_comm::send_deme(const metapopulation& mp, int n_evals)
     sent_bytes += 2*sizeof(int);
 
     scored_combo_tree_ptr_set_cit it;
-    for (it = mp.begin(); it != mp.end(); it++) {
+    for (it = mp.begin(); it != mp.end(); ++it) {
         const scored_combo_tree& btr = *it;
 
         // We are going to send only the composite score, and not the

--- a/opencog/learning/moses/moses/partial.cc
+++ b/opencog/learning/moses/moses/partial.cc
@@ -171,9 +171,9 @@ void partial_solver::final_cleanup(const metapopulation& cands)
         sib_it ldr = _leader.begin();
         sib_it cit = cand.begin();
         cit = cit.begin();
-        for (sib_it lit = ldr.begin(); lit != ldr.end(); lit++) {
+        for (sib_it lit = ldr.begin(); lit != ldr.end(); ++lit) {
             cit = cand.insert_subtree(cit, lit);
-            cit++;
+            ++cit;
         }
         _reduct(cand);
         _exemplars.push_back(cand);
@@ -203,7 +203,7 @@ void partial_solver::effective(combo_tree::iterator pred,
     interpreter_visitor iv(predicate);
     auto interpret_predicate = boost::apply_visitor(iv);
     CTable::iterator cend = _ctable.end();
-    for (CTable::iterator cit = _ctable.begin(); cit != cend; cit++) {
+    for (CTable::iterator cit = _ctable.begin(); cit != cend; ++cit) {
         vertex pr = interpret_predicate(cit->first.get_variant());
         const CTable::counter_t& c = cit->second;
         total_count += c.total_count();
@@ -241,7 +241,7 @@ void partial_solver::trim_table(CTable& taby,
             deleted += tc;
             taby.erase(cit++);
         }
-        else cit++;
+        else ++cit;
     }
 }
 
@@ -291,8 +291,8 @@ void partial_solver::eval_candidate (const combo_tree& cand)
         }
 
         predicate = sib;
-        sib++;
-        sib++;
+        ++sib;
+        ++sib;
 
         // Count how many items the first predicate mis-identifies.
         fail_count = 0;

--- a/opencog/learning/moses/optimization/optimization.cc
+++ b/opencog/learning/moses/optimization/optimization.cc
@@ -43,7 +43,7 @@ information_theoretic_bits(const field_set& fs)
 
     size_t n_disc_fields = fs.n_disc_fields();
     std::vector<field_set::disc_spec>::const_iterator it = fs.disc_and_bit().begin();
-    for (size_t cnt=0; cnt < n_disc_fields; cnt++, it++) {
+    for (size_t cnt=0; cnt < n_disc_fields; ++cnt, ++it) {
         const field_set::disc_spec& d = *it;
         res += log2<double>(d.multy);
     }

--- a/opencog/learning/moses/representation/build_knobs.cc
+++ b/opencog/learning/moses/representation/build_knobs.cc
@@ -451,7 +451,7 @@ void build_knobs::sample_logical_perms(pre_it it, vector<combo_tree>& perms)
                 perms.push_back(v);
             }
         }
-        arg_type++;
+        ++arg_type;
     }
 
     // Negative one correspnds to no pairs.
@@ -990,7 +990,7 @@ void build_knobs::append_linear_combination(pre_it it)
                     "unsupported argument type.");
             }
         }
-        tit++;
+        ++tit;
     }
 }
 
@@ -1046,9 +1046,9 @@ void build_knobs::enum_canonize(pre_it it)
     sib_it sib = it.begin();
     while(1) {
         sib_it next = sib;
-        next++;
+        ++next;
         if (next == it.end()) break;
-        next++;
+        ++next;
         if (is_logical_operator(*sib) || is_predicate(sib)) {
             logical_canonize(sib);
         }
@@ -1072,9 +1072,9 @@ void build_knobs::build_enum(pre_it it)
     sib_it sib = it.begin();
     while(1) {
         sib_it next = sib;
-        next++;
+        ++next;
         if (next == it.end()) break;
-        next++;
+        ++next;
 
         if (is_logical_operator(*sib) || is_predicate(sib)) {
             // Naively, what one might want to do here is:

--- a/opencog/learning/moses/representation/field_set.cc
+++ b/opencog/learning/moses/representation/field_set.cc
@@ -222,7 +222,7 @@ std::ostream& field_set::ostream_field_set(std::ostream& out) const
 
     std::vector<term_spec>::const_iterator tit = term().begin();
     std::vector<term_spec>::const_iterator tend = term().end();
-    for (; tit != tend; tit++, idx++)
+    for (; tit != tend; ++tit, ++idx)
     {
         out << "\t{ idx=" << idx
             << "; type=term"
@@ -233,7 +233,7 @@ std::ostream& field_set::ostream_field_set(std::ostream& out) const
 
     std::vector<contin_spec>::const_iterator cit = contin().begin();
     std::vector<contin_spec>::const_iterator cend = contin().end();
-    for (; cit != cend; cit++, idx++)
+    for (; cit != cend; ++cit, ++idx)
     {
         out << "\t{ idx=" << idx
             << "; type=contin"
@@ -246,7 +246,7 @@ std::ostream& field_set::ostream_field_set(std::ostream& out) const
 
     std::vector<disc_spec>::const_iterator dit = disc_and_bit().begin();
     std::vector<disc_spec>::const_iterator dend = disc_and_bit().end();
-    for (; dit != dend; dit++, idx++)
+    for (; dit != dend; ++dit, ++idx)
     {
         if (2 < dit->multy)
         {

--- a/opencog/learning/moses/scoring/bscores.cc
+++ b/opencog/learning/moses/scoring/bscores.cc
@@ -450,7 +450,7 @@ behavioral_score enum_table_bscore::best_possible_bscore() const
                   // the one of which there is the most.
                   unsigned most = 0;
                   CTable::counter_t::const_iterator it = c.begin();
-                  for (; it != c.end(); it++) {
+                  for (; it != c.end(); ++it) {
                       if (most < it->second) most = it->second;
                   }
                   return score_t (most - c.total_count());
@@ -643,7 +643,7 @@ behavioral_score enum_effective_bscore::operator()(const combo_tree& tr) const
     // Are we done yet?
     vector<bool> done(_ctable_usize);
     vector<bool>::iterator dit = done.begin();
-    for (; dit != done.end(); dit++) *dit = false;
+    for (; dit != done.end(); ++dit) *dit = false;
 
     sib_it predicate = it.begin();
     score_t weight = 1.0;
@@ -664,8 +664,8 @@ behavioral_score enum_effective_bscore::operator()(const combo_tree& tr) const
                     sc += c.get(consequent);
                     *bit += weight * sc;
                 }
-                bit++;
-                dit++;
+                ++bit;
+                ++dit;
             }
             break;
         }
@@ -696,8 +696,8 @@ behavioral_score enum_effective_bscore::operator()(const combo_tree& tr) const
                     *dit = true;
                 }
             }
-            bit++;
-            dit++;
+            ++bit;
+            ++dit;
         }
 
         // advance

--- a/opencog/learning/pleasure/main/main.cpp
+++ b/opencog/learning/pleasure/main/main.cpp
@@ -78,7 +78,7 @@ int main(int argc, char* argv[])
 
     pleasure::reduce(pop, reduct::mixed_reduction());
     
-    for (population::iterator it = pop.begin(); it != pop.end(); it++) {
+    for (population::iterator it = pop.begin(); it != pop.end(); ++it) {
         std::cout << *it << std::endl;
     }
     std::cout << "Running time: " << difftime(time(NULL), start_time) << std::endl;

--- a/opencog/learning/pleasure/pleasure/generation.cpp
+++ b/opencog/learning/pleasure/pleasure/generation.cpp
@@ -13,7 +13,7 @@ using namespace opencog;
     void enumerate_program_trees(generation_table& gtable, int depth, combo::type_tree& ttree, population& pop, const reduct::rule& reduction_rule) {
         pop.clear();
         // For each generation node with the right return-type, add it to the pop
-        for (std::vector<generation_node>::iterator it = gtable.begin(); it != gtable.end(); it++) {
+        for (std::vector<generation_node>::iterator it = gtable.begin(); it != gtable.end(); ++it) {
             if (combo::equal_type_tree(it->node, combo::get_signature_output(ttree))) {
                 for (node_list::iterator it2 = it->glist.begin(); it2 != it->glist.end(); it2++)
                     pop.push_back(combo::combo_tree(*it2));
@@ -31,7 +31,7 @@ using namespace opencog;
         }
         for (population::iterator it = pop.begin(); it != pop.end();) {
             bool erased = false;
-            for (combo::combo_tree::leaf_iterator lit = it->begin_leaf(); lit != it->end_leaf(); lit++) {
+            for (combo::combo_tree::leaf_iterator lit = it->begin_leaf(); lit != it->end_leaf(); ++lit) {
                 if (get_arity(*lit) != 0 && !combo::is_argument(*lit)) {
                     erased = true;
                     break;
@@ -43,17 +43,17 @@ using namespace opencog;
             if (erased)
                 it = pop.erase(it);
             else 
-                it++;
+                ++it;
         }
     }
 
     void increase_tree_depth(generation_table& gtable, population& pop, int& from_depth, combo::arity_t& needed_arg_count, int fill_from_arg, const reduct::rule& reduction_rule) {
-        for (population::iterator it = pop.begin(); it != pop.end(); it++) {
+        for (population::iterator it = pop.begin(); it != pop.end(); ++it) {
             int number_of_combinations = 1;
             bool can_have_leaves = false;
             std::vector<generation_table::iterator> assignment;
             std::vector<combo::combo_tree::leaf_iterator> leaves;
-            for (combo::combo_tree::leaf_iterator lit = it->begin_leaf(); lit != it->end_leaf(); lit++) {
+            for (combo::combo_tree::leaf_iterator lit = it->begin_leaf(); lit != it->end_leaf(); ++lit) {
                 if (combo::is_argument(*lit))
                     if (combo::get_argument(*lit).abs_idx() <= needed_arg_count)
                         continue;
@@ -72,10 +72,10 @@ using namespace opencog;
                 combo::combo_tree temp_tree(*it);
                 int ongoing_count = 1;
                 leaves.clear();
-                for (combo::combo_tree::leaf_iterator lit = temp_tree.begin_leaf(); lit != temp_tree.end_leaf(); lit++)
+                for (combo::combo_tree::leaf_iterator lit = temp_tree.begin_leaf(); lit != temp_tree.end_leaf(); ++lit)
                     leaves.push_back(lit);
                 std::vector<generation_table::iterator>::iterator it2 = assignment.begin();
-                for (std::vector<combo::combo_tree::leaf_iterator>::iterator lit = leaves.begin(); lit != leaves.end(); lit++) {                    
+                for (std::vector<combo::combo_tree::leaf_iterator>::iterator lit = leaves.begin(); lit != leaves.end(); ++lit) {
                     if (combo::is_argument(**lit))
                         if (combo::get_argument(**lit).abs_idx() <= needed_arg_count)
                            continue;
@@ -89,7 +89,7 @@ using namespace opencog;
                     it2++;
                 }
                 bool erased = true;
-                for (combo::combo_tree::leaf_iterator lit = temp_tree.begin_leaf(); lit != temp_tree.end_leaf(); lit++) {
+                for (combo::combo_tree::leaf_iterator lit = temp_tree.begin_leaf(); lit != temp_tree.end_leaf(); ++lit) {
                     if (combo::get_arity(*lit) != 0 && !combo::is_argument(*lit)) {
                         erased = false;
                         break;
@@ -109,9 +109,9 @@ using namespace opencog;
     }
     
     void fill_leaves(population& pop, int& from_arg) {
-        for (population::iterator it = pop.begin(); it != pop.end(); it++) {
+        for (population::iterator it = pop.begin(); it != pop.end(); ++it) {
             int local_from_arg = from_arg;
-            for (combo::combo_tree::leaf_iterator lit = it->begin_leaf(); lit != it->end_leaf(); lit++) {
+            for (combo::combo_tree::leaf_iterator lit = it->begin_leaf(); lit != it->end_leaf(); ++lit) {
                 if (!combo::is_argument(*lit)) {
                     combo::arity_t number_of_leaves = combo::get_arity(*lit);
                     if (number_of_leaves < 0) number_of_leaves = -1 * number_of_leaves + 1;
@@ -124,7 +124,7 @@ using namespace opencog;
     }
     
     void fill_leaves_single(combo::combo_tree& new_tree, int from_arg) {
-       for (combo::combo_tree::leaf_iterator lit = new_tree.begin_leaf(); lit != new_tree.end_leaf(); lit++) {
+       for (combo::combo_tree::leaf_iterator lit = new_tree.begin_leaf(); lit != new_tree.end_leaf(); ++lit) {
             if (!combo::is_argument(*lit)) {
                 combo::arity_t number_of_leaves = combo::get_arity(*lit);
                 if (number_of_leaves < 0) number_of_leaves = -1 * number_of_leaves + 1;

--- a/opencog/learning/pleasure/pleasure/generation_table.cpp
+++ b/opencog/learning/pleasure/pleasure/generation_table.cpp
@@ -10,7 +10,7 @@ using namespace opencog;
         std::vector<combo::type_tree> type_node_list;
         std::vector<node_list> type_lists;
         combo::type_tree_seq atlist = combo::get_signature_inputs(ttree);
-        for (std::set<combo::vertex>::iterator it = nlist.begin(); it != nlist.end(); it++) {
+        for (std::set<combo::vertex>::iterator it = nlist.begin(); it != nlist.end(); ++it) {
             generation_node gnode;
             combo::type_tree outttree = combo::get_output_type_tree(*it);
             gnode.node = outttree;
@@ -38,7 +38,7 @@ using namespace opencog;
                 type_lists[temp].insert(arg);
             }
         }
-        for (std::vector<generation_node>::iterator it = gtable.begin(); it != gtable.end(); it++) {
+        for (std::vector<generation_node>::iterator it = gtable.begin(); it != gtable.end(); ++it) {
             for (int it2 = 0; it2 != (int)type_node_list.size(); it2++) {
                 if (combo::equal_type_tree(type_node_list[it2], it->node))
                     it->glist = type_lists[it2];
@@ -47,7 +47,7 @@ using namespace opencog;
     }
     
     bool type_registered(combo::type_tree ttree, generation_table& gtable) {
-        for (generation_table::iterator it = gtable.begin(); it != gtable.end(); it++) {
+        for (generation_table::iterator it = gtable.begin(); it != gtable.end(); ++it) {
             if (combo::equal_type_tree(it->node, ttree))
                 return true;
         }

--- a/opencog/learning/pleasure/pleasure/population.cpp
+++ b/opencog/learning/pleasure/pleasure/population.cpp
@@ -8,7 +8,7 @@ using namespace opencog;
     void erase_duplicate(population& pop);
 
     void reduce(population& pop, const reduct::rule& reduction_rule) {
-        for (population::iterator it = pop.begin(); it != pop.end(); it++) {
+        for (population::iterator it = pop.begin(); it != pop.end(); ++it) {
             reduction_rule(*it);
         }
         erase_duplicate(pop);

--- a/opencog/nlp/question/SentenceQuery.cc
+++ b/opencog/nlp/question/SentenceQuery.cc
@@ -379,7 +379,7 @@ void SentenceQuery::solve(AtomSpace *as, Handle sentence_node)
 	bound_vars.clear();
 	std::vector<Handle>::const_iterator i;
 	for (i = normed_predicate.begin();
-	     i != normed_predicate.end(); i++)
+	     i != normed_predicate.end(); ++i)
 	{
 		Handle h = *i;
 		find_vars(h);

--- a/opencog/nlp/question/WordRelQuery.cc
+++ b/opencog/nlp/question/WordRelQuery.cc
@@ -139,7 +139,7 @@ void WordRelQuery::add_to_predicate(Handle ah)
 	/* scan for duplicates, and don't add them */
 	std::vector<Handle>::const_iterator i;
 	for (i = normed_predicate.begin();
-	     i != normed_predicate.end(); i++)
+	     i != normed_predicate.end(); ++i)
 	{
 		Handle h = *i;
 		if (h == ah) return;
@@ -152,7 +152,7 @@ void WordRelQuery::add_to_vars(Handle ah)
 	/* scan for duplicates, and don't add them */
 	std::vector<Handle>::const_iterator i;
 	for (i = bound_vars.begin();
-	     i != bound_vars.end(); i++)
+	     i != bound_vars.end(); ++i)
 	{
 		Handle h = *i;
 		if (h == ah) return;
@@ -346,7 +346,7 @@ bool WordRelQuery::solution(std::map<Handle, Handle> &pred_grounding,
 	// questions in the corpus, and we just happened to
 	// find one of them.)
 	std::map<Handle, Handle>::const_iterator j;
-	for (j=var_grounding.begin(); j != var_grounding.end(); j++)
+	for (j=var_grounding.begin(); j != var_grounding.end(); ++j)
 	{
 		std::pair<Handle, Handle> pv = *j;
 		Handle soln = pv.second;

--- a/opencog/nlp/wsd/EdgeThin.cc
+++ b/opencog/nlp/wsd/EdgeThin.cc
@@ -226,7 +226,7 @@ bool EdgeThin::thin_word(Handle word_h)
 
 	// Delete the rest.
 	std::list<Handle>::iterator it;
-	for (it=sense_list.begin(); it != sense_list.end(); it++)
+	for (it=sense_list.begin(); it != sense_list.end(); ++it)
 	{
 		Handle sense_h = *it;
 
@@ -256,7 +256,7 @@ bool EdgeThin::thin_word(Handle word_h)
 	// up with a higher score than the remaining senses, which would be
 	// wrong; it would be an inversion of how scoring is meant to work.
 	// So we get rid of these now.
-	for (it=sense_list.begin(); it != sense_list.end(); it++)
+	for (it=sense_list.begin(); it != sense_list.end(); ++it)
 	{
 		Handle sense_h = *it;
 		atom_space->removeAtom(sense_h, false);

--- a/opencog/nlp/wsd/Mihalcea.cc
+++ b/opencog/nlp/wsd/Mihalcea.cc
@@ -96,7 +96,7 @@ bool Mihalcea::process_sentence(Handle h)
 	// If there are any senses that are not attached to anything,
 	// get rid of them now.
 	std::deque<Handle>::iterator it;
-	for (it = short_list.begin(); it != short_list.end(); it++)
+	for (it = short_list.begin(); it != short_list.end(); ++it)
 	{
 		Handle parse = *it;
 		thinner.prune_parse(parse);

--- a/opencog/nlp/wsd/MihalceaEdge.cc
+++ b/opencog/nlp/wsd/MihalceaEdge.cc
@@ -95,7 +95,7 @@ void MihalceaEdge::annotate_parse(Handle h)
 	for (f = words.begin(); f != words.end(); ++f)
 	{
 		std::set<Handle>::const_iterator s = f;
-		s++;
+		++s;
 		for (; s != words.end(); ++s)
 		{
 			annotate_word_pair(*f, *s);
@@ -144,10 +144,10 @@ void MihalceaEdge::annotate_parse_pair(Handle ha, Handle hb)
 	gettimeofday(&start, NULL);
 #endif
 	std::set<Handle>::const_iterator ia;
-	for (ia = pa_words.begin(); ia != pa_words.end(); ia++)
+	for (ia = pa_words.begin(); ia != pa_words.end(); ++ia)
 	{
 		std::set<Handle>::const_iterator ib;
-		for (ib = words.begin(); ib != words.end(); ib++)
+		for (ib = words.begin(); ib != words.end(); ++ib)
 		{
 			annotate_word_pair(*ia, *ib);
 		}

--- a/opencog/nlp/wsd/ReportRank.cc
+++ b/opencog/nlp/wsd/ReportRank.cc
@@ -63,7 +63,7 @@ void ReportRank::report_document(const std::deque<Handle> &parse_list)
 
 	// Iterate over all the parses in the document.
 	std::deque<Handle>::const_iterator i;
-	for (i = parse_list.begin(); i != parse_list.end(); i++)
+	for (i = parse_list.begin(); i != parse_list.end(); ++i)
 	{
 		Handle h = *i;
 		foreach_word_instance(h, &ReportRank::count_word, this);
@@ -79,7 +79,7 @@ void ReportRank::report_document(const std::deque<Handle> &parse_list)
 	double average = normalization / sense_count;
 	normalization = 1.0 / average;
 
-	for (i = parse_list.begin(); i != parse_list.end(); i++)
+	for (i = parse_list.begin(); i != parse_list.end(); ++i)
 	{
 		Handle h = *i;
 		foreach_word_instance(h, &ReportRank::renorm_word, this);

--- a/opencog/nlp/wsd/SenseRank.cc
+++ b/opencog/nlp/wsd/SenseRank.cc
@@ -66,11 +66,11 @@ void SenseRank::rank_document(const std::deque<Handle> &parse_list)
 {
 	// Iterate over list of parses making up a "document"
 	std::deque<Handle>::const_iterator i;
-	for (i = parse_list.begin(); i != parse_list.end(); i++)
+	for (i = parse_list.begin(); i != parse_list.end(); ++i)
 	{
 		init_parse(*i);
 	}
-	for (i = parse_list.begin(); i != parse_list.end(); i++)
+	for (i = parse_list.begin(); i != parse_list.end(); ++i)
 	{
 #ifdef DEBUG
 	printf ("; SenseRank document sentence parse %x\n", (Handle) *i); 

--- a/opencog/nlp/wsd/Sweep.cc
+++ b/opencog/nlp/wsd/Sweep.cc
@@ -105,7 +105,7 @@ void Sweep::delete_edges(std::set<Handle> &edges)
 {
 	// Remove all of the senses
 	std::set<Handle>::iterator it;
-	for (it=edges.begin(); it != edges.end(); it++)
+	for (it=edges.begin(); it != edges.end(); ++it)
 	{
 		Handle edge_h = *it;
 		atom_space->removeAtom(edge_h, false);

--- a/opencog/persist/file/SavingLoading.cc
+++ b/opencog/persist/file/SavingLoading.cc
@@ -690,7 +690,7 @@ void SavingLoading::saveRepositories(FILE *f)
     unsigned int size = repositories.size();
     fwrite(&size, sizeof(unsigned int), 1, f);
 
-    for (RepositoryHash::const_iterator it = repositories.begin(); it != repositories.end(); it++) {
+    for (RepositoryHash::const_iterator it = repositories.begin(); it != repositories.end(); ++it) {
         const std::string& repId = it->first;
         int idSize = repId.length() + 1;
         fwrite(&idSize, sizeof(int), 1, f);
@@ -743,7 +743,7 @@ void SavingLoading::clearRepositories()
 {
     logger().fine("SavingLoading::clearRepositories");
     for (RepositoryHash::const_iterator it = repositories.begin();
-            it != repositories.end(); it++) {
+            it != repositories.end(); ++it) {
 
         it->second->clear();
     }

--- a/opencog/persist/file/SpaceServerSavable.cc
+++ b/opencog/persist/file/SpaceServerSavable.cc
@@ -61,7 +61,7 @@ void SpaceServerSavable::saveRepository(FILE * fp) const
     unsigned int mapSize = server->spaceMaps.size();
     fwrite(&mapSize, sizeof(unsigned int), 1, fp);
     std::map<Handle, SpaceServer::SpaceMap*>::iterator itr;
-    for (itr = server->spaceMaps.begin(); itr != server->spaceMaps.end(); itr++) {
+    for (itr = server->spaceMaps.begin(); itr != server->spaceMaps.end(); ++itr) {
         Handle mapHandle = (Handle)(itr->first);
         fwrite(&mapHandle, sizeof(Handle), 1, fp);
         SpaceServer::SpaceMap* map = itr->second;

--- a/opencog/persist/file/TemporalTableFile.cc
+++ b/opencog/persist/file/TemporalTableFile.cc
@@ -100,7 +100,7 @@ void TemporalTableFile::save(FILE *fp, TemporalTable *tbl)
         while (itr != hs->end()) {
             // writes each associated handle
             Handle handle = *itr;
-            itr++;
+            ++itr;
             UUID uuid = handle.value();
             fwrite(&uuid, sizeof(UUID), 1, fp);
         }

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -275,7 +275,7 @@ void DefaultPatternMatchCB::perform_search(PatternMatchEngine *pme,
 		_atom_space->getHandlesByType(back_inserter(handle_set), ptype);
 		std::list<Handle>::iterator i = handle_set.begin();
 		std::list<Handle>::iterator iend = handle_set.end();
-		for (; i != iend; i++)
+		for (; i != iend; ++i)
 		{
 			Handle h(*i);
 			dbgprt("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n");

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -770,7 +770,7 @@ bool PatternMatchEngine::get_next_untried_helper(bool search_optionals)
 	bool solved = false;
 
 	RootMap::iterator k;
-	for (k = _root_map.begin(); k != _root_map.end(); k++)
+	for (k = _root_map.begin(); k != _root_map.end(); ++k)
 	{
 		RootPair vk = *k;
 		RootList *rl = vk.second;
@@ -794,7 +794,7 @@ bool PatternMatchEngine::get_next_untried_helper(bool search_optionals)
 
 		std::vector<Handle>::iterator i = rl->begin();
 		std::vector<Handle>::iterator iend = rl->end();
-		for (; i != iend; i++)
+		for (; i != iend; ++i)
 		{
 			Handle root(*i);
 			if (Handle::UNDEFINED != clause_grounding[root])
@@ -1075,7 +1075,7 @@ void PatternMatchEngine::print_solution(
 	// Print out the bindings of solutions to variables.
 	std::map<Handle, Handle>::const_iterator j = vars.begin();
 	std::map<Handle, Handle>::const_iterator jend = vars.end();
-	for (; j != jend; j++)
+	for (; j != jend; ++j)
 	{
 		Handle var(j->first);
 		Handle soln(j->second);
@@ -1099,7 +1099,7 @@ void PatternMatchEngine::print_solution(
 	printf("\nGrounded clauses:\n");
 	std::map<Handle, Handle>::const_iterator m;
 	int i = 0;
-	for (m = clauses.begin(); m != clauses.end(); m++, i++)
+	for (m = clauses.begin(); m != clauses.end(); ++m, ++i)
 	{
 		if (m->second == Handle::UNDEFINED)
 		{

--- a/opencog/query/PatternUtils.cc
+++ b/opencog/query/PatternUtils.cc
@@ -55,7 +55,7 @@ bool remove_constants(const std::set<Handle> &vars,
 		Handle clause(*i);
 		if (any_variable_in_tree(clause, vars))
 		{
-			i++;
+			++i;
 		}
 		else
 		{

--- a/opencog/query/PatternUtils.h
+++ b/opencog/query/PatternUtils.h
@@ -210,7 +210,7 @@ static inline bool contains_atomtype(Handle& clause, Type atom_type)
 	const std::vector<Handle> &oset = lc->getOutgoingSet();
 	std::vector<Handle>::const_iterator i = oset.begin();
 	std::vector<Handle>::const_iterator iend = oset.end();
-	for (; i != iend; i++)
+	for (; i != iend; ++i)
 	{
 		Handle subclause(*i);
 		if (contains_atomtype(subclause, atom_type)) return true;

--- a/opencog/server/BuiltinRequestsModule.cc
+++ b/opencog/server/BuiltinRequestsModule.cc
@@ -260,7 +260,7 @@ std::string BuiltinRequestsModule::do_stepAgents(Request *dummy, std::list<std::
 
             // try to find an already started agent with that name
             AgentSeq::const_iterator tmp = agents.begin();
-            for ( ; tmp != agents.end() ; tmp++ ) if ( *it == (*tmp)->classinfo().id ) break;
+            for ( ; tmp != agents.end() ; ++tmp ) if ( *it == (*tmp)->classinfo().id ) break;
 
             AgentPtr agent;
             if (agents.end() == tmp) {

--- a/opencog/server/SystemActivityTable.cc
+++ b/opencog/server/SystemActivityTable.cc
@@ -58,7 +58,7 @@ void SystemActivityTable::setMaxAgentActivityTableSeqSize(size_t n)
     _maxAgentActivityTableSeqSize = n;
 
     for (AgentActivityTable::iterator it  = _agentActivityTable.begin();
-                                      it != _agentActivityTable.end(); it++) {
+                                      it != _agentActivityTable.end(); ++it) {
         ActivitySeq &seq = it->second;
         trimActivitySeq(seq, _maxAgentActivityTableSeqSize);
     }
@@ -77,7 +77,7 @@ void SystemActivityTable::atomRemoved(AtomPtr atom)
 {
     Handle h = atom->getHandle();
     for (AgentActivityTable::iterator it  = _agentActivityTable.begin();
-                                      it != _agentActivityTable.end(); it++) {
+                                      it != _agentActivityTable.end(); ++it) {
         ActivitySeq &seq = it->second;
         for (size_t n = 0; n < seq.size(); n++) {
             Activity *a = seq[n];
@@ -113,7 +113,7 @@ void SystemActivityTable::clearActivity(AgentPtr agent)
 void SystemActivityTable::clearActivity()
 {
     for (AgentActivityTable::iterator it  = _agentActivityTable.begin();
-                                      it != _agentActivityTable.end(); it++) {
+                                      it != _agentActivityTable.end(); ++it) {
         ActivitySeq& seq = it->second;
         for (size_t n = 0; n < seq.size(); n++)
             delete seq[n];

--- a/opencog/spacetime/TemporalTable.cc
+++ b/opencog/spacetime/TemporalTable.cc
@@ -199,7 +199,7 @@ HandleTemporalPairEntry* TemporalTable::get(const Temporal& t, TemporalRelations
             UnorderedHandleSet::iterator itr = hs->begin();
             while (itr != hs->end()) {
                 Handle h = *itr;
-                itr++;
+                ++itr;
                 HandleTemporalPairEntry* hte = new HandleTemporalPairEntry(HandleTemporalPair(h, time));
                 if (result == NULL) {
                     result = hte;
@@ -224,7 +224,7 @@ HandleTemporalPairEntry* TemporalTable::get(const Temporal& t, TemporalRelations
                 while (itr != hs->end()) {
                     DPRINTF("hs iterator has next\n");
                     Handle handle = *itr;
-                    itr++;
+                    ++itr;
                     DPRINTF("Got handle = %ld\n", handle.value());
                     if (time == NULL) {
                         DPRINTF("time is NULL. Creating Temporal object\n");
@@ -293,7 +293,7 @@ HandleTemporalPairEntry* TemporalTable::get(const Temporal& t, TemporalRelations
                         // DPRINTF("=> %s:\n", hs->toString().c_str());
                         while (itr != hs->end()) {
                             HandleTemporalPairEntry* newEntry = new HandleTemporalPairEntry(*itr, currentEntry->time);
-                            itr++;
+                            ++itr;
                             if (result) {
                                 resultTail->next = newEntry;
                             } else {
@@ -333,7 +333,7 @@ HandleTemporalPairEntry* TemporalTable::get(const Temporal& t, TemporalRelations
                         UnorderedHandleSet::iterator itr = hs->begin();
                         while (itr != hs->end()) {
                             Handle h = *itr;
-                            itr++;
+                            ++itr;
                             HandleTemporalPairEntry* hte = new HandleTemporalPairEntry(HandleTemporalPair(h, time));
                             if (result == NULL) {
                                 result = hte;
@@ -352,7 +352,7 @@ HandleTemporalPairEntry* TemporalTable::get(const Temporal& t, TemporalRelations
                 UnorderedHandleSet::iterator itr = hs->begin();
                 while (itr != hs->end()) {
                     Handle h = *itr;
-                    itr++;
+                    ++itr;
                     HandleTemporalPairEntry* hte = new HandleTemporalPairEntry(HandleTemporalPair(h, previousTime));
                     if (result == NULL) {
                         result = hte;
@@ -497,7 +497,7 @@ bool TemporalTable::remove(const Temporal& t, TemporalRelationship criterion)
                 while (itr != hs->end()) {
                     DPRINTF("hs iterator has next\n");
                     Handle handle = *itr;
-                    itr++;
+                    ++itr;
                     DPRINTF("Got handle = %ld\n", handle.value());
                     TemporalEntry* te = handleMap->remove(handle);
                     TemporalEntry* tailTe = tailHandleMap->get(handle);

--- a/opencog/spatial/AStar3DController.cc
+++ b/opencog/spatial/AStar3DController.cc
@@ -222,7 +222,7 @@ vector<spatial::Point3D> AStar3DController::getSolutionPoints()
     } else if (!approxSolution.empty()) {
         std::vector<MapSearchNode>::const_iterator prev_node, node;
         prev_node = node = approxSolution.begin();
-        for (++node; node != approxSolution.end(); node++) {
+        for (++node; node != approxSolution.end(); ++node) {
             gp.first = prev_node->x;
             gp.second = prev_node->y;
 
@@ -273,7 +273,7 @@ vector<spatial::Point3D> AStar3DController::getShortestCalculatedPath()
     vector<spatial::Point3D>::iterator it_point = calculatedPath.begin();
     shortestCalculatedPath.push_back( *it_point );
     double alpha = ( - (it_point + 1)->get<1>()) / (it_point->get<0>() - (it_point + 1)->get<0>());
-    it_point++;
+    ++it_point;
     while ( (it_point + 1) != calculatedPath.end() ) {
         double new_alpha = (it_point->get<1>() - (it_point + 1)->get<1>()) / (it_point->get<0>() - (it_point + 1)->get<0>());
         if (std::abs(it_point->get<2>()) > 0.0) {
@@ -284,7 +284,7 @@ vector<spatial::Point3D> AStar3DController::getShortestCalculatedPath()
             shortestCalculatedPath.push_back( *it_point );
             alpha = new_alpha;
         }
-        it_point++;
+        ++it_point;
     }
     shortestCalculatedPath.push_back( *it_point );
 

--- a/opencog/spatial/AStarController.cc
+++ b/opencog/spatial/AStarController.cc
@@ -216,14 +216,14 @@ vector<spatial::Point> AStarController::getShortestCalculatedPath()
     vector<spatial::Point>::iterator it_point = calculatedPath.begin();
     shortestCalculatedPath.push_back( *it_point );
     double alpha = (it_point->second - (it_point + 1)->second) / (it_point->first - (it_point + 1)->first);
-    it_point++;
+    ++it_point;
     while ( (it_point + 1) != calculatedPath.end() ) {
         double new_alpha = (it_point->second - (it_point + 1)->second) / (it_point->first - (it_point + 1)->first);
         if ( abs(new_alpha - alpha) > 0.002 ) {
             shortestCalculatedPath.push_back( *it_point );
             alpha = new_alpha;
         }
-        it_point++;
+        ++it_point;
     }
     shortestCalculatedPath.push_back( *it_point );
 

--- a/opencog/spatial/AStarTest.cc
+++ b/opencog/spatial/AStarTest.cc
@@ -103,7 +103,7 @@ void printSolution(vector<spatial::GridPoint> points)
     int stepCount = 0;
     for (iter = points.begin();
             iter != points.end();
-            iter++) {
+            ++iter) {
         cout << "Node " << stepCount << ": (" << (*iter).first << "," << (*iter).second << ")\n";
         stepCount++;
     }
@@ -116,7 +116,7 @@ void printPointsSolution(vector<spatial::Point> points)
     int stepCount = 0;
     for (iter = points.begin();
             iter != points.end();
-            iter++) {
+            ++iter) {
         cout << "Node " << stepCount << ": (" << (*iter).first << "," << (*iter).second << ")\n";
         stepCount++;
     }

--- a/opencog/spatial/LocalSpaceMap2D.cc
+++ b/opencog/spatial/LocalSpaceMap2D.cc
@@ -604,7 +604,7 @@ double LocalSpaceMap2D::getProperFreePointAltitude(const spatial::GridPoint& gp,
     double topSurface = _floorHeight;
     std::vector<spatial::Gradient> grads = getObjectGradientsByGridPoint(gp);
     std::vector<spatial::Gradient>::const_iterator it = grads.begin();
-    for (; it != grads.end(); it++) {
+    for (; it != grads.end(); ++it) {
         if (topSurface + _agentHeight > it->first) {
             // The agent is not able to stand on this point because the roof of
             // this point can not cover the agent.
@@ -690,7 +690,7 @@ double LocalSpaceMap2D::getProperDestAltitude(const spatial::GridPoint &src, con
         double topSurface = _floorHeight;
         std::vector<spatial::Gradient> grads = getObjectGradientsByGridPoint(dest);
         std::vector<spatial::Gradient>::const_iterator it = grads.begin();
-        for (; it != grads.end(); it++) {
+        for (; it != grads.end(); ++it) {
             if (srcHeight >= it->first) {
                 // bottom surface is lower than src altitude, then the altitude of
                 // top surface should be no smaller than its opposite surface.
@@ -732,7 +732,7 @@ spatial::ObjectID LocalSpaceMap2D::getTallestObjectInGrid(const GridPoint &gp) c
     spatial::ObjectID id;
     const spatial::ObjectInfoSet& objInfoSet = _grid.at(gp);
     spatial::ObjectInfoSet::const_iterator it = objInfoSet.begin();
-    for (; it != objInfoSet.end(); it++) {
+    for (; it != objInfoSet.end(); ++it) {
         if (it->isExtraBoundary) continue;
         spatial::ObjectID entityId = spatial::ObjectID(it->id);
         const EntityPtr& entityPtr = getEntity(entityId);
@@ -752,7 +752,7 @@ std::vector<spatial::Gradient> LocalSpaceMap2D::getObjectGradientsByGridPoint(co
         return grads;
     const spatial::ObjectInfoSet& objInfoSet = _grid.at(gp);
     spatial::ObjectInfoSet::const_iterator it = objInfoSet.begin();
-    for (; it != objInfoSet.end(); it++) {
+    for (; it != objInfoSet.end(); ++it) {
         if (it->isExtraBoundary) {
             continue;
         }
@@ -1410,7 +1410,7 @@ void rec_find::check_grid()
         spatial::ObjectInfoSet::const_iterator obj_info_it = (it->second).begin();
         while (obj_info_it != (it->second).end()) {
             _out.insert(obj_info_it->id);
-            obj_info_it++;
+            ++obj_info_it;
         }
     }
 }

--- a/opencog/spatial/stlastar.h
+++ b/opencog/spatial/stlastar.h
@@ -500,7 +500,7 @@ namespace opencog
                 }
 
                 UserState *GetOpenListNext( float &f, float &g, float &h ) {
-                    iterDbgOpen++;
+                    ++iterDbgOpen;
                     if ( iterDbgOpen != m_OpenList.end() ) {
                         f = (*iterDbgOpen)->f;
                         g = (*iterDbgOpen)->g;
@@ -535,7 +535,7 @@ namespace opencog
                 }
 
                 UserState *GetClosedListNext( float &f, float &g, float &h ) {
-                    iterDbgClosed++;
+                    ++iterDbgClosed;
                     if ( iterDbgClosed != m_ClosedList.end() ) {
                         f = (*iterDbgClosed)->f;
                         g = (*iterDbgClosed)->g;

--- a/opencog/util/log_prog_name.cc
+++ b/opencog/util/log_prog_name.cc
@@ -61,7 +61,7 @@ string determine_log_name(const string& log_file_prefix,
 
     string log_file = log_file_prefix;
     for(boost::program_options::variables_map::const_iterator it = vm.begin();
-        it != vm.end(); it++)
+        it != vm.end(); ++it)
         // we ignore the options in ignore_opt and any default one
         if(ignore_opt.find(it->first) == ignore_opt.end()
            && !it->second.defaulted()) {

--- a/opencog/util/numeric.h
+++ b/opencog/util/numeric.h
@@ -415,19 +415,19 @@ Float p_norm_distance(const Vec& a, const Vec& b, Float p=1.0)
     Float sum = 0.0;
     // Special case Manhattan distance.
     if (1.0 == p) {
-        for (; ia != a.end(); ia++, ib++)
+        for (; ia != a.end(); ++ia, ++ib)
             sum += fabs (*ia - *ib);
         return sum;
     }
     // Special case Euclidean distance.
     if (2.0 == p) {
-        for (; ia != a.end(); ia++, ib++)
+        for (; ia != a.end(); ++ia, ++ib)
             sum += sq (*ia - *ib);
         return sqrt(sum);
     }
     // Special case max difference
     if (0.0 >= p) {
-        for (; ia != a.end(); ia++, ib++) {
+        for (; ia != a.end(); ++ia, ++ib) {
             Float diff = fabs (*ia - *ib);
             if (sum < diff) sum = diff;
         }
@@ -435,7 +435,7 @@ Float p_norm_distance(const Vec& a, const Vec& b, Float p=1.0)
     }
 
     // General case.
-    for (; ia != a.end(); ia++, ib++) {
+    for (; ia != a.end(); ++ia, ++ib) {
         Float diff = fabs (*ia - *ib);
         if (0.0 < diff)
             sum += pow(diff, p);

--- a/tests/atomspace/HandleEntry.cc
+++ b/tests/atomspace/HandleEntry.cc
@@ -816,7 +816,7 @@ HandleEntry* HandleEntry::fromHandleSet(const UnorderedHandleSet &s)
 {
     HandleEntry *ret = NULL;
     UnorderedHandleSet::const_iterator it = s.cbegin();
-    for (; it != s.cend(); it++)
+    for (; it != s.cend(); ++it)
     {
         HandleEntry *temp = new HandleEntry(*it);
         ret = HandleEntry::concatenation(temp, ret);


### PR DESCRIPTION
...pes"
I used these scripts:
for i in `grep Prefer cppcheck_reports.txt|sed 's/\[\(.*\)\].*/\1/'`;do var1=`echo $i|cut -d: -f1`;var2=`echo $i|cut -d: -f2`;sed -i -e "${var2}s/([a-zA-Z._]*)(++)/\2\1/g" $var1;done;

for i in `grep Prefer cppcheck_reports.txt|sed 's/\[\(.*\)\].*/\1/'`;do var1=`echo $i|cut -d: -f1`;var2=`echo $i|cut -d: -f2`;sed -i -e "${var2}s/([a-zA-Z._]*)(--)/\2\1/g" $var1;done;
- fixed some problems with end of lines.

Then I built the whole project as a basic check, no error.
