### PR TITLE
README: change xercesc version

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ the build, will be more precise as to which parts will not be built.
 ###### xercesc
 > Apache Xerces-C++ XML Parser
 > Required for embodiment
-> http://xerces.apache.org/xerces-c/ | libxerces-c2-dev
+> http://xerces.apache.org/xerces-c/ | libxerces-c-dev
 
 ###### xmlrpc
 > XML-RPC support


### PR DESCRIPTION
Hello! I'm new to this project.
OpenCog seems to use xercesc library version 3, but README.md file still descript install library version 2.