### PR TITLE
Make chatbot useable again (mostly)

### DIFF
--- a/lib/opencog-chatbot.conf
+++ b/lib/opencog-chatbot.conf
@@ -19,23 +19,44 @@ MIN_STI               = -400
 #
 # Blank out the prompt, so that it doesn't spew out to the chatbot.
 PROMPT                = ""
+
 MODULES               = opencog/server/libbuiltinreqs.so,
-                        opencog/persist/sql/libpersist.so, 
+                        opencog/persist/sql/libpersist.so,
                         opencog/query/libquery.so,
-                        opencog/shell/libscheme-shell.so
+                        opencog/query/libQueryModule.so,
+                        opencog/shell/libscheme-shell.so,
+                        opencog/shell/libpy-shell.so,
+                        opencog/nlp/types/libnlp-types.so,
+                        opencog/nlp/lg-dict/libLGDictModule.so,
+                        opencog/nlp/sureal/libSuRealModule.so,
+                        opencog/learning/pln/libPLNTypes.so,
+                        opencog/dynamics/attention/libattention-types.so,
+                        opencog/dynamics/attention/libattention.so,
+                        opencog/embodiment/AtomSpaceExtensions/libembodiment-types.so,
+                        opencog/embodiment/AtomSpaceExtensions/libAtomSpaceExtensions.so,
+                        opencog/cython/libPythonModule.so,
+                        opencog/reasoning/RuleEngine/rule-engine-src/libRuleEngineModule.so
 
 SCM_PRELOAD           = atomspace/core_types.scm,
                         nlp/types/nlp_types.scm,
                         dynamics/attention/attention_types.scm,
                         embodiment/AtomSpaceExtensions/embodiment_types.scm,
                         viterbi/viterbi_types.scm,
+                        learning/pln/pln_types.scm,
+                        scm/apply.scm,
+                        scm/config.scm, 
                         scm/persistence.scm, 
                         scm/utilities.scm,
                         scm/file-utils.scm, 
                         scm/debug.scm,
+                        scm/repl-shell.scm,
+                        scm/av-tv.scm,
+                        nlp/scm/config.scm, 
                         nlp/scm/type-definitions.scm,
+                        nlp/scm/file-utils.scm,
                         nlp/scm/nlp-utils.scm,
                         nlp/scm/processing-utils.scm,
+                        nlp/scm/disjunct-list.scm,
                         nlp/chatbot/chat-interface.scm,
                         nlp/seme/seme-process.scm,
                         nlp/triples/preps.scm,
@@ -46,8 +67,27 @@ SCM_PRELOAD           = atomspace/core_types.scm,
                         nlp/triples/triples-pipeline.scm,
                         nlp/triples/question-pipeline.scm,
                         nlp/triples/deduction.scm,
-                        nlp/question/query.scm
+                        nlp/types/nlp_types.scm,
+                        nlp/question/query.scm,
+                        nlp/relex2logic/utilities.scm,
+                        nlp/relex2logic/rule-helpers.scm,
+                        nlp/relex2logic/post-processing.scm,
+                        nlp/sureal/surface-realization.scm,
+                        spacetime/spacetime_types.scm
 #                        nlp/pln/isa.scm
+
+# Uncomment if Python extensions are not stored in these locations,
+# or the binary and source directories:
+#     /usr/local/share/opencog/python
+#     /usr/share/opencog/python
+#     
+# Use a comma separated list for multiple dirs
+PYTHON_EXTENSION_DIRS  = ../opencog/python/web/api,
+                         ../opencog/python/pln,
+                         ../tests/python/test_pln
+
+# Run these python modules on start up
+PYTHON_PRELOAD = pyshell, restapi, pattern_match_functions, agent_finder
 
 # Data storage/backing-store
 STORAGE               = triples

--- a/scripts/run_chatbot_and_servers.sh
+++ b/scripts/run_chatbot_and_servers.sh
@@ -3,7 +3,7 @@
 #
 # Copyright 2009 - Joel Pitt
 #
-# Script launches a gnome-terminal with three tabs:
+# Script launches a mate-terminal with three tabs:
 # - CogServer
 # - RelEx server
 # - Cogita chatbot
@@ -14,15 +14,16 @@
 # Note: path to src and build directory and path to relex distribution need to
 # be updated (RelEx script opencog-server.sh must also be properly configured).
 
-branch_dir=/home/joel/src/opencog/trunk
-build_dir=${branch_dir}/bin
+branch_dir=/home/buck/Code/opencog
+build_dir=${branch_dir}/build
 
-relex_path=/home/joel/src/relex
+relex_path=/home/buck/Code/relex
 bot_name=cogita-$RANDOM
 
 old_dir=`pwd`
 cd ${build_dir}
-gnome-terminal \
+mate-terminal \
+  --maximize \
   --hide-menubar \
   --tab --title "CogServer" \ #--working-directory= \
   --command="./opencog/server/cogserver -c ../lib/opencog-chatbot.conf -DLOG_TO_STDOUT=TRUE" \
@@ -34,7 +35,8 @@ gnome-terminal \
 
 sleep 2
 # load axioms for chatting into cogserver
-cd ${build_dir}/opencog/nlp/triples/
+cd ${branch_dir}/opencog/nlp/chatbot
+pwd
 ./load-chatbot.sh
 cd ${old_dir}
 


### PR DESCRIPTION
This commit request fixes the config file to launch the opencog server ready to support a chatbot, and also changes the path at the end of the scripts/run_chatbot_and_servers.sh file.  The other changes to the run script should maybe be ignored, although I am not sure how to pick out just some changes.  The only major issue is that I have changed gnome-terminal to mate-terminal since that is what it is called on linux mint, but for most people this program name will be not found.

There is still the issue of commenting out the rule number 9 in rules.scm which causes a stackdump when the chatbot is asked a question.  I have not yet submitted that as a change as I don't want to remove the functionality until Linas has had a look at it to see if it can be fixed rather than commented out.  If no fix is possible (or at least not worth doing) then I can ammend this pull request to include the commenting out as well.
