### PR TITLE
AbsentLink support in pattern matcher.

### DIFF
--- a/opencog/atomspace/atom_types.script
+++ b/opencog/atomspace/atom_types.script
@@ -41,6 +41,14 @@ AND_LINK <- UNORDERED_LINK
 OR_LINK <- UNORDERED_LINK
 NOT_LINK <- UNORDERED_LINK
 
+// The 'intuitionist logic' version of NOT_LINK is ABSENT_LINK.
+// In 'intuitionist logic', the opposite of "true" is not "false",
+// the opposite is "don't know".  ABSENT_LINK is the effective
+// don't-know link.  Currently, it is used during pattern matching
+// to find clauses that may or may not be present: clauses that are
+// optionally present.
+ABSENT_LINK <- UNORDERED_LINK
+
 // ====================================================================
 // Herbrand/First-order-logic/lambda-calc/model-theory style links
 // and nodes.  This are used to implement the pattern matcher, and

--- a/opencog/query/PatternMatchCallback.h
+++ b/opencog/query/PatternMatchCallback.h
@@ -179,10 +179,15 @@ class PatternMatchCallback
 		 *
 		 * Note that all required clauses will have been grounded before
 		 * any optional clauses are examined.
+		 *
+		 * The default semantics here is to reject a match if the optional
+		 * clasues are detected.  This is in keeping with the semantics of
+		 * AbsentLink: a match is possible only if the indicated clauses
+		 * are absent!
 		 */
 		virtual bool optional_clause_match(Handle& pattrn, Handle& grnd)
 		{
-			return true;
+			return false;
 		}
 
 		/**

--- a/opencog/query/PatternMatchCallback.h
+++ b/opencog/query/PatternMatchCallback.h
@@ -187,6 +187,7 @@ class PatternMatchCallback
 		 */
 		virtual bool optional_clause_match(Handle& pattrn, Handle& grnd)
 		{
+			if (Handle::UNDEFINED == grnd) return true;
 			return false;
 		}
 

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1039,6 +1039,15 @@ void PatternMatchEngine::match(PatternMatchCallback *cb,
 		cl++;
 	}
 
