### PR TITLE
Negate *_match semantics

### DIFF
--- a/opencog/atomspace/ForeachTwo.h
+++ b/opencog/atomspace/ForeachTwo.h
@@ -21,6 +21,8 @@ namespace opencog
  * Invoke the callback on each pair of corresponding atoms in the
  * vectors va and vb. This iterator is typically useful for making
  * comparisons between atoms.
+ *
+ * Returns true if all calls return true, return false otherwise.
  */
 template<class T>
 inline bool foreach_atom_pair(const std::vector<Handle> &va,
@@ -33,18 +35,18 @@ inline bool foreach_atom_pair(const std::vector<Handle> &va,
 
     for (size_t i = 0; i < minsz; i++) {
         bool rc = (data->*cb)(va[i], vb[i]);
-        if (rc) return rc;
+        if (not rc) return false;
     }
 
     for (size_t i = vasz; i < vbsz; i++) {
         bool rc = (data->*cb)(Handle::UNDEFINED, vb[i]);
-        if (rc) return rc;
+        if (not rc) return false;
     }
     for (size_t i = vbsz; i < vasz; i++) {
         bool rc = (data->*cb)(va[i], Handle::UNDEFINED);
-        if (rc) return rc;
+        if (not rc) return false;
     }
-    return false;
+    return true;
 }
 
 /** @}*/

--- a/opencog/nlp/question/FrameQuery.cc
+++ b/opencog/nlp/question/FrameQuery.cc
@@ -216,8 +216,8 @@ bool FrameQuery::assemble_predicate(Atom *atom)
  * Are two nodes "equivalent", as far as the opencog representation 
  * of RelEx expressions are concerned? 
  *
- * Return true to signify a mismatch,
- * Return false to signify equivalence.
+ * Return false to signify a mismatch,
+ * Return true to signify equivalence.
  */
 bool FrameQuery::node_match(Node *aa, Node *ab)
 {
@@ -228,17 +228,17 @@ bool FrameQuery::node_match(Node *aa, Node *ab)
 
 	// DefinedLinguisticConcept nodes must match exactly;
 	// so if we are here, there's already a mismatch.
-	if (DEFINED_LINGUISTIC_CONCEPT_NODE == ntype) return true;
-	if (DEFINED_FRAME_NODE == ntype) return true;
-	if (DEFINED_FRAME_ELEMENT_NODE == ntype) return true;
+	if (DEFINED_LINGUISTIC_CONCEPT_NODE == ntype) return false;
+	if (DEFINED_FRAME_NODE == ntype) return false;
+	if (DEFINED_FRAME_ELEMENT_NODE == ntype) return false;
 
 #if BORKEN_STUFF
 	// Concept nodes can match if they inherit from the same concept.
 	if (CONCEPT_NODE == ntype)
 	{
-		bool mismatch = concept_match(aa, ab);
+		bool match = concept_match(aa, ab);
 		// printf("tree_comp concept mismatch=%d\n", mismatch);
-		return mismatch;
+		return match;
 	}
 #endif
 
@@ -250,7 +250,7 @@ bool FrameQuery::node_match(Node *aa, Node *ab)
 	fprintf (stderr, "unexpected comp %s\n"
 	                 "             to %s\n", sa.c_str(), sb.c_str());
 
-	return true;
+	return false;
 }
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/nlp/question/WordRelQuery.cc
+++ b/opencog/nlp/question/WordRelQuery.cc
@@ -180,8 +180,7 @@ bool WordRelQuery::find_vars(Handle word_instance)
 
 /**
  * Do two word instances have the same word lemma (word root form)?
- * Return true if they are are NOT (that is, if they
- * are mismatched). 
+ * Return true if they are (that is, if they match).
  *
  * Current NLP structure relating word-instances to lemmas is:
  * (LemmaLink (stv 1.0 1.0)
@@ -199,7 +198,7 @@ bool WordRelQuery::word_instance_match(Atom *aa, Atom *ab)
 	dbgprt("   to wrd inst "); prt(ab);
 
 	// If they're the same atom, then clearly they match.
-	if (aa == ab) return false;
+	if (aa == ab) return true;
 
 	// Look for incoming links that are LemmaLinks.
 	// The word lemma should be at the far end.
@@ -209,8 +208,7 @@ bool WordRelQuery::word_instance_match(Atom *aa, Atom *ab)
 	dbgprt("gen comp %d ", ca==cb); prt(ca);
 	dbgprt("        to "); prt(cb);
 
-	if (ca == cb) return false;
-	return true;
+	return ca == cb;
 }
 
 #ifdef DEAD_CODE_BUT_DONT_DELETE_JUST_YET
@@ -251,8 +249,8 @@ const char * WordRelQuery::get_word_instance(Atom *atom)
  * Are two nodes "equivalent", as far as the opencog representation
  * of RelEx expressions are concerned?
  *
- * Return true to signify a mismatch,
- * Return false to signify equivalence.
+ * Return false to signify a mismatch,
+ * Return true to signify equivalence.
  */
 bool WordRelQuery::node_match(Node *npat, Node *nsoln)
 {
@@ -264,7 +262,7 @@ bool WordRelQuery::node_match(Node *npat, Node *nsoln)
 	if ((pattype != soltype) && 
 	    (WORD_NODE != soltype) && 
 	    (SEME_NODE != soltype) && 
-	    (WORD_INSTANCE_NODE != soltype)) return true;
+	    (WORD_INSTANCE_NODE != soltype)) return false;
 
 	// DefinedLinguisticRelation nodes must usually match exactly;
 	// so if we are here, there's probably already a mismatch.
@@ -272,13 +270,13 @@ bool WordRelQuery::node_match(Node *npat, Node *nsoln)
 	    (PREPOSITIONAL_RELATIONSHIP_NODE == soltype))
 	{
 		const char *spat = npat->getName().c_str();
-		if (strcmp("isa", spat) && strcmp("hypothetical_isa", spat)) return true;
+		if (strcmp("isa", spat) && strcmp("hypothetical_isa", spat)) return false;
 		const char *ssol = npat->getName().c_str();
-		if (strcmp("isa", ssol) && strcmp("hypothetical_isa", ssol)) return true;
+		if (strcmp("isa", ssol) && strcmp("hypothetical_isa", ssol)) return false;
 
 		// If we got to here then we matched isa to isa or hypothetical_isa,
 		// and that's all good.  Err.. XXX bad if not a question, but whatever.
-		return false;
+		return true;
 	}
 
 	// Word instances match only if they have the same word lemma.
