### PR TITLE
PM: Make get_connected_components uses "vars"

### DIFF
--- a/opencog/query/PatternUtils.cc
+++ b/opencog/query/PatternUtils.cc
@@ -128,7 +128,7 @@ void get_connected_components(
 					components[i] = curr_component;
 
 					// Add to the varset cache for that component.
-					FindVariables fv;
+					FindVariables fv(vars);
 					fv.find_vars(cl);
 					for (Handle v : fv.varset) cur_vars.insert(v);
 					component_vars[i] = cur_vars;
@@ -161,7 +161,7 @@ void get_connected_components(
 		new_component.push_back(ncl);
 		components.push_back(new_component);
 
-		FindVariables fv;
+		FindVariables fv(vars);
 		fv.find_vars(ncl);
 		std::set<Handle> new_varcache(fv.varset);
 		component_vars.push_back(new_varcache);

--- a/opencog/query/PatternUtils.h
+++ b/opencog/query/PatternUtils.h
@@ -44,6 +44,9 @@ class FindVariables
 	public:
 		std::set<Handle> varset;
 
+		inline FindVariables() {}
+		inline FindVariables(const std::set<Handle>& input) : input_varset(input) {}
+
 		/**
 		 * Create a set of all of the VariableNodes that lie in the
 		 * outgoing set of the handle (recursively).
@@ -53,7 +56,9 @@ class FindVariables
 			Type t = h->getType();
 			if (classserver().isNode(t))
 			{
-				if (t == VARIABLE_NODE) varset.insert(h);
+				if ((input_varset.empty() && t == VARIABLE_NODE) || input_varset.count(h) == 1)
+					varset.insert(h);
+
 				return;
 			}
 
@@ -65,6 +70,8 @@ class FindVariables
 		{
 			for (Handle h : hlist) find_vars(h);
 		}
+	private:
+		std::set<Handle> input_varset;
 };
 
 /**


### PR DESCRIPTION
`get_connected_components` was ignoring its `vars` argument.  Changed `FindVariables` to accept a vars list.  Exisiting usage should be intact.