+	printf("\nPredicate includes the following optinoal clauses:\n");
+	cl = 0;
+	for (Handle h : _optionals)
+	{
+		printf("Optional clause %d: ", cl);
+		prt(h);
+		cl++;
+	}
+
 	// Print out the bound variables in the predicate.
 	for (Handle h : _bound_vars)
 	{

--- a/opencog/query/PatternUtils.cc
+++ b/opencog/query/PatternUtils.cc
@@ -169,7 +169,8 @@ void split_clauses_pos_neg(const std::vector<Handle>& clauses,
                            std::vector<Handle>& negate)
 {
 	for (Handle h : clauses) {
-		if (NOT_LINK == h->getType()) {
+		Type t = h->getType();
+		if (NOT_LINK == t or ABSENT_LINK == t) {
 			negate.push_back(LinkCast(h)->getOutgoingAtom(0));
 		}
 		else {

--- a/tests/query/Boolean2NotUTest.cxxtest
+++ b/tests/query/Boolean2NotUTest.cxxtest
@@ -69,7 +69,7 @@ class Boolean2NotUTest :  public CxxTest::TestSuite
 };
 
 /*
- * Unlike the BooleanUTest, this test has two NOT statements in it.
+ * Unlike the BooleanUTest, this test has two ABSENT_LINK statements in it.
  * This function sets up the following structures:
  *  # IF _subj(be, $var1) ^ 
  *       _obj(be, $var2) ^
@@ -123,13 +123,13 @@ void Boolean2NotUTest::setUp(void)
 				an(VARIABLE_NODE, "$winst"),
 				an(CONCEPT_NODE, "be")
 			),
-			al(NOT_LINK,
+			al(ABSENT_LINK,
 				al(INHERITANCE_LINK,
 					an(VARIABLE_NODE, "$var2"),
 					an(CONCEPT_NODE, "definite")
 				)
 			),
-			al(NOT_LINK,
+			al(ABSENT_LINK,
 				al(INHERITANCE_LINK,
 					an(VARIABLE_NODE, "$winst"),
 					an(CONCEPT_NODE, "hyp")
@@ -265,11 +265,11 @@ void Boolean2NotUTest::test_isa(void)
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
 	// Result should be a ListLink
-	Handle result = crisp_logic_imply(as, implication);
+	Handle result = imply(as, implication);
 
 	// There should be only one solution: the Berlin one.
 	// The Madrid graph should be rejected because of the 
-	// NOT definite link.
+	// ABSENT_LINK rejects the definite feature of 'captial'.
 	TSM_ASSERT_EQUALS("wrong number of solutions found", 1, getarity(result));
 
 	// Then, evaluationLink, as above.

--- a/tests/query/BooleanUTest.cxxtest
+++ b/tests/query/BooleanUTest.cxxtest
@@ -70,7 +70,7 @@ class BooleanUTest :  public CxxTest::TestSuite
 
 /*
  * This function sets up the following structures:
- *  # IF _subj(be, $var1) ^ 
+ *  # IF _subj(be, $var1) ^
  *       _obj(be, $var2) ^
  *        !DEFINITE-FLAG($var2)
  *      THEN ^3_isa($var1, $var2)
@@ -87,7 +87,7 @@ void BooleanUTest::setUp(void)
 	as = new AtomSpace();
 
 	// Create an implication link that will be tested.
-	implication = 
+	implication =
 	al(IMPLICATION_LINK,
 		al(AND_LINK,
 			al(EVALUATION_LINK,
@@ -104,7 +104,7 @@ void BooleanUTest::setUp(void)
 					an(VARIABLE_NODE, "$var2")
 				)
 			),
-			// used to gaurentee that both are in the same "sentence"
+			// Used to gaurantee that both are in the same "sentence"
 			al(MEMBER_LINK,
 				an(VARIABLE_NODE, "$var1"),
 				an(VARIABLE_NODE, "$sent")
@@ -113,7 +113,7 @@ void BooleanUTest::setUp(void)
 				an(VARIABLE_NODE, "$var2"),
 				an(VARIABLE_NODE, "$sent")
 			),
-			al(NOT_LINK,
+			al(ABSENT_LINK,
 				al(INHERITANCE_LINK,
 					an(VARIABLE_NODE, "$var2"),
 					an(CONCEPT_NODE, "definite")
@@ -233,11 +233,12 @@ void BooleanUTest::test_isa(void)
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
 	// Result should be a ListLink
-	Handle result = crisp_logic_imply(as, implication);
+	Handle result = imply(as, implication);
 
 	// There should be only one solution: the Berlin one.
-	// The Madrid graph should be rejected because of the 
-	// NOT definite link.
+	// The Madrid graph should be rejected because of the
+	// captial is marked 'definite' and the ABSENT_LINK
+	// should reject that.
 	TSM_ASSERT_EQUALS("wrong number of solutions found", 1, getarity(result));
 
 	// Then, evaluationLink, as above.

--- a/tests/query/ExecutionOutputUTest.cxxtest
+++ b/tests/query/ExecutionOutputUTest.cxxtest
@@ -170,7 +170,7 @@ void ExecutionOutputUTest::test_exec(void)
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
 	// Result should be a ListLink
-	Handle result = crisp_logic_imply(as, implication);
+	Handle result = imply(as, implication);
 
 	// There should be only one solution: the Berlin one.
 	// The Madrid graph should be rejected because of the 

--- a/tests/query/ImplicationUTest.cxxtest
+++ b/tests/query/ImplicationUTest.cxxtest
@@ -285,14 +285,14 @@ void ImplicationUTest::test_exec(void)
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
 	// Result should be a ListLink
-	Handle result = crisp_logic_imply(as, implication);
+	Handle result = imply(as, implication);
 	logger().debug("result is %s\n", SchemeSmob::to_string(result).c_str());
 
 	// There should be two solutions: 
 	TSM_ASSERT_EQUALS("wrong number of solutions found", 2, getarity(result));
 
 	// Result should be a ListLink w/ two solutions
-	result = crisp_logic_imply(as, implication2);
+	result = imply(as, implication2);
 	logger().debug("result is %s\n", SchemeSmob::to_string(result).c_str());
 	TSM_ASSERT_EQUALS("wrong number of solutions found", 2, getarity(result));
 

--- a/tests/query/VarTypeNotUTest.cxxtest
+++ b/tests/query/VarTypeNotUTest.cxxtest
@@ -122,14 +122,14 @@ void VarTypeNot::test_exec(void)
 	TSM_ASSERT("Failed to load test data", Handle::UNDEFINED != vscope_bad);
 
 	// Result should be a ListLink w/ zero solutions
-	Handle result_good = crisp_logic_bindlink(as, vscope_good);
+	Handle result_good = bindlink(as, vscope_good);
 	logger().debug("result-good is %s\n", SchemeSmob::to_string(result_good).c_str());
 	TSM_ASSERT_EQUALS("wrong number of solutions found", 0, getarity(result_good));
 
 	bool caught = false;
 	try
 	{
-		crisp_logic_bindlink(as, vscope_bad);
+		bindlink(as, vscope_bad);
    }
    catch (const InvalidParamException& ex)
    {

--- a/tests/query/var-type-not.scm
+++ b/tests/query/var-type-not.scm
@@ -2,7 +2,7 @@
 (define (stv mean conf) (cog-new-stv mean conf))
 
 ; SENTENCE: [The color of the sky is blue.]
-; _predadj (<<color>>, <<blue>>) 
+; _predadj (<<color>>, <<blue>>)
 (EvaluationLink (stv 1.0 1.0)
    (DefinedLinguisticRelationshipNode "_predadj")
    (ListLink
@@ -10,7 +10,7 @@
       (WordInstanceNode "blue@cf040834-cf7a-42ae-bd42-83a001d3c3e3")
    )
 )
-; of (<<color>>, <<sky>>) 
+; of (<<color>>, <<sky>>)
 (EvaluationLink (stv 1.0 1.0)
    (PrepositionalRelationshipNode "of")
    (ListLink
@@ -20,14 +20,14 @@
 )
 
 
-; The whole point here is that the NotLink means that no match at all
-; should be found. i.e. $prep can match "of" and should thus be
+; The whole point here is that the AbsentLink means that no match at
+; all should be found. i.e. $prep can match "of" and should thus be
 ; rejected.
 ;
 
 (define (rule-good)
    (BindLink
-      (ListLink 
+      (ListLink
          (TypedVariableLink
             (VariableNode "$var2")
             (VariableTypeNode "WordInstanceNode")
@@ -46,15 +46,15 @@
          (AndLink
             (EvaluationLink (stv 1 0.99999988)
                (DefinedLinguisticRelationshipNode "_predadj")
-               (ListLink 
+               (ListLink
                   (VariableNode "$var2")
                   (VariableNode "$var1")
                )
             )
-            (NotLink 
-               (EvaluationLink (stv 1 0.99999988) 
+            (AbsentLink
+               (EvaluationLink (stv 1 0.99999988)
                   (VariableNode "$prep")
-                  (ListLink 
+                  (ListLink
                      (VariableNode "$var2")
                      (VariableNode "$var3")
                   )
@@ -72,12 +72,12 @@
 )
 
 
-; This rule has an explicitly bad VariableTypeNode -- 
+; This rule has an explicitly bad VariableTypeNode --
 ; PreposxitionalRelationshipNode is misspelled (on purpose,
 ; since we want to test for the mis-spelled case).
 (define (rule-bad)
    (BindLink
-      (ListLink 
+      (ListLink
          (TypedVariableLink
             (VariableNode "$var2")
             (VariableTypeNode "WordInstanceNode")
@@ -96,15 +96,15 @@
          (AndLink
             (EvaluationLink (stv 1 0.99999988)
                (DefinedLinguisticRelationshipNode "_predadj")
-               (ListLink 
+               (ListLink
                   (VariableNode "$var2")
                   (VariableNode "$var1")
                )
             )
-            (NotLink 
-               (EvaluationLink (stv 1 0.99999988) 
+            (AbsentLink
+               (EvaluationLink (stv 1 0.99999988)
                   (VariableNode "$prep")
-                  (ListLink 
+                  (ListLink
                      (VariableNode "$var2")
                      (VariableNode "$var3")
                   )


### PR DESCRIPTION
Create an explicit AbsentLink that really means "this clause is absent in the pattern search".  This avoids overloading the meaning of NotLink, because absence is not the same as negation.