@@ -286,9 +284,9 @@ bool WordRelQuery::node_match(Node *npat, Node *nsoln)
 	    (WORD_NODE == soltype) || // XXX get rid of WordNode here, someday.
 	    (SEME_NODE == soltype))
 	{
-		bool mismatch = word_instance_match(npat, nsoln);
-		dbgprt("word instance mismatch=%d\n", mismatch);
-		return mismatch;
+		bool match = word_instance_match(npat, nsoln);
+		dbgprt("word instance match=%d\n", mismatch);
+		return match;
 	}
 
 	// XXX This code is never reached !!!??? 
@@ -321,8 +319,8 @@ printf("duude compare %s to %s\n", sa, sb);
 			s[len] = 0x0;
 			sb = s;
 		}
-		if (!strcmp(sa, sb)) return false;
-		return true;
+		if (!strcmp(sa, sb)) return true;
+		return false;
 	}
 
 	fprintf(stderr, "Error: unexpected ground node type %d %s\n", soltype,
@@ -333,7 +331,7 @@ printf("duude compare %s to %s\n", sa, sb);
 	fprintf (stderr, "unexpected comp %s\n"
 	                 "             to %s\n", sa.c_str(), sb.c_str());
 
-	return true;
+	return false;
 }
 
 /* ======================================================== */

--- a/opencog/nlp/question/WordRelQuery.cc
+++ b/opencog/nlp/question/WordRelQuery.cc
@@ -319,8 +319,7 @@ printf("duude compare %s to %s\n", sa, sb);
 			s[len] = 0x0;
 			sb = s;
 		}
