### PR TITLE
Scheme performance fixes

### DIFF
--- a/lib/OpenCogAtomTypes.cmake
+++ b/lib/OpenCogAtomTypes.cmake
@@ -127,20 +127,21 @@ FOREACH (LINE ${TYPE_SCRIPT_CONTENTS})
         STRING(REGEX MATCH "LINK$" ISLINK ${TYPE})
 
         # Print out the scheme definitions
+        FILE(APPEND "${SCM_FILE}" "(define-public ${TYPE_NAME}Type (cog-type->int '${TYPE_NAME}))\n")
         IF (ISNODE STREQUAL "NODE")
             FILE(APPEND "${SCM_FILE}" "(define-public (${TYPE_NAME} . x)\n")
-            FILE(APPEND "${SCM_FILE}" "\t(apply cog-new-node (append (list '${TYPE_NAME}) x)))\n")
+            FILE(APPEND "${SCM_FILE}" "\t(apply cog-new-node (append (list ${TYPE_NAME}Type) x)))\n")
         ENDIF (ISNODE STREQUAL "NODE")
         IF (ISLINK STREQUAL "LINK")
             FILE(APPEND "${SCM_FILE}" "(define-public (${TYPE_NAME} . x)\n")
-            FILE(APPEND "${SCM_FILE}" "\t(apply cog-new-link (append (list '${TYPE_NAME}) x)))\n")
+            FILE(APPEND "${SCM_FILE}" "\t(apply cog-new-link (append (list ${TYPE_NAME}Type) x)))\n")
         ENDIF (ISLINK STREQUAL "LINK")
 
         # If not named as a node or a link, assume its a link
         # This is kind of hacky, but I don't know what else to do ... 
         IF (NOT ISNODE STREQUAL "NODE" AND NOT ISLINK STREQUAL "LINK")
             FILE(APPEND "${SCM_FILE}" "(define-public (${TYPE_NAME} . x)\n")
-            FILE(APPEND "${SCM_FILE}" "\t(apply cog-new-link (append (list '${TYPE_NAME}) x)))\n")
+            FILE(APPEND "${SCM_FILE}" "\t(apply cog-new-link (append (list ${TYPE_NAME}Type) x)))\n")
         ENDIF (NOT ISNODE STREQUAL "NODE" AND NOT ISLINK STREQUAL "LINK")
 
         IF (PARENT_TYPES)

--- a/opencog/atomspace/atom_types.script
+++ b/opencog/atomspace/atom_types.script
@@ -1,15 +1,17 @@
 //
-// Script for automatic "atom type" generation. For more more information,
-// consult  the documentation in the opencog/atomspace/README file.
+// Script for automatic "atom type" generation. For more more
+// information, consult the opencog/atomspace/README file.
 //
-// Please note: some of the types below are used only via the scheme bindings.
-// Thus, just because you can comment some of these out, and the code still
-// compiles, that does not mean that these types are unused!  Be sure to grep
-// for the CamelCase names, to see if they show up elsewhere!
+// Please note: some of the types below are used only via the scheme
+// bindings. Thus, just because you can comment some of these out, and
+// the code still compiles, that does not mean that these types are
+// unused!  Be sure to grep for the CamelCase names, to see if they
+// show up elsewhere!
 //
-// Some of them are used by Python PLN code (which also uses the CamelCase names).
+// Some of them are used by Python PLN code (which also uses the
+// CamelCase names).
 //
-// Special type designating that no atom type has been assigned
+// Special type designating that no atom type has been assigned.
 NOTYPE
 
 // Base of hierarchy

--- a/opencog/benchmark/diary.txt
+++ b/opencog/benchmark/diary.txt
@@ -745,3 +745,45 @@ incoming string, decide what to do with it, and then call the smob
 handler.  Yes, we are nickel-n-dimed in other places, but that one
 is 2/3rds of the total time, and its essentially not tunable within
 opencog.
