### PR TITLE
guile: Added OpenCog scheme module support

### DIFF
--- a/lib/OpenCogAtomTypes.cmake
+++ b/lib/OpenCogAtomTypes.cmake
@@ -60,6 +60,7 @@ FILE(APPEND "${SCM_FILE}" "; generated from atom definitions in types.script by 
 FILE(APPEND "${SCM_FILE}" ";\n")
 FILE(APPEND "${SCM_FILE}" "; This file contains basic scheme wrappers for atom creation.\n")
 FILE(APPEND "${SCM_FILE}" ";\n")
+FILE(APPEND "${SCM_FILE}" "(define-module (opencog atomtypes) #:use-module (opencog))\n")
 
 FILE(STRINGS "${SCRIPT_FILE}" TYPE_SCRIPT_CONTENTS)
 FOREACH (LINE ${TYPE_SCRIPT_CONTENTS})
@@ -127,18 +128,18 @@ FOREACH (LINE ${TYPE_SCRIPT_CONTENTS})
 
         # Print out the scheme definitions
         IF (ISNODE STREQUAL "NODE")
-            FILE(APPEND "${SCM_FILE}" "(define (${TYPE_NAME} . x)\n")
+            FILE(APPEND "${SCM_FILE}" "(define-public (${TYPE_NAME} . x)\n")
             FILE(APPEND "${SCM_FILE}" "\t(apply cog-new-node (append (list '${TYPE_NAME}) x)))\n")
         ENDIF (ISNODE STREQUAL "NODE")
         IF (ISLINK STREQUAL "LINK")
-            FILE(APPEND "${SCM_FILE}" "(define (${TYPE_NAME} . x)\n")
+            FILE(APPEND "${SCM_FILE}" "(define-public (${TYPE_NAME} . x)\n")
             FILE(APPEND "${SCM_FILE}" "\t(apply cog-new-link (append (list '${TYPE_NAME}) x)))\n")
         ENDIF (ISLINK STREQUAL "LINK")
 
         # If not named as a node or a link, assume its a link
         # This is kind of hacky, but I don't know what else to do ... 
         IF (NOT ISNODE STREQUAL "NODE" AND NOT ISLINK STREQUAL "LINK")
-            FILE(APPEND "${SCM_FILE}" "(define (${TYPE_NAME} . x)\n")
+            FILE(APPEND "${SCM_FILE}" "(define-public (${TYPE_NAME} . x)\n")
             FILE(APPEND "${SCM_FILE}" "\t(apply cog-new-link (append (list '${TYPE_NAME}) x)))\n")
         ENDIF (NOT ISNODE STREQUAL "NODE" AND NOT ISLINK STREQUAL "LINK")
 

--- a/opencog/guile/README
+++ b/opencog/guile/README
@@ -100,6 +100,18 @@ utilities can be pulled up at the scheme shell prompt, by saying
 have to consult the individual scm files for more info.
 
 
+== Modules ==
+-------------
+Currently OpenCog's scheme functions are broken into 3 different scheme
+modules: (opencog), (opencog extension), and (opencog atomtypes).  Each
+one can be listed with the following code:
+
+(module-for-each (lambda (symbol value) (display symbol) (newline))
+(resolve-interface '(opencog)))
+
+Replace '(opencog) with the corresponding module name.
+
+
 == Core Functions ==
 --------------------
 The following are the "core" functions, implemented in the guile-to-C++
@@ -791,9 +803,3 @@ ToDo
    data corruption. However, guile needs to be fixed to change this 
    behaviour.
 
-
--- list all proceedures in a module:
-   (module-for-each (lambda (symbol value) (display symbol) (newline))
-   (resolve-interface '(guile)))
-
-   Make the above easier for users.

--- a/opencog/guile/SchemePrimitive.h
+++ b/opencog/guile/SchemePrimitive.h
@@ -31,6 +31,7 @@ class PrimitiveEnviron
 	private:
 		static bool is_inited;
 		static void init(void);
+		static void init_helper(void*);
 
 		static void * c_wrap_register(void *);
 		void really_do_register(const char *, int);

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -48,7 +48,12 @@ void SchemeSmob::init()
 	{
 		is_inited = true;
 		init_smob_type();
-		register_procs();
+		scm_c_define_module("opencog", register_procs, NULL);
+		scm_c_use_module("opencog");
+
+		// define the empty (opencog atomtypes) for adding types externally
+		scm_c_define_module("opencog atomtypes", NULL, NULL);
+		scm_c_use_module("opencog atomtypes");
 
 		atomspace_fluid = scm_make_fluid();
 		atomspace_fluid = scm_permanent_object(atomspace_fluid);
@@ -151,75 +156,81 @@ SCM SchemeSmob::equalp_misc(SCM a, SCM b)
  #define C(X) ((SCM (*) ()) X)
 #endif
 
-void SchemeSmob::register_procs(void)
+void SchemeSmob::register_procs(void*)
 {
-	scm_c_define_gsubr("cog-atom",              1, 0, 0, C(ss_atom));
-	scm_c_define_gsubr("cog-handle",            1, 0, 0, C(ss_handle));
-	scm_c_define_gsubr("cog-undefined-handle",  0, 0, 0, C(ss_undefined_handle));
-	scm_c_define_gsubr("cog-new-node",          2, 0, 1, C(ss_new_node));
-	scm_c_define_gsubr("cog-new-link",          1, 0, 1, C(ss_new_link));
-	scm_c_define_gsubr("cog-node",              2, 0, 1, C(ss_node));
-	scm_c_define_gsubr("cog-link",              1, 0, 1, C(ss_link));
-	scm_c_define_gsubr("cog-delete",            1, 0, 1, C(ss_delete));
-	scm_c_define_gsubr("cog-delete-recursive",  1, 0, 1, C(ss_delete_recursive));
-	scm_c_define_gsubr("cog-purge",             1, 0, 1, C(ss_purge));
-	scm_c_define_gsubr("cog-purge-recursive",   1, 0, 1, C(ss_purge_recursive));
-	scm_c_define_gsubr("cog-atom?",             1, 0, 1, C(ss_atom_p));
-	scm_c_define_gsubr("cog-node?",             1, 0, 1, C(ss_node_p));
-	scm_c_define_gsubr("cog-link?",             1, 0, 1, C(ss_link_p));
+	register_proc("cog-atom",              1, 0, 0, C(ss_atom));
+	register_proc("cog-handle",            1, 0, 0, C(ss_handle));
+	register_proc("cog-undefined-handle",  0, 0, 0, C(ss_undefined_handle));
+	register_proc("cog-new-node",          2, 0, 1, C(ss_new_node));
+	register_proc("cog-new-link",          1, 0, 1, C(ss_new_link));
+	register_proc("cog-node",              2, 0, 1, C(ss_node));
+	register_proc("cog-link",              1, 0, 1, C(ss_link));
+	register_proc("cog-delete",            1, 0, 1, C(ss_delete));
+	register_proc("cog-delete-recursive",  1, 0, 1, C(ss_delete_recursive));
+	register_proc("cog-purge",             1, 0, 1, C(ss_purge));
+	register_proc("cog-purge-recursive",   1, 0, 1, C(ss_purge_recursive));
+	register_proc("cog-atom?",             1, 0, 1, C(ss_atom_p));
+	register_proc("cog-node?",             1, 0, 1, C(ss_node_p));
+	register_proc("cog-link?",             1, 0, 1, C(ss_link_p));
 
 	// property setters on atoms
-	scm_c_define_gsubr("cog-set-av!",           2, 0, 0, C(ss_set_av));
-	scm_c_define_gsubr("cog-set-tv!",           2, 0, 0, C(ss_set_tv));
-	scm_c_define_gsubr("cog-inc-vlti!",         1, 0, 0, C(ss_inc_vlti));
-	scm_c_define_gsubr("cog-dec-vlti!",         1, 0, 0, C(ss_dec_vlti));
+	register_proc("cog-set-av!",           2, 0, 0, C(ss_set_av));
+	register_proc("cog-set-tv!",           2, 0, 0, C(ss_set_tv));
+	register_proc("cog-inc-vlti!",         1, 0, 0, C(ss_inc_vlti));
+	register_proc("cog-dec-vlti!",         1, 0, 0, C(ss_dec_vlti));
 
 	// property getters on atoms
-	scm_c_define_gsubr("cog-name",              1, 0, 0, C(ss_name));
-	scm_c_define_gsubr("cog-type",              1, 0, 0, C(ss_type));
-	scm_c_define_gsubr("cog-arity",             1, 0, 0, C(ss_arity));
-	scm_c_define_gsubr("cog-incoming-set",      1, 0, 0, C(ss_incoming_set));
-	scm_c_define_gsubr("cog-outgoing-set",      1, 0, 0, C(ss_outgoing_set));
-	scm_c_define_gsubr("cog-tv",                1, 0, 0, C(ss_tv));
-	scm_c_define_gsubr("cog-av",                1, 0, 0, C(ss_av));
+	register_proc("cog-name",              1, 0, 0, C(ss_name));
+	register_proc("cog-type",              1, 0, 0, C(ss_type));
+	register_proc("cog-arity",             1, 0, 0, C(ss_arity));
+	register_proc("cog-incoming-set",      1, 0, 0, C(ss_incoming_set));
+	register_proc("cog-outgoing-set",      1, 0, 0, C(ss_outgoing_set));
+	register_proc("cog-tv",                1, 0, 0, C(ss_tv));
+	register_proc("cog-av",                1, 0, 0, C(ss_av));
 
 	// Truth-values
-	scm_c_define_gsubr("cog-new-stv",           2, 0, 0, C(ss_new_stv));
-	scm_c_define_gsubr("cog-new-ctv",           3, 0, 0, C(ss_new_ctv));
-	scm_c_define_gsubr("cog-new-itv",           3, 0, 0, C(ss_new_itv));
-	scm_c_define_gsubr("cog-tv?",               1, 0, 0, C(ss_tv_p));
-	scm_c_define_gsubr("cog-stv?",              1, 0, 0, C(ss_stv_p));
-	scm_c_define_gsubr("cog-ctv?",              1, 0, 0, C(ss_ctv_p));
-	scm_c_define_gsubr("cog-itv?",              1, 0, 0, C(ss_itv_p));
-	scm_c_define_gsubr("cog-tv->alist",         1, 0, 0, C(ss_tv_get_value));
+	register_proc("cog-new-stv",           2, 0, 0, C(ss_new_stv));
+	register_proc("cog-new-ctv",           3, 0, 0, C(ss_new_ctv));
+	register_proc("cog-new-itv",           3, 0, 0, C(ss_new_itv));
+	register_proc("cog-tv?",               1, 0, 0, C(ss_tv_p));
+	register_proc("cog-stv?",              1, 0, 0, C(ss_stv_p));
+	register_proc("cog-ctv?",              1, 0, 0, C(ss_ctv_p));
+	register_proc("cog-itv?",              1, 0, 0, C(ss_itv_p));
+	register_proc("cog-tv->alist",         1, 0, 0, C(ss_tv_get_value));
 
 	// Atom Spaces
-	scm_c_define_gsubr("cog-new-atomspace",     0, 1, 0, C(ss_new_as));
-	scm_c_define_gsubr("cog-atomspace?",        1, 0, 0, C(ss_as_p));
-	scm_c_define_gsubr("cog-atomspace",         0, 0, 0, C(ss_get_as));
-	scm_c_define_gsubr("cog-set-atomspace!",    1, 0, 0, C(ss_set_as));
+	register_proc("cog-new-atomspace",     0, 1, 0, C(ss_new_as));
+	register_proc("cog-atomspace?",        1, 0, 0, C(ss_as_p));
+	register_proc("cog-atomspace",         0, 0, 0, C(ss_get_as));
+	register_proc("cog-set-atomspace!",    1, 0, 0, C(ss_set_as));
 
 	// Attention values
-	scm_c_define_gsubr("cog-new-av",            3, 0, 0, C(ss_new_av));
-	scm_c_define_gsubr("cog-av?",               1, 0, 0, C(ss_av_p));
-	scm_c_define_gsubr("cog-av->alist",         1, 0, 0, C(ss_av_get_value));
+	register_proc("cog-new-av",            3, 0, 0, C(ss_new_av));
+	register_proc("cog-av?",               1, 0, 0, C(ss_av_p));
+	register_proc("cog-av->alist",         1, 0, 0, C(ss_av_get_value));
 
 	// AttentionalFocus
-	scm_c_define_gsubr("cog-af-boundary",       0, 0, 0, C(ss_af_boundary));
-	scm_c_define_gsubr("cog-set-af-boundary!",  1, 0, 0, C(ss_set_af_boundary));
-	scm_c_define_gsubr("cog-af",                0, 0, 0, C(ss_af));
+	register_proc("cog-af-boundary",       0, 0, 0, C(ss_af_boundary));
+	register_proc("cog-set-af-boundary!",  1, 0, 0, C(ss_set_af_boundary));
+	register_proc("cog-af",                0, 0, 0, C(ss_af));
     
 	// ExecutionOutputLinks
-	scm_c_define_gsubr("cog-execute!",          1, 0, 0, C(ss_execute));
+	register_proc("cog-execute!",          1, 0, 0, C(ss_execute));
 
 	// Atom types
-	scm_c_define_gsubr("cog-get-types",         0, 0, 0, C(ss_get_types));
-	scm_c_define_gsubr("cog-type?",             1, 0, 0, C(ss_type_p));
-	scm_c_define_gsubr("cog-get-subtypes",      1, 0, 0, C(ss_get_subtypes));
-	scm_c_define_gsubr("cog-subtype?",          2, 0, 0, C(ss_subtype_p));
+	register_proc("cog-get-types",         0, 0, 0, C(ss_get_types));
+	register_proc("cog-type?",             1, 0, 0, C(ss_type_p));
+	register_proc("cog-get-subtypes",      1, 0, 0, C(ss_get_subtypes));
+	register_proc("cog-subtype?",          2, 0, 0, C(ss_subtype_p));
 
 	// Iterators
-	scm_c_define_gsubr("cog-map-type",          2, 0, 0, C(ss_map_type));
+	register_proc("cog-map-type",          2, 0, 0, C(ss_map_type));
+}
+
+void SchemeSmob::register_proc(const char* name, int req, int opt, int rst, scm_t_subr fcn)
+{
+	scm_c_define_gsubr(name, req, opt, rst, fcn);
+	scm_c_export(name, NULL);
 }
 
 #endif

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -50,7 +50,8 @@ class SchemeSmob
 		};
 
 		static bool is_inited;
-		static void register_procs(void);
+		static void register_procs(void*);
+		static void register_proc(const char*, int, int, int, scm_t_subr);
 
 		// The cog_misc_tag are for all other opencog types, such
 		// as truth values, which are ephemeral (garbage-collected)


### PR DESCRIPTION
Wrap the OpenCog scheme primitives into modules so that they can be loaded & used when creating custom modules in new scm files.  Previously defining new modules lost the binding to the opencog primitives.

* The default `cog-new-node` style primitives are in `(opencog)`
* Custom primitives are in `(opencog extension)`
* Scheme atom types shortcut such as `(ConceptNode "abc")` are in `(opencog atomtypes)`

All are loaded by default to allow existing code to function.  Existing tests that passed before still pass.  **You need to do `make clean` so the changes to the _types.scm generation code will take place.**

You can see what functions are in the module with
```
(module-for-each (lambda (symbol value) (display symbol) (newline)) (resolve-interface '(opencog)))
(module-for-each (lambda (symbol value) (display symbol) (newline)) (resolve-interface '(opencog atomtypes)))
(module-for-each (lambda (symbol value) (display symbol) (newline)) (resolve-interface '(opencog extension)))
```

When defining your own scm module externally, you can load the opencog module like
```
(define-module (your mod name))
(use-modules (opencog))
(use-modules (opencog atomtypes))
(use-modules (opencog extension))
```