-		if (!strcmp(sa, sb)) return true;
-		return false;
+		return !strcmp(sa, sb);
 	}
 
 	fprintf(stderr, "Error: unexpected ground node type %d %s\n", soltype,

--- a/opencog/nlp/sureal/SuRealPMCB.cc
+++ b/opencog/nlp/sureal/SuRealPMCB.cc
@@ -56,7 +56,7 @@ SuRealPMCB::SuRealPMCB(AtomSpace* pAS, std::set<Handle> vars) : DefaultPatternMa
  *
  * @param hPat    the variable, a node extracted from the original query
  * @param hSoln   the potential mapping
- * @return        true if solution is rejected, false if accepted
+ * @return        false if solution is rejected, true if accepted
  */
 bool SuRealPMCB::variable_match(Handle &hPat, Handle &hSoln)
 {
@@ -64,11 +64,11 @@ bool SuRealPMCB::variable_match(Handle &hPat, Handle &hSoln)
 
     // reject if the solution is not of the same type
     if (hPat->getType() != hSoln->getType())
-        return true;
+        return false;
 
     // VariableNode can be matched to any VariableNode, similarly for InterpretationNode
     if (hPat->getType() == VARIABLE_NODE || hPat->getType() == INTERPRETATION_NODE)
-        return false;
+        return true;
 
     std::string sPat = _as->getName(hPat);
     std::string sPatWord = sPat.substr(0, sPat.find_first_of('@'));
@@ -81,7 +81,7 @@ bool SuRealPMCB::variable_match(Handle &hPat, Handle &hSoln)
 
     // no WordNode? reject!
     if (hSolnWordNode == Handle::UNDEFINED)
-        return true;
+        return false;
 
     // get the neighbor of each WordNode within LgWordCset
     HandleSeq qPatSet =_as->getNeighbors(hPatWordNode, false, true, LG_WORD_CSET, false);
@@ -96,9 +96,9 @@ bool SuRealPMCB::variable_match(Handle &hPat, Handle &hSoln)
 
     // if there's no common LG dictionary rules, then the two words do not match
     if (qItrsect.empty())
-        return true;
+        return false;
 
-    return false;
+    return true;
 }
 
 /**
@@ -111,7 +111,7 @@ bool SuRealPMCB::variable_match(Handle &hPat, Handle &hSoln)
  *
  * @param pattrn_link_h   the matched clause, extracted from the input SetLink
  * @param grnd_link_h     the corresponding grounding to be checked
- * @return                true if rejected, false if accepted
+ * @return                false if rejected, true if accepted
  */
 bool SuRealPMCB::clause_match(Handle &pattrn_link_h, Handle &grnd_link_h)
 {
@@ -129,8 +129,8 @@ bool SuRealPMCB::clause_match(Handle &pattrn_link_h, Handle &grnd_link_h)
         return std::any_of(qN.begin(), qN.end(), [](Handle& hn) { return hn->getType() == INTERPRETATION_NODE; });
     };
 
-    // reject match (ie. return true) if there is no InterpretationNode
-    return not std::any_of(qISet.begin(), qISet.end(), hasInterpretation);
+    // reject match (ie. return false) if there is no InterpretationNode
+    return std::any_of(qISet.begin(), qISet.end(), hasInterpretation);
 }
 
 /**

--- a/opencog/query/AttentionalFocusCB.cc
+++ b/opencog/query/AttentionalFocusCB.cc
@@ -26,17 +26,14 @@ using namespace opencog;
 
 bool AttentionalFocusCB::node_match(Handle& node1, Handle& node2)
 {
-	return node1 != node2 or
-		node2->getSTI() <= _as->getAttentionalFocusBoundary();
+	return node1 == node2 and
+		node2->getSTI() > _as->getAttentionalFocusBoundary();
 }
 
 bool AttentionalFocusCB::link_match(LinkPtr& lpat, LinkPtr& lsoln)
 {
-	if (DefaultPatternMatchCB::link_match(lpat, lsoln))
-	{
-		return true;
-	}
-	return lsoln->getSTI() <= _as->getAttentionalFocusBoundary();
+	return DefaultPatternMatchCB::link_match(lpat, lsoln)
+		and lsoln->getSTI() > _as->getAttentionalFocusBoundary();
 }
 
 IncomingSet AttentionalFocusCB::get_incoming_set(Handle h)

--- a/opencog/query/CrispLogicPMCB.h
+++ b/opencog/query/CrispLogicPMCB.h
@@ -48,20 +48,19 @@ class CrispLogicPMCB :
 		CrispLogicPMCB(AtomSpace* as) : DefaultPatternMatchCB(as) {}
 
 		/**
- 		 * This callback is called whenever a match has beeen identified
+ 		 * This callback is called whenever a match has been identified
  		 * for a required assertion. Here, we check the truth value; if
- 		 * it is >0.5, its taken to be true, and accepted, else, its 
+ 		 * it is >= 0.5, its taken to be true, and accepted, else, its 
  		 * taken to be false. 
  		 *
- 		 * Note the inverted return value: return "false" to accept 
- 		 * a clause, and return "true" to reject it. 
+ 		 * Return "true" to accept a clause, and return "false" to
+ 		 * reject it.
  		 */
 		virtual bool clause_match(Handle& pattrn, Handle& grnd)
 		{
 			TruthValuePtr tv(grnd->getTruthValue());
 			// printf (">>>>>>>> clause match tv=%f\n", tv.getMean());
-			if (tv->getMean() < 0.5) return true;
-			return false;
+			reutn tv->getMean() >= 0.5;
 		}
 
 		/**
@@ -70,20 +69,18 @@ class CrispLogicPMCB :
  		 * in the sense that, if its absent, its taken to be false, and
  		 * the pattern match is taken to be full-filled (because the pattern
  		 * was not found).  If the clause is found, then it is accepted only
- 		 * if its truth value is *less* than 0.5. (i.e. it must be false to 
- 		 * be accepted .. ergo, its a negation).
+ 		 * if its truth value is *less* than 0.5.
  		 *
- 		 * As usual, return "false" to accept a clause, and return "true" to
+ 		 * As usual, return "true" to accept a clause, and return "false" to
  		 * reject it. 
  		 */
 		virtual bool optional_clause_match(Handle& pattrn, Handle& grnd)
 		{
 			// printf (">>>>>>>>>> hello optional term!! %p\n", grnd);
-			if (Handle::UNDEFINED == grnd) return false;
+			if (Handle::UNDEFINED == grnd) return true;
 			TruthValuePtr tv(grnd->getTruthValue());
 			// printf (">>>> optional tv=%f\n", tv.getMean());
-			if (tv->getMean() > 0.5) return true;
-			return false;
+			return tv->getMean() < 0.5;
 		}
 };
 