+
+=====================================================================
+23 January 2015:
+Above measurements partly invalidated; ss_new_node is now about 20%
+faster after some rework.
+
+Where is the time being spent?
+Consider the program:
+	(define (lop n)
+		(begin
+			(ConceptNode (number->string n))
+			(if (< 0 n) (lop (- n 1)) #f) ))
+
+and then perform timing measurements on:
+	(lop 50000)
+
+Find that 61% of total time is spent in ss_new_node and 39% is spent
+in guile itself.  The above is effectively memoized. If it is compiled,
+viz.
+	(compile `(define (lop n) ...) #:env (current-module))
+
+then find that 69% of time in ss_new_node 31% of time in guile.
+----
+Of the time spent in ss_new_node, about 48% is spent in
+AtomSpace::addNode() and the rest is in preparing to call it ...
+
+breakdown:
+	43% in verify
+	1% in get atomspace
+	48% in AtomSpace::addNode()
+	1% in get tv, av
+	9.5% in handle_to_scm()
+
+Breakdon of verify:
+	1%  verify_atom_type()
+	43% in verify_string()   ouuuuuch
+
+of verify_string():
+	41% in scm_to_locale_string() ouch ... 
+
+Wow... scm_to_utf8_string() is 10x faster than scm_to_locale_string()
+and scm_i_string_chars() is another 4x faster.  Yowwww

--- a/opencog/guile/SchemeEval.cc
+++ b/opencog/guile/SchemeEval.cc
@@ -294,7 +294,7 @@ std::string SchemeEval::prt(SCM node)
 		SCM port = scm_open_output_string();
 		scm_display (node, port);
 		SCM rc = scm_get_output_string(port);
-		char * str = scm_to_locale_string(rc);
+		char * str = scm_to_utf8_string(rc);
 		std::string rv = str;
 		free(str);
 		scm_close_port(port);
@@ -331,7 +331,7 @@ SCM SchemeEval::catch_handler (SCM tag, SCM throw_args)
 {
 	// Check for read error. If a read error, then wait for user to correct it.
 	SCM re = scm_symbol_to_string(tag);
-	char * restr = scm_to_locale_string(re);
+	char * restr = scm_to_utf8_string(re);
 	_pending_input = false;
 
 	if (0 == strcmp(restr, "read-error"))
@@ -626,7 +626,7 @@ std::string SchemeEval::do_poll_result()
 	{
 		std::string rv = poll_port();
 
-		char * str = scm_to_locale_string(error_string);
+		char * str = scm_to_utf8_string(error_string);
 		rv += str;
 		free(str);
 		set_error_string(SCM_EOL);
@@ -685,7 +685,7 @@ SCM SchemeEval::do_scm_eval(SCM sexpr)
 	_eval_done = true;
 	if (_caught_error)
 	{
-		char * str = scm_to_locale_string(error_string);
+		char * str = scm_to_utf8_string(error_string);
 		// Don't blank out the error string yet.... we need it later.
 		// (probably because someone called cog-bind with an
 		// ExecutionOutputLink in it with a bad scheme schema node.)
@@ -795,7 +795,7 @@ SCM SchemeEval::do_scm_eval_str(const std::string &expr)
 	_eval_done = true;
 	if (_caught_error)
 	{
-		char * str = scm_to_locale_string(error_string);
+		char * str = scm_to_utf8_string(error_string);
 		set_error_string(SCM_EOL);
 		set_captured_stack(SCM_BOOL_F);
 

--- a/opencog/guile/SchemeExec.cc
+++ b/opencog/guile/SchemeExec.cc
@@ -40,7 +40,7 @@ Handle SchemeEval::do_apply(const std::string &func, Handle varargs)
  */
 SCM SchemeEval::do_apply_scm( const std::string& func, Handle varargs )
 {
-	SCM sfunc = scm_from_locale_symbol(func.c_str());
+	SCM sfunc = scm_from_utf8_symbol(func.c_str());
 	SCM expr = SCM_EOL;
 	
 	// If there were args, pass the args to the function.

--- a/opencog/guile/SchemePrimitive.cc
+++ b/opencog/guile/SchemePrimitive.cc
@@ -4,7 +4,7 @@
  * Allow C++ code to be invoked from scheme -- 
  * by defining a scheme primitive function.
  *
- * Copyright (C) 2009 Linas Vepstas
+ * Copyright (C) 2009, 2014 Linas Vepstas
  */
 
 #include <exception>
@@ -129,31 +129,11 @@ SCM PrimitiveEnviron::do_call(SCM sfe, SCM arglist)
 	}
 	catch (const std::exception& ex)
 	{
-		const char *msg = ex.what();
-
-		// Should we even bother to log this?
-		logger().info("Guile caught C++ exception: %s", msg);
-
-		// scm_misc_error(fe->get_name(), msg, SCM_EOL);
-		scm_throw(
-			scm_from_locale_symbol("C++-EXCEPTION"),
-			scm_cons(
-				scm_from_locale_string(fe->get_name()),
-				scm_cons(
-					scm_from_locale_string(msg),
-					SCM_EOL)));
-		// Hmm. scm_throw never returns.
+		SchemeSmob::throw_exception(ex.what(), fe->get_name());
 	}
 	catch (...)
 	{
-		// scm_misc_error(fe->get_name(), "unknown C++ exception", SCM_EOL);
-		scm_error_scm(
-			scm_from_locale_symbol("C++ exception"),
-			scm_from_locale_string(fe->get_name()),
-			scm_from_locale_string("unknown C++ exception"),
-			SCM_EOL,
-			SCM_EOL);
-		logger().error("Guile caught unknown C++ exception");
+		SchemeSmob::throw_exception(NULL, fe->get_name());
 	}
 	scm_remember_upto_here_1(sfe);
 	return rc;

--- a/opencog/guile/SchemePrimitive.h
+++ b/opencog/guile/SchemePrimitive.h
@@ -314,8 +314,14 @@ class SchemePrimitive : public PrimitiveEnviron
 					if (scm_is_true(scm_symbol_p(input)))
 						input = scm_symbol_to_string(input);
 
-					const char *lstr = scm_i_string_chars(input);
-					Type t = classserver().getType(lstr);
+					Type t = NOTYPE;
+					if (scm_is_integer(input))
+						t = scm_to_ushort(input);
+					else
+					{
+						const char *lstr = scm_i_string_chars(input);
+						t = classserver().getType(lstr);
+					}
 
 					int i = scm_to_int(scm_cadr(args));
 
@@ -330,8 +336,14 @@ class SchemePrimitive : public PrimitiveEnviron
 					if (scm_is_true(scm_symbol_p(input)))
 						input = scm_symbol_to_string(input);
 
-					const char *lstr = scm_i_string_chars(input);
-					Type t = classserver().getType(lstr);
+					Type t = NOTYPE;
+					if (scm_is_integer(input))
+						t = scm_to_ushort(input);
+					else
+					{
+						const char *lstr = scm_i_string_chars(input);
+						t = classserver().getType(lstr);
+					}
 
 					int i = scm_to_int(scm_cadr(args));
 					double d = scm_to_double(scm_caddr(args));

--- a/opencog/guile/SchemePrimitive.h
+++ b/opencog/guile/SchemePrimitive.h
@@ -1,7 +1,7 @@
 /*
  * SchemePrimitive.h
  *
- * Allow C++ code to be invoked from scheme -- 
+ * Allow C++ code to be invoked from scheme --
  * by creating a new scheme primitive function.
  *
  * Copyright (C) 2009 Linas Vepstas
@@ -102,7 +102,7 @@ class SchemePrimitive : public PrimitiveEnviron
 		} method;
 		T* that;
 		const char *scheme_name;
-		enum 
+		enum
 		{
 			B_HI,  // return boolean, take handle and int
 			D_HHT, // return double, take handle, handle, and type
@@ -141,7 +141,7 @@ class SchemePrimitive : public PrimitiveEnviron
 					Handle h1 = SchemeSmob::verify_handle(scm_car(args), scheme_name, 1);
 					Handle h2 = SchemeSmob::verify_handle(scm_cadr(args), scheme_name, 2);
 					Type t = SchemeSmob::verify_atom_type(scm_caddr(args), scheme_name, 3);
-					
+
 					double d = (that->*method.d_hht)(h1,h2,t);
 					rc = scm_from_double(d);
 					break;
@@ -152,7 +152,7 @@ class SchemePrimitive : public PrimitiveEnviron
 					Handle h2 = SchemeSmob::verify_handle(scm_cadr(args), scheme_name, 2);
 					Type t = SchemeSmob::verify_atom_type(scm_caddr(args), scheme_name, 3);
 					bool b = scm_to_bool(scm_cadddr(args));
-					
+
 					double d = (that->*method.d_hhtb)(h1,h2,t,b);
 					rc = scm_from_double(d);
 					break;
@@ -220,7 +220,7 @@ class SchemePrimitive : public PrimitiveEnviron
 				{
 					// First arg is a handle
 					Handle h = SchemeSmob::verify_handle(scm_car(args), scheme_name, 1);
-					
+
 					// Second arg is a type
 					Type t = SchemeSmob::verify_atom_type(scm_cadr(args), scheme_name, 2);
 
@@ -242,13 +242,13 @@ class SchemePrimitive : public PrimitiveEnviron
 				{
 					// First arg is a handle
 					Handle h = SchemeSmob::verify_handle(scm_car(args), scheme_name, 1);
-					
+
 					// Second arg is a type
 					Type t = SchemeSmob::verify_atom_type(scm_cadr(args), scheme_name, 2);
 
 					// Third arg is an int
 					int i = SchemeSmob::verify_int(scm_caddr(args), scheme_name, 3);
-					
+
 					//Fourth arg is a bool
 					bool b = scm_to_bool(scm_cadddr(args));
 
@@ -313,13 +313,12 @@ class SchemePrimitive : public PrimitiveEnviron
 					//(f 'SimilarityLink) or (f "SimilarityLink")
 					if (scm_is_true(scm_symbol_p(input)))
 						input = scm_symbol_to_string(input);
-					
-					char *lstr = scm_to_locale_string(input);
+
+					const char *lstr = scm_i_string_chars(input);
 					Type t = classserver().getType(lstr);
-					free(lstr);
-					
+
 					int i = scm_to_int(scm_cadr(args));
-					
+
 					(that->*method.v_ti)(t, i);
 					break;
 				}
@@ -330,15 +329,14 @@ class SchemePrimitive : public PrimitiveEnviron
 					//(f 'SimilarityLink) or (f "SimilarityLink")
 					if (scm_is_true(scm_symbol_p(input)))
 						input = scm_symbol_to_string(input);
-					
-					char *lstr = scm_to_locale_string(input);
+
+					const char *lstr = scm_i_string_chars(input);
 					Type t = classserver().getType(lstr);
-					free(lstr);
-					
+
 					int i = scm_to_int(scm_cadr(args));
 					double d = scm_to_double(scm_caddr(args));
 					int i2 = scm_to_int(scm_cadddr(args));
-					
+
 					(that->*method.v_tidi)(t, i, d, i2);
 					break;
 				}
@@ -376,7 +374,7 @@ class SchemePrimitive : public PrimitiveEnviron
 		signature = SIG; \
 		do_register(name, 2); /* cb has 2 args */ \
 	}
-	
+
 #define DECLARE_CONSTR_3(SIG, LSIG, RET_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE) \
 	SchemePrimitive(const char *name, RET_TYPE (T::*cb)(ARG1_TYPE, ARG2_TYPE, ARG3_TYPE), T *data) \
 	{ \

--- a/opencog/guile/SchemePrimitive.h
+++ b/opencog/guile/SchemePrimitive.h
@@ -291,7 +291,7 @@ class SchemePrimitive : public PrimitiveEnviron
 					std::string str = SchemeSmob::verify_string(scm_car(args), scheme_name, 1);
 
 					const std::string &rs = (that->*method.s_s)(str);
-					rc = scm_from_locale_string(rs.c_str());
+					rc = scm_from_utf8_string(rs.c_str());
 					break;
 				}
 				case V_H:

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -217,6 +217,8 @@ void SchemeSmob::register_procs(void*)
 	// Atom types
 	register_proc("cog-get-types",         0, 0, 0, C(ss_get_types));
 	register_proc("cog-type?",             1, 0, 0, C(ss_type_p));
+	register_proc("cog-node-type?",        1, 0, 0, C(ss_node_type_p));
+	register_proc("cog-link-type?",        1, 0, 0, C(ss_link_type_p));
 	register_proc("cog-get-subtypes",      1, 0, 0, C(ss_get_subtypes));
 	register_proc("cog-subtype?",          2, 0, 0, C(ss_subtype_p));
 

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -155,11 +155,11 @@ void SchemeSmob::throw_exception(const char *msg, const char * func)
 
 		// scm_misc_error(fe->get_name(), msg, SCM_EOL);
 		scm_throw(
-			scm_from_locale_symbol("C++-EXCEPTION"),
+			scm_from_utf8_symbol("C++-EXCEPTION"),
 			scm_cons(
-				scm_from_locale_string(func),
+				scm_from_utf8_string(func),
 				scm_cons(
-					scm_from_locale_string(msg),
+					scm_from_utf8_string(msg),
 					SCM_EOL)));
 		// Hmm. scm_throw never returns.
 	}
@@ -167,9 +167,9 @@ void SchemeSmob::throw_exception(const char *msg, const char * func)
 	{
 		// scm_misc_error(fe->get_name(), "unknown C++ exception", SCM_EOL);
 		scm_error_scm(
-			scm_from_locale_symbol("C++ exception"),
-			scm_from_locale_string(func),
-			scm_from_locale_string("unknown C++ exception"),
+			scm_from_utf8_symbol("C++ exception"),
+			scm_from_utf8_string(func),
+			scm_from_utf8_string("unknown C++ exception"),
 			SCM_EOL,
 			SCM_EOL);
 		logger().error("Guile caught unknown C++ exception");

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -3,7 +3,7 @@
  *
  * Scheme small objects (SMOBS) for opencog -- core functions.
  *
- * Copyright (c) 2008, 2013, 2014 Linas Vepstas <linas@linas.org>
+ * Copyright (c) 2008, 2013, 2014, 2015 Linas Vepstas <linas@linas.org>
  */
 
 #ifdef HAVE_GUILE
@@ -142,6 +142,37 @@ SCM SchemeSmob::equalp_misc(SCM a, SCM b)
 			if (*av == *bv) return SCM_BOOL_T;
 			return SCM_BOOL_F;
 		}
+	}
+}
+
+/* ============================================================== */
+
+void SchemeSmob::throw_exception(const char *msg, const char * func)
+{
+	if (msg) {
+		// Should we even bother to log this?
+		logger().info("Guile caught C++ exception: %s", msg);
+
+		// scm_misc_error(fe->get_name(), msg, SCM_EOL);
+		scm_throw(
+			scm_from_locale_symbol("C++-EXCEPTION"),
+			scm_cons(
+				scm_from_locale_string(func),
+				scm_cons(
+					scm_from_locale_string(msg),
+					SCM_EOL)));
+		// Hmm. scm_throw never returns.
+	}
+	else
+	{
+		// scm_misc_error(fe->get_name(), "unknown C++ exception", SCM_EOL);
+		scm_error_scm(
+			scm_from_locale_symbol("C++ exception"),
+			scm_from_locale_string(func),
+			scm_from_locale_string("unknown C++ exception"),
+			SCM_EOL,
+			SCM_EOL);
+		logger().error("Guile caught unknown C++ exception");
 	}
 }
 

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -216,6 +216,7 @@ void SchemeSmob::register_procs(void*)
 
 	// Atom types
 	register_proc("cog-get-types",         0, 0, 0, C(ss_get_types));
+	register_proc("cog-type->int",         1, 0, 0, C(ss_get_type));
 	register_proc("cog-type?",             1, 0, 0, C(ss_type_p));
 	register_proc("cog-node-type?",        1, 0, 0, C(ss_node_type_p));
 	register_proc("cog-link-type?",        1, 0, 0, C(ss_link_type_p));

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -163,8 +163,6 @@ class SchemeSmob
 		// validate arguments coming from scheme passing into C++
 		static void throw_exception(const char *, const char *);
 		static Type verify_atom_type(SCM, const char *, int pos = 1);
-		static Type verify_node_type(SCM, const char *, int pos = 1);
-		static Type verify_link_type(SCM, const char *, int pos = 1);
 		static Handle verify_handle(SCM, const char *, int pos = 1);
 		static TruthValue * verify_tv(SCM, const char *, int pos = 1);
 		static AttentionValue * verify_av(SCM, const char *, int pos = 1);

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -106,6 +106,8 @@ class SchemeSmob
 		static SCM ss_map_type(SCM, SCM);
 		static SCM ss_get_types(void);
 		static SCM ss_type_p(SCM);
+		static SCM ss_node_type_p(SCM);
+		static SCM ss_link_type_p(SCM);
 		static SCM ss_get_subtypes(SCM);
 		static SCM ss_subtype_p(SCM, SCM);
 

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -161,6 +161,7 @@ class SchemeSmob
 		static AtomSpace *get_as_from_list(SCM);
 
 		// validate arguments coming from scheme passing into C++
+		static void throw_exception(const char *, const char *);
 		static Type verify_atom_type(SCM, const char *, int pos = 1);
 		static Type verify_node_type(SCM, const char *, int pos = 1);
 		static Type verify_link_type(SCM, const char *, int pos = 1);

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -163,6 +163,7 @@ class SchemeSmob
 		// validate arguments coming from scheme passing into C++
 		static Type verify_atom_type(SCM, const char *, int pos = 1);
 		static Type verify_node_type(SCM, const char *, int pos = 1);
+		static Type verify_link_type(SCM, const char *, int pos = 1);
 		static Handle verify_handle(SCM, const char *, int pos = 1);
 		static TruthValue * verify_tv(SCM, const char *, int pos = 1);
 		static AttentionValue * verify_av(SCM, const char *, int pos = 1);

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -105,6 +105,7 @@ class SchemeSmob
 		// AtomSpace query functions
 		static SCM ss_map_type(SCM, SCM);
 		static SCM ss_get_types(void);
+		static SCM ss_get_type(SCM);
 		static SCM ss_type_p(SCM);
 		static SCM ss_node_type_p(SCM);
 		static SCM ss_link_type_p(SCM);

--- a/opencog/guile/SchemeSmobAV.cc
+++ b/opencog/guile/SchemeSmobAV.cc
@@ -142,9 +142,9 @@ SCM SchemeSmob::ss_av_get_value (SCM s)
 	SCM lti = scm_from_short(av->getLTI());
 	SCM vlti = scm_from_ushort(av->getVLTI());
 
-	SCM ssti = scm_from_locale_symbol("sti");
-	SCM slti = scm_from_locale_symbol("lti");
-	SCM svlti = scm_from_locale_symbol("vlti");
+	SCM ssti = scm_from_utf8_symbol("sti");
+	SCM slti = scm_from_utf8_symbol("lti");
+	SCM svlti = scm_from_utf8_symbol("vlti");
 	scm_remember_upto_here_1(s);
 
 	SCM rc = SCM_EOL;

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -276,6 +276,13 @@ SCM SchemeSmob::ss_get_type (SCM stype)
  */
 SCM SchemeSmob::ss_type_p (SCM stype)
 {
+	if (scm_integer_p(stype)) {
+		Type t = scm_to_ushort(stype);
+		if (classserver().isValid(t))
+			return SCM_BOOL_T;
+		return SCM_BOOL_F;
+	}
+
 	if (scm_is_true(scm_symbol_p(stype)))
 		stype = scm_symbol_to_string(stype);
 
@@ -296,6 +303,13 @@ SCM SchemeSmob::ss_type_p (SCM stype)
  */
 SCM SchemeSmob::ss_node_type_p (SCM stype)
 {
+	if (scm_integer_p(stype)) {
+		Type t = scm_to_ushort(stype);
+		if (classserver().isNode(t))
+			return SCM_BOOL_T;
+		return SCM_BOOL_F;
+	}
+
 	if (scm_is_true(scm_symbol_p(stype)))
 		stype = scm_symbol_to_string(stype);
 
@@ -317,6 +331,13 @@ SCM SchemeSmob::ss_node_type_p (SCM stype)
  */
 SCM SchemeSmob::ss_link_type_p (SCM stype)
 {
+	if (scm_integer_p(stype)) {
+		Type t = scm_to_ushort(stype);
+		if (classserver().isLink(t))
+			return SCM_BOOL_T;
+		return SCM_BOOL_F;
+	}
+
 	if (scm_is_true(scm_symbol_p(stype)))
 		stype = scm_symbol_to_string(stype);
 

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -54,7 +54,7 @@ SCM SchemeSmob::ss_name (SCM satom)
 	Handle h = verify_handle(satom, "cog-name");
 	NodePtr nnn(NodeCast(h));
 	if (nnn) name = nnn->getName();
-	SCM str = scm_from_locale_string(name.c_str());
+	SCM str = scm_from_utf8_string(name.c_str());
 	return str;
 }
 
@@ -63,7 +63,7 @@ SCM SchemeSmob::ss_type (SCM satom)
 	Handle h = verify_handle(satom, "cog-type");
 	Type t = h->getType();
 	const std::string &tname = classserver().getTypeName(t);
-	SCM str = scm_from_locale_string(tname.c_str());
+	SCM str = scm_from_utf8_string(tname.c_str());
 	SCM sym = scm_string_to_symbol(str);
 
 	return sym;
@@ -222,7 +222,7 @@ SCM SchemeSmob::ss_get_types (void)
 	while (1) {
 		t--;
 		const std::string &tname = classserver().getTypeName(t);
-		SCM str = scm_from_locale_string(tname.c_str());
+		SCM str = scm_from_utf8_string(tname.c_str());
 		SCM sym = scm_string_to_symbol(str);
 		list = scm_cons(sym, list);
 		if (0 == t) break;
@@ -245,7 +245,7 @@ SCM SchemeSmob::ss_get_subtypes (SCM stype)
 	for (unsigned int i=0; i<ns; i++) {
 		t = subl[i];
 		const std::string &tname = classserver().getTypeName(t);
-		SCM str = scm_from_locale_string(tname.c_str());
+		SCM str = scm_from_utf8_string(tname.c_str());
 		SCM sym = scm_string_to_symbol(str);
 		list = scm_cons(sym, list);
 	}

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -254,7 +254,7 @@ SCM SchemeSmob::ss_get_subtypes (SCM stype)
 }
 
 /**
- * Return true if a type
+ * Return true if stype is an atom type
  */
 SCM SchemeSmob::ss_type_p (SCM stype)
 {
@@ -269,6 +269,48 @@ SCM SchemeSmob::ss_type_p (SCM stype)
 	free(ct);
 
 	if (NOTYPE == t) return SCM_BOOL_F;
+
+	return SCM_BOOL_T;
+}
+
+/**
+ * Return true if stype is a node type
+ */
+SCM SchemeSmob::ss_node_type_p (SCM stype)
+{
+	if (scm_is_true(scm_symbol_p(stype)))
+		stype = scm_symbol_to_string(stype);
+
+	if (scm_is_false(scm_string_p(stype)))
+		return SCM_BOOL_F;
+
+	char * ct = scm_to_locale_string(stype);
+	Type t = classserver().getType(ct);
+	free(ct);
+
+	if (NOTYPE == t) return SCM_BOOL_F;
+	if (false == classserver().isA(t, NODE)) return SCM_BOOL_F;
+
+	return SCM_BOOL_T;
+}
+
+/**
+ * Return true if stype is a link type
+ */
+SCM SchemeSmob::ss_link_type_p (SCM stype)
+{
+	if (scm_is_true(scm_symbol_p(stype)))
+		stype = scm_symbol_to_string(stype);
+
+	if (scm_is_false(scm_string_p(stype)))
+		return SCM_BOOL_F;
+
+	char * ct = scm_to_locale_string(stype);
+	Type t = classserver().getType(ct);
+	free(ct);
+
+	if (NOTYPE == t) return SCM_BOOL_F;
+	if (false == classserver().isA(t, LINK)) return SCM_BOOL_F;
 
 	return SCM_BOOL_T;
 }

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -264,9 +264,8 @@ SCM SchemeSmob::ss_get_type (SCM stype)
 	if (scm_is_false(scm_string_p(stype)))
 		return scm_from_ushort(NOTYPE);
 
-	char * ct = scm_to_locale_string(stype);
+	const char * ct = scm_i_string_chars(stype);
 	Type t = classserver().getType(ct);
-	free(ct);
 
 	return scm_from_ushort(t);
 }
@@ -289,9 +288,8 @@ SCM SchemeSmob::ss_type_p (SCM stype)
 	if (scm_is_false(scm_string_p(stype)))
 		return SCM_BOOL_F;
 
-	char * ct = scm_to_locale_string(stype);
+	const char * ct = scm_i_string_chars(stype);
 	Type t = classserver().getType(ct);
-	free(ct);
 
 	if (NOTYPE == t) return SCM_BOOL_F;
 
@@ -316,9 +314,8 @@ SCM SchemeSmob::ss_node_type_p (SCM stype)
 	if (scm_is_false(scm_string_p(stype)))
 		return SCM_BOOL_F;
 
-	char * ct = scm_to_locale_string(stype);
+	const char * ct = scm_i_string_chars(stype);
 	Type t = classserver().getType(ct);
-	free(ct);
 
 	if (NOTYPE == t) return SCM_BOOL_F;
 	if (false == classserver().isA(t, NODE)) return SCM_BOOL_F;
@@ -344,9 +341,8 @@ SCM SchemeSmob::ss_link_type_p (SCM stype)
 	if (scm_is_false(scm_string_p(stype)))
 		return SCM_BOOL_F;
 
-	char * ct = scm_to_locale_string(stype);
+	const char * ct = scm_i_string_chars(stype);
 	Type t = classserver().getType(ct);
-	free(ct);
 
 	if (NOTYPE == t) return SCM_BOOL_F;
 	if (false == classserver().isA(t, LINK)) return SCM_BOOL_F;
@@ -365,9 +361,8 @@ SCM SchemeSmob::ss_subtype_p (SCM stype, SCM schild)
 	if (scm_is_false(scm_string_p(stype)))
 		return SCM_BOOL_F;
 
-	char * ct = scm_to_locale_string(stype);
+	const char * ct = scm_i_string_chars(stype);
 	Type parent = classserver().getType(ct);
-	free(ct);
 
 	if (NOTYPE == parent) return SCM_BOOL_F;
 
@@ -378,9 +373,8 @@ SCM SchemeSmob::ss_subtype_p (SCM stype, SCM schild)
 	if (scm_is_false(scm_string_p(schild)))
 		return SCM_BOOL_F;
 
-	ct = scm_to_locale_string(schild);
-	Type child = classserver().getType(ct);
-	free(ct);
+	const char * cht = scm_i_string_chars(schild);
+	Type child = classserver().getType(cht);
 
 	if (NOTYPE == child) return SCM_BOOL_F;
 

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -254,6 +254,24 @@ SCM SchemeSmob::ss_get_subtypes (SCM stype)
 }
 
 /**
+ * Return integer value corresponding to the string type name.
+ */
+SCM SchemeSmob::ss_get_type (SCM stype)
+{
+	if (scm_is_true(scm_symbol_p(stype)))
+		stype = scm_symbol_to_string(stype);
+
+	if (scm_is_false(scm_string_p(stype)))
+		return scm_from_ushort(NOTYPE);
+
+	char * ct = scm_to_locale_string(stype);
+	Type t = classserver().getType(ct);
+	free(ct);
+
+	return scm_from_ushort(t);
+}
+
+/**
  * Return true if stype is an atom type
  */
 SCM SchemeSmob::ss_type_p (SCM stype)

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -276,7 +276,7 @@ SCM SchemeSmob::ss_get_type (SCM stype)
  */
 SCM SchemeSmob::ss_type_p (SCM stype)
 {
-	if (scm_integer_p(stype)) {
+	if (scm_is_integer(stype)) {
 		Type t = scm_to_ushort(stype);
 		if (classserver().isValid(t))
 			return SCM_BOOL_T;
@@ -303,7 +303,7 @@ SCM SchemeSmob::ss_type_p (SCM stype)
  */
 SCM SchemeSmob::ss_node_type_p (SCM stype)
 {
-	if (scm_integer_p(stype)) {
+	if (scm_is_integer(stype)) {
 		Type t = scm_to_ushort(stype);
 		if (classserver().isNode(t))
 			return SCM_BOOL_T;
@@ -331,7 +331,7 @@ SCM SchemeSmob::ss_node_type_p (SCM stype)
  */
 SCM SchemeSmob::ss_link_type_p (SCM stype)
 {
-	if (scm_integer_p(stype)) {
+	if (scm_is_integer(stype)) {
 		Type t = scm_to_ushort(stype);
 		if (classserver().isLink(t))
 			return SCM_BOOL_T;

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -250,9 +250,8 @@ Type SchemeSmob::verify_atom_type (SCM stype, const char *subrname, int pos)
 	if (scm_is_false(scm_string_p(stype)))
 		scm_wrong_type_arg_msg(subrname, pos, stype, "name of opencog atom type");
 
-	char * ct = scm_to_locale_string(stype);
+	const char * ct = scm_i_string_chars(stype);
 	Type t = classserver().getType(ct);
-	free(ct);
 
 	// Make sure that the type is good
 	if (NOTYPE == t)

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -386,18 +386,9 @@ SCM SchemeSmob::ss_node (SCM stype, SCM sname, SCM kv_pairs)
 /**
  * Verify that the arguments are appropriate for a link
  */
-static Type verify_link (SCM stype, const char * subrname)
+Type SchemeSmob::verify_link_type (SCM stype, const char * subrname, int pos)
 {
-	if (scm_is_true(scm_symbol_p(stype)))
-		stype = scm_symbol_to_string(stype);
-
-	char * ct = scm_to_locale_string(stype);
-	Type t = classserver().getType(ct);
-	free(ct);
-
-	// Make sure that the type is good
-	if (NOTYPE == t)
-		scm_wrong_type_arg_msg(subrname, 1, stype, "name of opencog atom type");
+	Type t = verify_atom_type(stype, subrname, pos);
 
 	if (false == classserver().isA(t, LINK))
 		scm_wrong_type_arg_msg(subrname, 1, stype, "name of opencog link type");
@@ -465,10 +456,10 @@ SchemeSmob::verify_handle_list (SCM satom_list, const char * subrname, int pos)
 SCM SchemeSmob::ss_new_link (SCM stype, SCM satom_list)
 {
 	Handle h;
-	Type t = verify_link (stype, "cog-new-link");
+	Type t = verify_link_type(stype, "cog-new-link", 1);
 
 	std::vector<Handle> outgoing_set;
-	outgoing_set = verify_handle_list (satom_list, "cog-new-link", 2);
+	outgoing_set = verify_handle_list(satom_list, "cog-new-link", 2);
 
 	AtomSpace* atomspace = get_as_from_list(satom_list);
 	if (NULL == atomspace) atomspace = ss_get_env_as("cog-new-link");
@@ -499,7 +490,7 @@ SCM SchemeSmob::ss_new_link (SCM stype, SCM satom_list)
  */
 SCM SchemeSmob::ss_link (SCM stype, SCM satom_list)
 {
-	Type t = verify_link (stype, "cog-link");
+	Type t = verify_link_type(stype, "cog-link", 1);
 
 	std::vector<Handle> outgoing_set;
 	outgoing_set = verify_handle_list (satom_list, "cog-link", 2);

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -272,9 +272,10 @@ std::string SchemeSmob::verify_string (SCM sname, const char *subrname,
 	if (scm_is_false(scm_string_p(sname)))
 		scm_wrong_type_arg_msg(subrname, pos, sname, msg);
 
-	char * cname = scm_to_locale_string(sname);
+	// char * cname = scm_to_utf8_string(sname);
+	const char * cname = scm_i_string_chars(sname);
 	std::string name(cname);
-	free(cname);
+	// free(cname);
 	return name;
 }
 

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -29,10 +29,10 @@ using namespace opencog;
  */
 std::string SchemeSmob::to_string(SCM node)
 {
-    if (SCM_SMOB_PREDICATE(SchemeSmob::cog_misc_tag, node))
-        return misc_to_string(node);
+	if (SCM_SMOB_PREDICATE(SchemeSmob::cog_misc_tag, node))
+		return misc_to_string(node);
 
-    return "";
+	return "";
 }
 
 /**
@@ -44,80 +44,80 @@ std::string SchemeSmob::to_string(SCM node)
  */
 std::string SchemeSmob::to_string(Handle h)
 {
-    return handle_to_string(h, 0);
+	return handle_to_string(h, 0);
 }
 
 std::string SchemeSmob::handle_to_string(Handle h, int indent)
 {
-    if (Handle::UNDEFINED == h) return "#<Undefined atom handle>";
-    if (NULL == h) return "#<Invalid handle>";
+	if (Handle::UNDEFINED == h) return "#<Undefined atom handle>";
+	if (NULL == h) return "#<Invalid handle>";
 
-    // Print a scheme expression, so that the output can be saved
-    // to file, and then restored, as needed.
-    std::string ret = "";
-    for (int i=0; i< indent; i++) ret += "   ";
-    ret += "(";
-    ret += classserver().getTypeName(h->getType());
-    NodePtr nnn(NodeCast(h));
-    LinkPtr lll(LinkCast(h));
-    if (nnn) {
-        ret += " \"";
-        ret += nnn->getName();
-        ret += "\"";
+	// Print a scheme expression, so that the output can be saved
+	// to file, and then restored, as needed.
+	std::string ret = "";
+	for (int i=0; i< indent; i++) ret += "   ";
+	ret += "(";
+	ret += classserver().getTypeName(h->getType());
+	NodePtr nnn(NodeCast(h));
+	LinkPtr lll(LinkCast(h));
+	if (nnn) {
+		ret += " \"";
+		ret += nnn->getName();
+		ret += "\"";
 
-        // Print the truth value only after the node name
-        TruthValuePtr tv(h->getTruthValue());
-        if (!tv->isDefaultTV()) {
-            ret += " ";
-            ret += tv_to_string (tv.get());
-        }
+		// Print the truth value only after the node name
+		TruthValuePtr tv(h->getTruthValue());
+		if (!tv->isDefaultTV()) {
+			ret += " ";
+			ret += tv_to_string (tv.get());
+		}
 
-        // Print the attention value after the truth value
-        AttentionValuePtr av(h->getAttentionValue());
-        if (av != AttentionValue::DEFAULT_AV()) {
-            ret += " ";
-            ret += av_to_string (av.get());
-        }
-        ret += ")";
-        return ret;
-    }
-    else if (lll) {
-        // If there's a truth value, print it before the other atoms
-        TruthValuePtr tv(h->getTruthValue());
-        if (!tv->isDefaultTV()) {
-            ret += " ";
-            ret += tv_to_string (tv.get());
-        }
+		// Print the attention value after the truth value
+		AttentionValuePtr av(h->getAttentionValue());
+		if (av != AttentionValue::DEFAULT_AV()) {
+			ret += " ";
+			ret += av_to_string (av.get());
+		}
+		ret += ")";
+		return ret;
+	}
+	else if (lll) {
+		// If there's a truth value, print it before the other atoms
+		TruthValuePtr tv(h->getTruthValue());
+		if (!tv->isDefaultTV()) {
+			ret += " ";
+			ret += tv_to_string (tv.get());
+		}
 
-        // Print the attention value after the truth value
-        AttentionValuePtr av(h->getAttentionValue());
-        if (av != AttentionValue::DEFAULT_AV()) {
-            ret += " ";
-            ret += av_to_string (av.get());
-        }
+		// Print the attention value after the truth value
+		AttentionValuePtr av(h->getAttentionValue());
+		if (av != AttentionValue::DEFAULT_AV()) {
+			ret += " ";
+			ret += av_to_string (av.get());
+		}
 
-        // print the outgoing link set.
-        ret += "\n";
-        std::vector<Handle> oset = lll->getOutgoingSet();
-        unsigned int arity = oset.size();
-        for (unsigned int i=0; i<arity; i++) {
-            //ret += " ";
-            ret += handle_to_string(oset[i], /*(0==i)?0:*/indent+1);
-            ret += "\n";
-            //if (i != arity-1) ret += "\n";
-        }
-        for (int i=0; i < indent; i++) ret += "   ";
-        ret += ")";
-        return ret;
-    }
+		// print the outgoing link set.
+		ret += "\n";
+		std::vector<Handle> oset = lll->getOutgoingSet();
+		unsigned int arity = oset.size();
+		for (unsigned int i=0; i<arity; i++) {
+			//ret += " ";
+			ret += handle_to_string(oset[i], /*(0==i)?0:*/indent+1);
+			ret += "\n";
+			//if (i != arity-1) ret += "\n";
+		}
+		for (int i=0; i < indent; i++) ret += "   ";
+		ret += ")";
+		return ret;
+	}
 
-    return ret;
+	return ret;
 }
 
 std::string SchemeSmob::handle_to_string(SCM node)
 {
-    Handle h(scm_to_handle(node));
-    return handle_to_string(h, 0) + "\n";
+	Handle h(scm_to_handle(node));
+	return handle_to_string(h, 0) + "\n";
 }
 
 /* ============================================================== */
@@ -129,30 +129,30 @@ std::string SchemeSmob::handle_to_string(SCM node)
 
 SCM SchemeSmob::handle_to_scm (Handle h)
 {
-    Handle* hp = new Handle(h); // so that the smart pointer increments!
-    // Force resolution to occur now, not later.
-    hp->operator->();
-    scm_gc_register_collectable_memory (hp,
-                    sizeof(h), "opencog handle");
+	Handle* hp = new Handle(h); // so that the smart pointer increments!
+	// Force resolution to occur now, not later.
+	hp->operator->();
+	scm_gc_register_collectable_memory (hp,
+					sizeof(h), "opencog handle");
 
-    SCM smob;
-    SCM_NEWSMOB (smob, cog_misc_tag, hp);
-    SCM_SET_SMOB_FLAGS(smob, COG_HANDLE);
-    return smob;
+	SCM smob;
+	SCM_NEWSMOB (smob, cog_misc_tag, hp);
+	SCM_SET_SMOB_FLAGS(smob, COG_HANDLE);
+	return smob;
 }
 
 Handle SchemeSmob::scm_to_handle (SCM sh)
 {
-    if (not SCM_SMOB_PREDICATE(SchemeSmob::cog_misc_tag, sh))
-        return Handle::UNDEFINED;
+	if (not SCM_SMOB_PREDICATE(SchemeSmob::cog_misc_tag, sh))
+		return Handle::UNDEFINED;
 
-    scm_t_bits misctype = SCM_SMOB_FLAGS(sh);
-    if (COG_HANDLE != misctype)
-        return Handle::UNDEFINED;
+	scm_t_bits misctype = SCM_SMOB_FLAGS(sh);
+	if (COG_HANDLE != misctype)
+		return Handle::UNDEFINED;
 
-    Handle h(*((Handle *) SCM_SMOB_DATA(sh)));
-    scm_remember_upto_here_1(sh);
-    return h;
+	Handle h(*((Handle *) SCM_SMOB_DATA(sh)));
+	scm_remember_upto_here_1(sh);
+	return h;
 }
 
 /* ============================================================== */
@@ -161,12 +161,12 @@ Handle SchemeSmob::scm_to_handle (SCM sh)
  */
 SCM SchemeSmob::ss_atom (SCM suuid)
 {
-    if (scm_is_false(scm_integer_p(suuid)))
-        scm_wrong_type_arg_msg("cog-atom", 1, suuid, "integer opencog uuid");
+	if (scm_is_false(scm_integer_p(suuid)))
+		scm_wrong_type_arg_msg("cog-atom", 1, suuid, "integer opencog uuid");
 
-    // SCM_RETURN_NEWSMOB (cog_uuid_tag, suuid);
-    UUID uuid = scm_to_ulong(suuid);
-    return handle_to_scm(Handle(uuid));
+	// SCM_RETURN_NEWSMOB (cog_uuid_tag, suuid);
+	UUID uuid = scm_to_ulong(suuid);
+	return handle_to_scm(Handle(uuid));
 }
 
 /* ============================================================== */
@@ -175,11 +175,11 @@ SCM SchemeSmob::ss_atom (SCM suuid)
  */
 SCM SchemeSmob::ss_handle (SCM satom)
 {
-    Handle h(scm_to_handle(satom));
-    if (Handle::UNDEFINED == h)
-        scm_wrong_type_arg_msg("cog-handle", 1, satom, "opencog atom");
+	Handle h(scm_to_handle(satom));
+	if (Handle::UNDEFINED == h)
+		scm_wrong_type_arg_msg("cog-handle", 1, satom, "opencog atom");
 
-    return scm_from_ulong(h.value());
+	return scm_from_ulong(h.value());
 }
 
 /* ============================================================== */
@@ -188,7 +188,7 @@ SCM SchemeSmob::ss_handle (SCM satom)
  */
 SCM SchemeSmob::ss_undefined_handle (void)
 {
-    return scm_from_ulong(Handle::UNDEFINED.value());
+	return scm_from_ulong(Handle::UNDEFINED.value());
 }
 
 /* ============================================================== */
@@ -196,14 +196,14 @@ SCM SchemeSmob::ss_undefined_handle (void)
 
 SCM SchemeSmob::ss_atom_p (SCM s)
 {
-    if (not SCM_SMOB_PREDICATE(SchemeSmob::cog_misc_tag, s))
-        return SCM_BOOL_F;
+	if (not SCM_SMOB_PREDICATE(SchemeSmob::cog_misc_tag, s))
+		return SCM_BOOL_F;
 
-    scm_t_bits misctype = SCM_SMOB_FLAGS(s);
-    if (COG_HANDLE == misctype)
-        return SCM_BOOL_T;
+	scm_t_bits misctype = SCM_SMOB_FLAGS(s);
+	if (COG_HANDLE == misctype)
+		return SCM_BOOL_T;
 
-    return SCM_BOOL_F;
+	return SCM_BOOL_F;
 }
 
 /* ============================================================== */
@@ -211,13 +211,13 @@ SCM SchemeSmob::ss_atom_p (SCM s)
 
 SCM SchemeSmob::ss_node_p (SCM s)
 {
-    Handle h(scm_to_handle(s));
-    if (Handle::UNDEFINED == h)
-        return SCM_BOOL_F;
+	Handle h(scm_to_handle(s));
+	if (Handle::UNDEFINED == h)
+		return SCM_BOOL_F;
 
-    if (NodeCast(h)) return SCM_BOOL_T;
+	if (NodeCast(h)) return SCM_BOOL_T;
 
-    return SCM_BOOL_F;
+	return SCM_BOOL_F;
 }
 
 /* ============================================================== */
@@ -225,12 +225,12 @@ SCM SchemeSmob::ss_node_p (SCM s)
 
 SCM SchemeSmob::ss_link_p (SCM s)
 {
-    Handle h(scm_to_handle(s));
-    if (Handle::UNDEFINED == h)
-        return SCM_BOOL_F;
+	Handle h(scm_to_handle(s));
+	if (Handle::UNDEFINED == h)
+		return SCM_BOOL_F;
 
-    if (LinkCast(h)) return SCM_BOOL_T;
-    return SCM_BOOL_F;
+	if (LinkCast(h)) return SCM_BOOL_T;
+	return SCM_BOOL_F;
 }
 
 /* ============================================================== */
@@ -241,21 +241,21 @@ SCM SchemeSmob::ss_link_p (SCM s)
  */
 Type SchemeSmob::verify_atom_type (SCM stype, const char *subrname, int pos)
 {
-    if (scm_is_true(scm_symbol_p(stype)))
-        stype = scm_symbol_to_string(stype);
+	if (scm_is_true(scm_symbol_p(stype)))
+		stype = scm_symbol_to_string(stype);
 
-    if (scm_is_false(scm_string_p(stype)))
-        scm_wrong_type_arg_msg(subrname, pos, stype, "name of opencog atom type");
+	if (scm_is_false(scm_string_p(stype)))
+		scm_wrong_type_arg_msg(subrname, pos, stype, "name of opencog atom type");
 
-    char * ct = scm_to_locale_string(stype);
-    Type t = classserver().getType(ct);
-    free(ct);
+	char * ct = scm_to_locale_string(stype);
+	Type t = classserver().getType(ct);
+	free(ct);
 
-    // Make sure that the type is good
-    if (NOTYPE == t)
-        scm_wrong_type_arg_msg(subrname, pos, stype, "name of opencog atom type");
+	// Make sure that the type is good
+	if (NOTYPE == t)
+		scm_wrong_type_arg_msg(subrname, pos, stype, "name of opencog atom type");
 
-    return t;
+	return t;
 }
 
 /**
@@ -265,12 +265,12 @@ Type SchemeSmob::verify_atom_type (SCM stype, const char *subrname, int pos)
  */
 Type SchemeSmob::verify_node_type (SCM stype, const char *subrname, int pos)
 {
-    Type t = verify_atom_type(stype, subrname, pos);
+	Type t = verify_atom_type(stype, subrname, pos);
 
-    if (false == classserver().isA(t, NODE))
-        scm_wrong_type_arg_msg(subrname, pos, stype, "name of opencog node type");
+	if (false == classserver().isA(t, NODE))
+		scm_wrong_type_arg_msg(subrname, pos, stype, "name of opencog node type");
 
-    return t;
+	return t;
 }
 
 /**
@@ -278,15 +278,15 @@ Type SchemeSmob::verify_node_type (SCM stype, const char *subrname, int pos)
  * Return the string, in C.
  */
 std::string SchemeSmob::verify_string (SCM sname, const char *subrname,
-                                       int pos, const char * msg)
+									   int pos, const char * msg)
 {
-    if (scm_is_false(scm_string_p(sname)))
-        scm_wrong_type_arg_msg(subrname, pos, sname, msg);
+	if (scm_is_false(scm_string_p(sname)))
+		scm_wrong_type_arg_msg(subrname, pos, sname, msg);
 
-    char * cname = scm_to_locale_string(sname);
-    std::string name(cname);
-    free(cname);
-    return name;
+	char * cname = scm_to_locale_string(sname);
+	std::string name(cname);
+	free(cname);
+	return name;
 }
 
 /**
@@ -294,12 +294,12 @@ std::string SchemeSmob::verify_string (SCM sname, const char *subrname,
  * Return the int.
  */
 int SchemeSmob::verify_int (SCM sint, const char *subrname,
-                            int pos, const char * msg)
+							int pos, const char * msg)
 {
-    if (scm_is_false(scm_integer_p(sint)))
-        scm_wrong_type_arg_msg(subrname, pos, sint, msg);
+	if (scm_is_false(scm_integer_p(sint)))
+		scm_wrong_type_arg_msg(subrname, pos, sint, msg);
 
-    return scm_to_int(sint);
+	return scm_to_int(sint);
 }
 
 /**
@@ -307,41 +307,41 @@ int SchemeSmob::verify_int (SCM sint, const char *subrname,
  */
 SCM SchemeSmob::ss_new_node (SCM stype, SCM sname, SCM kv_pairs)
 {
-    Type t = verify_node_type(stype, "cog-new-node", 1);
+	Type t = verify_node_type(stype, "cog-new-node", 1);
 
-    // Special case handling for NumberNode
-    if (NUMBER_NODE == t and scm_is_number(sname)) {
-        sname = scm_number_to_string(sname, _radix_ten);
-        // TODO: if we're given a string, I guess maybe we should check
-        // that the string is convertible to a number ??
-    }
-    std::string name(verify_string (sname, "cog-new-node", 2,
-        "string name for the node"));
+	// Special case handling for NumberNode
+	if (NUMBER_NODE == t and scm_is_number(sname)) {
+		sname = scm_number_to_string(sname, _radix_ten);
+		// TODO: if we're given a string, I guess maybe we should check
+		// that the string is convertible to a number ??
+	}
+	std::string name(verify_string (sname, "cog-new-node", 2,
+		"string name for the node"));
 
-    AtomSpace* atomspace = get_as_from_list(kv_pairs);
-    if (NULL == atomspace) atomspace = ss_get_env_as("cog-new-node");
+	AtomSpace* atomspace = get_as_from_list(kv_pairs);
+	if (NULL == atomspace) atomspace = ss_get_env_as("cog-new-node");
 
-    Handle h;
-    // Now, create the actual node... in the actual atom space.
-    // tv->clone is called here, because, for the atomspace, we want
-    // to use a use-counted std:shared_ptr, whereas in guile, we are
-    // using a garbage-collected raw pointer.  So clone makes up the
-    // difference.
-    const TruthValue *tv = get_tv_from_list(kv_pairs);
-    if (tv)
-        h = atomspace->addNode(t, name, tv->clone());
-    else
-        h = atomspace->addNode(t, name);
+	Handle h;
+	// Now, create the actual node... in the actual atom space.
+	// tv->clone is called here, because, for the atomspace, we want
+	// to use a use-counted std:shared_ptr, whereas in guile, we are
+	// using a garbage-collected raw pointer.  So clone makes up the
+	// difference.
+	const TruthValue *tv = get_tv_from_list(kv_pairs);
+	if (tv)
+		h = atomspace->addNode(t, name, tv->clone());
+	else
+		h = atomspace->addNode(t, name);
 
-    // Was an attention value explicitly specified?
-    // If so, then we've got to set it.
-    AttentionValue *av = get_av_from_list(kv_pairs);
-    if (av) {
-        h->setAttentionValue(av->clone());
-    }
+	// Was an attention value explicitly specified?
+	// If so, then we've got to set it.
+	AttentionValue *av = get_av_from_list(kv_pairs);
+	if (av) {
+		h->setAttentionValue(av->clone());
+	}
 
-    scm_remember_upto_here_1(kv_pairs);
-    return handle_to_scm(h);
+	scm_remember_upto_here_1(kv_pairs);
+	return handle_to_scm(h);
 }
 
 /**
@@ -352,31 +352,31 @@ SCM SchemeSmob::ss_new_node (SCM stype, SCM sname, SCM kv_pairs)
  */
 SCM SchemeSmob::ss_node (SCM stype, SCM sname, SCM kv_pairs)
 {
-    Type t = verify_node_type(stype, "cog-node", 1);
-    std::string name = verify_string (sname, "cog-node", 2,
-                                    "string name for the node");
+	Type t = verify_node_type(stype, "cog-node", 1);
+	std::string name = verify_string (sname, "cog-node", 2,
+									"string name for the node");
 
-    AtomSpace* atomspace = get_as_from_list(kv_pairs);
-    if (NULL == atomspace) atomspace = ss_get_env_as("cog-node");
+	AtomSpace* atomspace = get_as_from_list(kv_pairs);
+	if (NULL == atomspace) atomspace = ss_get_env_as("cog-node");
 
-    // Now, look for the actual node... in the actual atom space.
-    Handle h(atomspace->getHandle(t, name));
-    if (Handle::UNDEFINED == h) return SCM_EOL;
-    if (NULL == h) return SCM_EOL;
+	// Now, look for the actual node... in the actual atom space.
+	Handle h(atomspace->getHandle(t, name));
+	if (Handle::UNDEFINED == h) return SCM_EOL;
+	if (NULL == h) return SCM_EOL;
 
-    // If there was a truth value, change it.
-    const TruthValue *tv = get_tv_from_list(kv_pairs);
-    if (tv) {
-        h->setTruthValue(tv->clone());
-    }
+	// If there was a truth value, change it.
+	const TruthValue *tv = get_tv_from_list(kv_pairs);
+	if (tv) {
+		h->setTruthValue(tv->clone());
+	}
 
-    // If there was an attention value, change it.
-    const AttentionValue *av = get_av_from_list(kv_pairs);
-    if (av) {
-        h->setAttentionValue(av->clone());
-    }
-    scm_remember_upto_here_1(kv_pairs);
-    return handle_to_scm (h);
+	// If there was an attention value, change it.
+	const AttentionValue *av = get_av_from_list(kv_pairs);
+	if (av) {
+		h->setAttentionValue(av->clone());
+	}
+	scm_remember_upto_here_1(kv_pairs);
+	return handle_to_scm (h);
 }
 
 /* ============================================================== */
@@ -385,21 +385,21 @@ SCM SchemeSmob::ss_node (SCM stype, SCM sname, SCM kv_pairs)
  */
 static Type verify_link (SCM stype, const char * subrname)
 {
-    if (scm_is_true(scm_symbol_p(stype)))
-        stype = scm_symbol_to_string(stype);
+	if (scm_is_true(scm_symbol_p(stype)))
+		stype = scm_symbol_to_string(stype);
 
-    char * ct = scm_to_locale_string(stype);
-    Type t = classserver().getType(ct);
-    free(ct);
+	char * ct = scm_to_locale_string(stype);
+	Type t = classserver().getType(ct);
+	free(ct);
 
-    // Make sure that the type is good
-    if (NOTYPE == t)
-        scm_wrong_type_arg_msg(subrname, 1, stype, "name of opencog atom type");
+	// Make sure that the type is good
+	if (NOTYPE == t)
+		scm_wrong_type_arg_msg(subrname, 1, stype, "name of opencog atom type");
 
-    if (false == classserver().isA(t, LINK))
-        scm_wrong_type_arg_msg(subrname, 1, stype, "name of opencog link type");
+	if (false == classserver().isA(t, LINK))
+		scm_wrong_type_arg_msg(subrname, 1, stype, "name of opencog link type");
 
-    return t;
+	return t;
 }
 
 /**
@@ -408,52 +408,52 @@ static Type verify_link (SCM stype, const char * subrname)
 std::vector<Handle>
 SchemeSmob::verify_handle_list (SCM satom_list, const char * subrname, int pos)
 {
-    // Verify that second arg is an actual list. Allow null list
-    // (which is rather unusal, but legit.  Allow embedded nulls
-    // as this can be convenient for writing scheme code.
-    if (!scm_is_pair(satom_list) and !scm_is_null(satom_list))
-        scm_wrong_type_arg_msg(subrname, pos, satom_list, "a list of atoms");
+	// Verify that second arg is an actual list. Allow null list
+	// (which is rather unusal, but legit.  Allow embedded nulls
+	// as this can be convenient for writing scheme code.
+	if (!scm_is_pair(satom_list) and !scm_is_null(satom_list))
+		scm_wrong_type_arg_msg(subrname, pos, satom_list, "a list of atoms");
 
-    std::vector<Handle> outgoing_set;
-    SCM sl = satom_list;
-    pos = 2;
-    while (scm_is_pair(sl)) {
-        SCM satom = SCM_CAR(sl);
+	std::vector<Handle> outgoing_set;
+	SCM sl = satom_list;
+	pos = 2;
+	while (scm_is_pair(sl)) {
+		SCM satom = SCM_CAR(sl);
 
-        // Verify that the contents of the list are actual atoms.
-        Handle h(scm_to_handle(satom));
-        if (Handle::UNDEFINED != h) {
-            outgoing_set.push_back(h);
-        }
-        else if (scm_is_pair(satom) and !scm_is_null(satom_list)) {
-            // Allow lists to be specified: e.g.
-            // (cog-new-link 'ListLink (list x y z))
-            // Do this via a recursive call, flattening nested lists
-            // as we go along.
-            const std::vector<Handle> &oset =
-                verify_handle_list(satom, subrname, pos);
-            std::vector<Handle>::const_iterator it;
-            for (it = oset.begin(); it != oset.end(); ++it) {
-                outgoing_set.push_back(*it);
-            }
-        }
-        else if (scm_is_null(satom)) {
-            // No-op, just ignore.
-        }
-        else {
-            // Its legit to have embedded truth values, just skip them.
-				if (not SCM_SMOB_PREDICATE(SchemeSmob::cog_misc_tag, satom)) {
-                // If its not an atom, and its not a truth value, and
-                // its not an attention value, and its not an atomspace,
-                // then whatever it is, its bad.
-                scm_wrong_type_arg_msg(subrname, pos, satom, "opencog atom");
-            }
-        }
-        sl = SCM_CDR(sl);
-        pos++;
-    }
+		// Verify that the contents of the list are actual atoms.
+		Handle h(scm_to_handle(satom));
+		if (Handle::UNDEFINED != h) {
+			outgoing_set.push_back(h);
+		}
+		else if (scm_is_pair(satom) and !scm_is_null(satom_list)) {
+			// Allow lists to be specified: e.g.
+			// (cog-new-link 'ListLink (list x y z))
+			// Do this via a recursive call, flattening nested lists
+			// as we go along.
+			const std::vector<Handle> &oset =
+				verify_handle_list(satom, subrname, pos);
+			std::vector<Handle>::const_iterator it;
+			for (it = oset.begin(); it != oset.end(); ++it) {
+				outgoing_set.push_back(*it);
+			}
+		}
+		else if (scm_is_null(satom)) {
+			// No-op, just ignore.
+		}
+		else {
+			// Its legit to have embedded truth values, just skip them.
+			if (not SCM_SMOB_PREDICATE(SchemeSmob::cog_misc_tag, satom)) {
+				// If its not an atom, and its not a truth value, and
+				// its not an attention value, and its not an atomspace,
+				// then whatever it is, its bad.
+				scm_wrong_type_arg_msg(subrname, pos, satom, "opencog atom");
+			}
+		}
+		sl = SCM_CDR(sl);
+		pos++;
+	}
 
-    return outgoing_set;
+	return outgoing_set;
 }
 
 /**
@@ -461,32 +461,32 @@ SchemeSmob::verify_handle_list (SCM satom_list, const char * subrname, int pos)
  */
 SCM SchemeSmob::ss_new_link (SCM stype, SCM satom_list)
 {
-    Handle h;
-    Type t = verify_link (stype, "cog-new-link");
+	Handle h;
+	Type t = verify_link (stype, "cog-new-link");
 
-    std::vector<Handle> outgoing_set;
-    outgoing_set = verify_handle_list (satom_list, "cog-new-link", 2);
+	std::vector<Handle> outgoing_set;
+	outgoing_set = verify_handle_list (satom_list, "cog-new-link", 2);
 
-    AtomSpace* atomspace = get_as_from_list(satom_list);
-    if (NULL == atomspace) atomspace = ss_get_env_as("cog-new-link");
+	AtomSpace* atomspace = get_as_from_list(satom_list);
+	if (NULL == atomspace) atomspace = ss_get_env_as("cog-new-link");
 
-    // Fish out a truth value, if its there.
-    const TruthValue *tv = get_tv_from_list(satom_list);
-    if (tv) {
-        h = atomspace->addLink(t, outgoing_set, tv->clone());
-    } else {
-        // Now, create the actual link... in the actual atom space.
-        h = atomspace->addLink(t, outgoing_set);
-    }
+	// Fish out a truth value, if its there.
+	const TruthValue *tv = get_tv_from_list(satom_list);
+	if (tv) {
+		h = atomspace->addLink(t, outgoing_set, tv->clone());
+	} else {
+		// Now, create the actual link... in the actual atom space.
+		h = atomspace->addLink(t, outgoing_set);
+	}
 
-    // Was an attention value explicitly specified?
-    // If so, then we've got to set it.
-    const AttentionValue *av = get_av_from_list(satom_list);
-    if (av) {
-        h->setAttentionValue(av->clone());
-    }
-    scm_remember_upto_here_1(satom_list);
-    return handle_to_scm (h);
+	// Was an attention value explicitly specified?
+	// If so, then we've got to set it.
+	const AttentionValue *av = get_av_from_list(satom_list);
+	if (av) {
+		h->setAttentionValue(av->clone());
+	}
+	scm_remember_upto_here_1(satom_list);
+	return handle_to_scm (h);
 }
 
 /**
@@ -496,29 +496,29 @@ SCM SchemeSmob::ss_new_link (SCM stype, SCM satom_list)
  */
 SCM SchemeSmob::ss_link (SCM stype, SCM satom_list)
 {
-    Type t = verify_link (stype, "cog-link");
+	Type t = verify_link (stype, "cog-link");
 
-    std::vector<Handle> outgoing_set;
-    outgoing_set = verify_handle_list (satom_list, "cog-link", 2);
+	std::vector<Handle> outgoing_set;
+	outgoing_set = verify_handle_list (satom_list, "cog-link", 2);
 
-    AtomSpace* atomspace = get_as_from_list(satom_list);
-    if (NULL == atomspace) atomspace = ss_get_env_as("cog-link");
+	AtomSpace* atomspace = get_as_from_list(satom_list);
+	if (NULL == atomspace) atomspace = ss_get_env_as("cog-link");
 
-    // Now, look to find the actual link... in the actual atom space.
-    Handle h(atomspace->getHandle(t, outgoing_set));
-    if (Handle::UNDEFINED == h) return SCM_EOL;
-    if (NULL == h) return SCM_EOL;
+	// Now, look to find the actual link... in the actual atom space.
+	Handle h(atomspace->getHandle(t, outgoing_set));
+	if (Handle::UNDEFINED == h) return SCM_EOL;
+	if (NULL == h) return SCM_EOL;
 
-    // If there was a truth value, change it.
-    const TruthValue *tv = get_tv_from_list(satom_list);
-    if (tv) h->setTruthValue(tv->clone());
+	// If there was a truth value, change it.
+	const TruthValue *tv = get_tv_from_list(satom_list);
+	if (tv) h->setTruthValue(tv->clone());
 
-    // If there was an attention value, change it.
-    const AttentionValue *av = get_av_from_list(satom_list);
-    if (av) h->setAttentionValue(av->clone());
+	// If there was an attention value, change it.
+	const AttentionValue *av = get_av_from_list(satom_list);
+	if (av) h->setAttentionValue(av->clone());
 
-    scm_remember_upto_here_1(satom_list);
-    return handle_to_scm (h);
+	scm_remember_upto_here_1(satom_list);
+	return handle_to_scm (h);
 }
 
 /* ============================================================== */
@@ -530,26 +530,26 @@ SCM SchemeSmob::ss_link (SCM stype, SCM satom_list)
  */
 SCM SchemeSmob::ss_delete (SCM satom, SCM kv_pairs)
 {
-    Handle h = verify_handle(satom, "cog-delete");
+	Handle h = verify_handle(satom, "cog-delete");
 
-    // It can happen that the atom has already been deleted, but we're
-    // still holding on to its UUID.  This is rare... but possible. So
-    // don't crash when it happens.
-    if (NULL == h.operator->()) return SCM_BOOL_F;
+	// It can happen that the atom has already been deleted, but we're
+	// still holding on to its UUID.  This is rare... but possible. So
+	// don't crash when it happens.
+	if (NULL == h.operator->()) return SCM_BOOL_F;
 
-    // The remove will fail/log warning if the incoming set isn't null.
-    if (h->getIncomingSetSize() > 0) return SCM_BOOL_F;
+	// The remove will fail/log warning if the incoming set isn't null.
+	if (h->getIncomingSetSize() > 0) return SCM_BOOL_F;
 
-    AtomSpace* atomspace = get_as_from_list(kv_pairs);
-    if (NULL == atomspace) atomspace = ss_get_env_as("cog-delete");
+	AtomSpace* atomspace = get_as_from_list(kv_pairs);
+	if (NULL == atomspace) atomspace = ss_get_env_as("cog-delete");
 
-    // AtomSpace::removeAtom() returns true if atom was deleted,
-    // else returns false
-    bool rc = atomspace->removeAtom(h, false);
+	// AtomSpace::removeAtom() returns true if atom was deleted,
+	// else returns false
+	bool rc = atomspace->removeAtom(h, false);
 
-    // rc should always be true at this point ...
-    if (rc) return SCM_BOOL_T;
-    return SCM_BOOL_F;
+	// rc should always be true at this point ...
+	if (rc) return SCM_BOOL_T;
+	return SCM_BOOL_F;
 }
 
 /* ============================================================== */
@@ -560,15 +560,15 @@ SCM SchemeSmob::ss_delete (SCM satom, SCM kv_pairs)
  */
 SCM SchemeSmob::ss_delete_recursive (SCM satom, SCM kv_pairs)
 {
-    Handle h = verify_handle(satom, "cog-delete-recursive");
+	Handle h = verify_handle(satom, "cog-delete-recursive");
 
-    AtomSpace* atomspace = get_as_from_list(kv_pairs);
-    if (NULL == atomspace) atomspace = ss_get_env_as("cog-delete-recursive");
+	AtomSpace* atomspace = get_as_from_list(kv_pairs);
+	if (NULL == atomspace) atomspace = ss_get_env_as("cog-delete-recursive");
 
-    bool rc = atomspace->removeAtom(h, true);
+	bool rc = atomspace->removeAtom(h, true);
 
-    if (rc) return SCM_BOOL_T;
-    return SCM_BOOL_F;
+	if (rc) return SCM_BOOL_T;
+	return SCM_BOOL_F;
 }
 
 /* ============================================================== */
@@ -580,26 +580,26 @@ SCM SchemeSmob::ss_delete_recursive (SCM satom, SCM kv_pairs)
  */
 SCM SchemeSmob::ss_purge (SCM satom, SCM kv_pairs)
 {
-    Handle h = verify_handle(satom, "cog-purge");
+	Handle h = verify_handle(satom, "cog-purge");
 
-    // It can happen that the atom has already been purged, but we're
-    // still holding on to its UUID.  This is rare... but possible. So
-    // don't crash when it happens.
-    if (NULL == h.operator->()) return SCM_BOOL_F;
+	// It can happen that the atom has already been purged, but we're
+	// still holding on to its UUID.  This is rare... but possible. So
+	// don't crash when it happens.
+	if (NULL == h.operator->()) return SCM_BOOL_F;
 
-    // The purge will fail/log warning if the incoming set isn't null.
-    if (h->getIncomingSetSize() > 0) return SCM_BOOL_F;
+	// The purge will fail/log warning if the incoming set isn't null.
+	if (h->getIncomingSetSize() > 0) return SCM_BOOL_F;
 
-    AtomSpace* atomspace = get_as_from_list(kv_pairs);
-    if (NULL == atomspace) atomspace = ss_get_env_as("cog-purge");
+	AtomSpace* atomspace = get_as_from_list(kv_pairs);
+	if (NULL == atomspace) atomspace = ss_get_env_as("cog-purge");
 
-    // AtomSpace::purgeAtom() returns true if atom was purged,
-    // else returns false
-    bool rc = atomspace->purgeAtom(h, false);
+	// AtomSpace::purgeAtom() returns true if atom was purged,
+	// else returns false
+	bool rc = atomspace->purgeAtom(h, false);
 
-    // rc should always be true at this point ...
-    if (rc) return SCM_BOOL_T;
-    return SCM_BOOL_F;
+	// rc should always be true at this point ...
+	if (rc) return SCM_BOOL_T;
+	return SCM_BOOL_F;
 }
 
 /* ============================================================== */
@@ -610,15 +610,15 @@ SCM SchemeSmob::ss_purge (SCM satom, SCM kv_pairs)
  */
 SCM SchemeSmob::ss_purge_recursive (SCM satom, SCM kv_pairs)
 {
-    Handle h = verify_handle(satom, "cog-purge-recursive");
+	Handle h = verify_handle(satom, "cog-purge-recursive");
 
-    AtomSpace* atomspace = get_as_from_list(kv_pairs);
-    if (NULL == atomspace) atomspace = ss_get_env_as("cog-purge-recursive");
+	AtomSpace* atomspace = get_as_from_list(kv_pairs);
+	if (NULL == atomspace) atomspace = ss_get_env_as("cog-purge-recursive");
 
-    bool rc = atomspace->purgeAtom(h, true);
+	bool rc = atomspace->purgeAtom(h, true);
 
-    if (rc) return SCM_BOOL_T;
-    return SCM_BOOL_F;
+	if (rc) return SCM_BOOL_T;
+	return SCM_BOOL_F;
 }
 
 #endif

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -271,10 +271,9 @@ std::string SchemeSmob::verify_string (SCM sname, const char *subrname,
 	if (scm_is_false(scm_string_p(sname)))
 		scm_wrong_type_arg_msg(subrname, pos, sname, msg);
 
-	// char * cname = scm_to_utf8_string(sname);
-	const char * cname = scm_i_string_chars(sname);
+	char * cname = scm_to_utf8_string(sname);
 	std::string name(cname);
-	// free(cname);
+	free(cname);
 	return name;
 }
 

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -241,6 +241,9 @@ SCM SchemeSmob::ss_link_p (SCM s)
  */
 Type SchemeSmob::verify_atom_type (SCM stype, const char *subrname, int pos)
 {
+	if (scm_is_integer(stype))
+		return scm_to_ushort(stype);
+
 	if (scm_is_true(scm_symbol_p(stype)))
 		stype = scm_symbol_to_string(stype);
 

--- a/opencog/guile/SchemeSmobTV.cc
+++ b/opencog/guile/SchemeSmobTV.cc
@@ -298,9 +298,9 @@ SCM SchemeSmob::ss_tv_get_value (SCM s)
 			SCM mean = scm_from_double(stv->getMean());
 			SCM conf = scm_from_double(stv->getConfidence());
 			SCM count = scm_from_double(stv->getCount());
-			SCM smean = scm_from_locale_symbol("mean");
-			SCM sconf = scm_from_locale_symbol("confidence");
-			SCM scount = scm_from_locale_symbol("count");
+			SCM smean = scm_from_utf8_symbol("mean");
+			SCM sconf = scm_from_utf8_symbol("confidence");
+			SCM scount = scm_from_utf8_symbol("count");
 	
 			SCM rc = SCM_EOL;
 			rc = scm_acons(sconf, conf, rc);
@@ -315,9 +315,9 @@ SCM SchemeSmob::ss_tv_get_value (SCM s)
 			SCM mean = scm_from_double(ctv->getMean());
 			SCM conf = scm_from_double(ctv->getConfidence());
 			SCM cont = scm_from_double(ctv->getCount());
-			SCM smean = scm_from_locale_symbol("mean");
-			SCM sconf = scm_from_locale_symbol("confidence");
-			SCM scont = scm_from_locale_symbol("count");
+			SCM smean = scm_from_utf8_symbol("mean");
+			SCM sconf = scm_from_utf8_symbol("confidence");
+			SCM scont = scm_from_utf8_symbol("count");
 	
 			SCM rc = SCM_EOL;
 			rc = scm_acons(scont, cont, rc), 
@@ -332,9 +332,9 @@ SCM SchemeSmob::ss_tv_get_value (SCM s)
 			SCM lower = scm_from_double(itv->getL());
 			SCM upper = scm_from_double(itv->getU());
 			SCM conf = scm_from_double(itv->getConfidence());
-			SCM slower = scm_from_locale_symbol("lower");
-			SCM supper = scm_from_locale_symbol("upper");
-			SCM sconf = scm_from_locale_symbol("confidence");
+			SCM slower = scm_from_utf8_symbol("lower");
+			SCM supper = scm_from_utf8_symbol("upper");
+			SCM sconf = scm_from_utf8_symbol("confidence");
 	
 			SCM rc = SCM_EOL;
 			rc = scm_acons(sconf, conf, rc);

--- a/opencog/guile/SchemeSmobTV.cc
+++ b/opencog/guile/SchemeSmobTV.cc
@@ -63,7 +63,7 @@ static TruthValue *get_tv_from_kvp(SCM kvp, const char * subrname, int pos)
 
 		skey = scm_keyword_to_symbol(skey);
 		skey = scm_symbol_to_string(skey);
-		char * key = scm_to_locale_string(skey);
+		char * key = scm_to_utf8_string(skey);
 
 		kvp = SCM_CDR(kvp);
 		pos ++;

--- a/opencog/nlp/types/atom_types.script
+++ b/opencog/nlp/types/atom_types.script
@@ -1,11 +1,12 @@
 //
-// Script for automatic "atom type" generation. For more more information,
-// consult  the documentation in the opencog/atomspace/README file.
+// Script for automatic "atom type" generation. For more more
+// information, consult the opencog/atomspace/README file.
 //
-// Please note: some of the types below are used only via the scheme bindings.
-// Thus, just because you can comment some of these out, and the code still
-// compiles, that does not mean that these types are unused!  Be sure to grep
-// for the CamelCase names, to see if they show up elsewhere!
+// Please note: some of the types below are used only via the scheme
+// bindings. Thus, just because you can comment some of these out, and
+// the code still compiles, that does not mean that these types are
+// unused!  Be sure to grep for the CamelCase names, to see if they
+// show up elsewhere!
 //
 // ====================================================================
 // Older parsing and language handling nodes;

--- a/opencog/reasoning/pln/atom_types.script
+++ b/opencog/reasoning/pln/atom_types.script
@@ -1,5 +1,7 @@
-// =====================================================================
-// Additional link types from Probabilistic Logic Networks
+//
+// Assorted atom types that are used by PLN.
+// TODO XXX: Review, and see if these are acutally being used.
+//
 PREDICTIVE_IMPLICATION_LINK <- ORDERED_LINK
 TAIL_PREDICTIVE_IMPLICATION_LINK <- ORDERED_LINK
 

--- a/opencog/spacetime/atom_types.script
+++ b/opencog/spacetime/atom_types.script
@@ -1,5 +1,6 @@
-
-        
+//
+// Atom type definitions for the varouts space & time server types.
+//
 // ====================================================================
 // SpaceServer atoms
 SPACE_MAP_NODE <- NODE


### PR DESCRIPTION
If Jim is going to start measuring performance ... well, make sure its not embarrassing.
ChangeLog: 
 * avoid locale_string() its painfully slow; use ut8_string() instead.
 *  use ints instead of strings for atom types.  This avoid string compares when creating atoms.