--- a/opencog/query/CrispLogicPMCB.h
+++ b/opencog/query/CrispLogicPMCB.h
@@ -60,7 +60,7 @@ class CrispLogicPMCB :
 		{
 			TruthValuePtr tv(grnd->getTruthValue());
 			// printf (">>>>>>>> clause match tv=%f\n", tv.getMean());
-			reutn tv->getMean() >= 0.5;
+			return tv->getMean() >= 0.5;
 		}
 
 		/**

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -336,7 +336,7 @@ bool DefaultPatternMatchCB::virtual_link_match(LinkPtr& lvirt, Handle& gargs)
 	Handle schema(lvirt->getOutgoingAtom(0));
 	bool relation_holds = EvaluationLink::do_evaluate(_as, schema, gargs);
 
-	return not relation_holds;
+	return relation_holds;
 }
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/query/DefaultPatternMatchCB.h
+++ b/opencog/query/DefaultPatternMatchCB.h
@@ -56,15 +56,15 @@ class DefaultPatternMatchCB :
 		 * second is a possible solution (grounding) node from the
 		 * atomspace.
 		 *
-		 * Return false if the nodes match, else return
-		 * true. (i.e. return true if mis-match).
+		 * Return true if the nodes match, else return
+		 * false. (i.e. return false if mis-match).
 		 *
 		 * By default, the nodes must be identical.
 		 */
 		virtual bool node_match(Handle& npat_h, Handle& nsoln_h)
 		{
 			// If equality, then a match.
-			return npat_h != nsoln_h;
+			return npat_h == nsoln_h;
 		}
 
 		/**
@@ -73,8 +73,8 @@ class DefaultPatternMatchCB :
 		 * node in the atomspace. The first argument
 		 * is a variable from the pattern, and the second
 		 * is a possible grounding node from the atomspace.
-		 * Return false if the nodes match, else return
-		 * true. (i.e. return true if mis-match).
+		 * Return true if the nodes match, else return
+		 * false. (i.e. return false if mis-match).
 		 */
 		virtual bool variable_match(Handle& npat_h, Handle& nsoln_h)
 		{
@@ -84,24 +84,23 @@ class DefaultPatternMatchCB :
 			// accept the match. This allows any kind of node types to be
 			// explicitly bound as variables.  However, the type VariableNode
 			// gets special handling, below.
-			if (pattype != VARIABLE_NODE) return false;
+			if (pattype != VARIABLE_NODE) return true;
 
 			// If the ungrounded term is a variable, then see if there
 			// are any restrictions on the variable type.
 			// If no restrictions, we are good to go.
-			if (NULL == _type_restrictions) return false;
+			if (NULL == _type_restrictions) return true;
 
 			// If we are here, there's a restriction on the grounding type.
 			// Validate the node type, if needed.
 			VariableTypeMap::const_iterator it = _type_restrictions->find(npat_h);
-			if (it == _type_restrictions->end()) return false;
+			if (it == _type_restrictions->end()) return true;
 
 			// Is the ground-atom type in our list of allowed types?
 			Type soltype = nsoln_h->getType();
 			const std::set<Type> &tset = it->second;
 			std::set<Type>::const_iterator allow = tset.find(soltype);
-			if (allow != tset.end()) return false;
-			return true;
+			return allow != tset.end();
 		}
 
 		/**
@@ -110,8 +109,8 @@ class DefaultPatternMatchCB :
 		 * link in the atomspace. The first argument
 		 * is a link from the pattern, and the second
 		 * is a possible solution link from the atomspace.
-		 * Return false if the links match, else return
-		 * true. (i.e. return true if mis-match).
+		 * Return true if the links match, else return
+		 * false. (i.e. return false if mis-match).
 		 *
 		 * By default, the link arity and the
 		 * link types must match.
@@ -120,19 +119,18 @@ class DefaultPatternMatchCB :
 		{
 			// If the pattern is exactly the same link as the proposed
 			// grounding, then its a perfect match. 
-			if (lpat == lsoln) return false;
+			if (lpat == lsoln) return true;
 
-			if (lpat->getArity() != lsoln->getArity()) return true;
+			if (lpat->getArity() != lsoln->getArity()) return false;
 			Type pattype = lpat->getType();
 			Type soltype = lsoln->getType();
 
-			// If types differ, no match,
-			if (pattype != soltype) return true;
-			return false;
+			// If types differ, no match
+			return pattype == soltype;
 		}
 
 		/**
-		 * Called when a virtual link is encountered. Returns true
+		 * Called when a virtual link is encountered. Returns false
 		 * to reject the match.
 		 */
 		virtual bool virtual_link_match(LinkPtr& lpat, Handle& args);

--- a/opencog/query/PatternMatchCallback.h
+++ b/opencog/query/PatternMatchCallback.h
@@ -48,8 +48,8 @@ class PatternMatchCallback
 		 * node in the atomspace. The first argument
 		 * is a node from the pattern, and the second
 		 * is a possible solution node from the atomspace.
-		 * Return false if the nodes match, else return
-		 * true. (i.e. return true if mis-match).
+		 * Return true if the nodes match, else return
+		 * false. (i.e. return false if mis-match).
 		 *
 		 * Note: those handles are not supposed to be
 		 * modified. Ideally they should be const but it turns out
@@ -65,8 +65,8 @@ class PatternMatchCallback
 		 * node in the atomspace. The first argument
 		 * is a variable from the pattern, and the second
 		 * is a possible solution node from the atomspace.
-		 * Return false if the grouding is acceptable, else
-		 * return true. (i.e. return true if mis-match).
+		 * Return true if the grouding is acceptable, else
+		 * return false. (i.e. return false if mis-match).
 		 */
 		virtual bool variable_match(Handle& node1, Handle& node2) = 0;
 
@@ -75,11 +75,11 @@ class PatternMatchCallback
 		 * is to be compared to a possibly matching link in
 		 * the atomspace. The first argument is a link from
 		 * the pattern, and the second is a possible
-		 * grounding link from the atomspace. Return false
+		 * grounding link from the atomspace. Return true
 		 * if the link contents should be compared, else
-		 * return true. (i.e. return true if mis-match).
+		 * return false. (i.e. return false if mis-match).
 		 *
-		 * If false is returned, then the pattern matcher
+		 * If true is returned, then the pattern matcher
 		 * will proceed, and will compare the outgoing sets
 		 * of the two links.  Thus, this callback should not
 		 * bother with looking at the outgoing sets.  Indeed,
@@ -112,7 +112,7 @@ class PatternMatchCallback
 		 */
 		virtual bool post_link_match(LinkPtr& link1, LinkPtr& link2)
 		{
-			return false; // Accept the match, by default.
+			return true; // Accept the match, by default.
 		}
 
 		/**
@@ -122,9 +122,9 @@ class PatternMatchCallback
 		 * 'virtual' sense, in that it is instead considered to exist if
 		 * a GroundedPredicateNode evaluates to true or not.  When such
 		 * a virtual link is encountered, this callback is called to make
-		 * this decision. This should return true to reject the match.
-		 * That is, a return value of "true" denotes that the virtual
-		 * atom does not exist; while "false" implies that it does exist.
+		 * this decision. This should return false to reject the match.
+		 * That is, a return value of "false" denotes that the virtual
+		 * atom does not exist; while "true" implies that it does exist.
 		 * This is the same convention as link_match() and post_link_match().
 		 *
 		 * Unlike the other callbacks, this takes arguments in s slightly
@@ -152,7 +152,7 @@ class PatternMatchCallback
 		 * true to terminate search.
 		 */
 		virtual bool grounding(const std::map<Handle, Handle> &var_soln,
-                             const std::map<Handle, Handle> &pred_soln) = 0;
+		                       const std::map<Handle, Handle> &pred_soln) = 0;
 
 		/**
 		 * Called when a top-level clause has been fully grounded.
@@ -161,15 +161,15 @@ class PatternMatchCallback
 		 * the overall truth value of a solution (grounding).
 		 *
 		 * A clause match has occured if all calls to node_match()
-		 * and link_match() in that clause have returned false.
+		 * and link_match() in that clause have returned true.
 		 *
-		 * Return true to discard the use of this clause as a possible
-		 * grounding, return false to use this grounding.
+		 * Return false to discard the use of this clause as a possible
+		 * grounding, return true to use this grounding.
 		 */
 		virtual bool clause_match(Handle& pattrn_link_h, Handle& grnd_link_h)
 		{
 			//	if (pattrn_link_h == grnd_link_h) return true;
-			return false;
+			return true;
 		}
 
 		/**
@@ -178,17 +178,17 @@ class PatternMatchCallback
 		 * grounded as a result of the search. If it has been grounded,
 		 * then grnd will be non-null.
 		 *
-		 * Return true to terminate further searches from this point
+		 * Return false to terminate further searches from this point
 		 * on; the result of termination will be backtracking to search
 		 * for other possible groundings of the required clauses.
-		 * Return false to examine the next optional clause (if any).
+		 * Return true to examine the next optional clause (if any).
 		 *
 		 * Note that all required clauses will have been grounded before
 		 * any optional clauses are examined.
 		 */
 		virtual bool optional_clause_match(Handle& pattrn, Handle& grnd)
 		{
-			return false;
+			return true;
 		}
 
 		/**

--- a/opencog/query/VirtualMatch.cc
+++ b/opencog/query/VirtualMatch.cc
@@ -173,7 +173,7 @@ bool PatternMatch::recursive_virtual(PatternMatchCallback *cb,
 			// if (0 == gargs->getIncomingSetSize())
 				// _atom_space->purgeAtom(gargs, false);
 
-			if (match) return false;
+			if (not match) return false;
 
 			// FYI ... if the virtual_link_match() accepts the match, we
 			// still don't instantiate the grounded form in the atomspace,

--- a/opencog/reasoning/RuleEngine/rule-engine-src/pln/ForwardChainPatternMatchCB.cc
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/pln/ForwardChainPatternMatchCB.cc
@@ -37,23 +37,14 @@ HandleSeq& ForwardChainPatternMatchCB::get_results() {
 	return result_list;
 }
 bool ForwardChainPatternMatchCB::node_match(Handle& node1, Handle& node2) {
-	if (not AttentionalFocusCB::node_match(node1, node2) or not fc_->search_in_af) {
-		//force inference to be made only in the target list
-		bool result = not fc_->is_in_target_list(node1);
-		return result;
-
-	} else {
-		return true;
-	}
+	return (AttentionalFocusCB::node_match(node1, node2) or not fc_->search_in_af)
+		// force inference to be made only in the target list
+		and fc_->is_in_target_list(node1);
 }
 bool ForwardChainPatternMatchCB::link_match(LinkPtr& lpat, LinkPtr& lsoln) {
-	if (not AttentionalFocusCB::link_match(lpat, lsoln) or not fc_->search_in_af) {
-		//force inference to be made only in the target list
-		bool result = not fc_->is_in_target_list(Handle(lsoln));
-		return result;
-	} else {
-		return true;
-	}
+	return (AttentionalFocusCB::link_match(lpat, lsoln) or not fc_->search_in_af)
+		// force inference to be made only in the target list
+		and fc_->is_in_target_list(Handle(lsoln));
 }
 bool ForwardChainPatternMatchCB::grounding(
 		const std::map<Handle, Handle> &var_soln,

--- a/opencog/reasoning/RuleEngine/rule-engine-src/pln/ForwardChainPatternMatchCB.h
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/pln/ForwardChainPatternMatchCB.h
@@ -49,7 +49,7 @@ public:
 	 * A callback handler of the Pattern matcher used to store references to new conclusion the target list
 	 */
 	bool grounding(const std::map<Handle, Handle> &var_soln,
-				const std::map<Handle, Handle> &pred_soln);
+	               const std::map<Handle, Handle> &pred_soln);
 };
 
 #endif /* FORWARDCHAINPATTERNMATCHCB_H_ */

--- a/tests/query/PatternUTest.cxxtest
+++ b/tests/query/PatternUTest.cxxtest
@@ -123,7 +123,7 @@ bool PMCB::node_match(Node *npat, Node *nsoln)
 	Type soltype = nsoln->getType();
 
 	// Reject obvioius mismatches
-	if (pattype != soltype) return true;
+	if (pattype != soltype) return false;
 
 	Handle ha = npat->getHandle();
 	Handle hb = nsoln->getHandle();
@@ -131,8 +131,7 @@ bool PMCB::node_match(Node *npat, Node *nsoln)
 		ha.value(), npat->getName().c_str(),
 		hb.value(), nsoln->getName().c_str());
 
-	if (npat == nsoln) return false;
-	return true;
+	return npat == nsoln;
 }
 
 bool PMCB::grounding(const std::map<Handle, Handle> &var_soln,

--- a/tests/query/StackUTest.cxxtest
+++ b/tests/query/StackUTest.cxxtest
@@ -70,8 +70,7 @@ class TestPMCB :
 	{
 		lcnt ++;
 		// match the initial anchor clause, but reject the rest.
-		if (anch == grnd) return false;
-		return true;
+		return anch == grnd;
 	}
 
 	virtual bool grounding(const std::map<Handle, Handle> &var_soln,


### PR DESCRIPTION
Here's my attempt to flip the semantics of *_match and tree_compare (i.e. a fix for issue #1220).

It seems to work but I've noticed that MultiThreadUTest and SCMExecutionUTest randomly fail. However I did see them failing before. So I think it's kinda crucial that we fix them, before perhaps merging that branch (unless those 2 tests are obviously unrelated to the pattern matcher).
