### PR TITLE
NLP: added new atom types and utilities

### DIFF
--- a/opencog/nlp/lg-dict/utilities.scm
+++ b/opencog/nlp/lg-dict/utilities.scm
@@ -34,13 +34,6 @@
 )
 
 ; ---------------------------------------------------------------------
-; lg-inst-get-disjunct - Given WordInstanceNode, get the disjunct (LgAnd) used
-;
-(define (lg-inst-get-disjunct word-inst)
-	(car (cog-chase-link 'LgWordCset 'LgAnd word-inst))
-)
-
-; ---------------------------------------------------------------------
 ; lg-conn-type-match? - Check if two connectors type match
 ;
 (define (lg-conn-type-match? lconn rconn)

--- a/opencog/nlp/lg-dict/utilities.scm
+++ b/opencog/nlp/lg-dict/utilities.scm
@@ -1,0 +1,112 @@
+;(define-module (opencog nlp lg-dict))
+
+;(use-modules (opencog))
+;(use-modules (opencog extension))
+
+; ---------------------------------------------------------------------
+; lg-similar? - Handy function to quickly check if two words' LG entries intersect
+;
+(define-public (lg-similar? word1 word2)
+	(define (get-set w)
+ 		(define roots (filter (lambda (l) (equal? (cog-type l) 'LgWordCset)) (cog-incoming-set w)))
+		(map cog-get-partner roots (circular-list w))
+	)
+
+	; create the dictionary entry as needed
+	(lg-get-dict-entry word1)
+	(lg-get-dict-entry word2)
+	; check if the two word has common LG dict entry
+	(not (null? (lset-intersection equal? (get-set word1) (get-set word2))))
+)
+
+; ---------------------------------------------------------------------
+; lg-conn-get-type - Get the LgConnectorNode out of LgConnector link
+;
+(define (lg-conn-get-type conn)
+	(gar conn)
+)
+
+; ---------------------------------------------------------------------
+; lg-conn-get-dir - Get the LgConnDirNode out of LgConnector link
+;
+(define (lg-conn-get-dir conn)
+	(gdr conn)
+)
+
+; ---------------------------------------------------------------------
+; lg-inst-get-disjunct - Given WordInstanceNode, get the disjunct (LgAnd) used
+;
+(define (lg-inst-get-disjunct word-inst)
+	(car (cog-chase-link 'LgWordCset 'LgAnd word-inst))
+)
+
+; ---------------------------------------------------------------------
+; lg-conn-type-match? - Check if two connectors type match
+;
+(define (lg-conn-type-match? lconn rconn)
+	; helper function to do special handling of head/tail
+	(define (match-start lconn-list rconn-list)
+		(define lh (car lconn-list))
+		(define rh (car rconn-list))
+		(cond
+			((and (char-lower-case? lh) (char-lower-case? rh))
+				(if (equal? lh rh)
+					#f
+					(match-subscript (cdr lconn-list) (cdr rconn-list))
+				)
+			)
+			((char-lower-case? lh)
+				(match-subscript (cdr lconn-list) rconn-list)
+			)
+			((char-lower-case? rh)
+				(match-subscript lconn-list (cdr rconn-list))
+			)
+			(else
+				(match-subscript (cdr lconn-list) (cdr rconn-list))
+			)
+		)
+	)
+	; main function for matching subscripts
+	(define (match-subscript lconn-list rconn-list)
+		(cond
+			((or (null? lconn-list) (null? rconn-list))
+				#t
+			)
+			((or (char-upper-case? (car lconn-list)) (char-upper-case? (car rconn-list)))
+				(if (equal? (car lconn-list) (car rconn-list))
+					(match-subscript (cdr lconn-list) (cdr rconn-list))
+					#f
+				)
+			)
+			((equal? (car lconn-list) (car rconn-list))
+				(match-subscript (cdr lconn-list) (cdr rconn-list))
+			)
+			((or (equal? (car lconn-list) #\*) (equal? (car rconn-list) #\*))
+				(match-subscript (cdr lconn-list) (cdr rconn-list))
+			)
+			(else
+				#f
+			)
+		)
+	)
+	(match-start
+		(string->list (cog-name (lg-conn-get-type lconn)))
+		(string->list (cog-name (lg-conn-get-type rconn)))
+	)
+)
+
+; ---------------------------------------------------------------------
+; lg-conn-linkable? - Check if two connectors can be linked
+;
+(define (lg-conn-linkable? leftconn rightconn)
+	; check if the two connectors type match
+	(if (lg-conn-type-match? leftconn rightconn)
+		; check if the directions are correct
+		(if (and (equal? (lg-conn-get-dir leftconn) (LgConnDirNode "+")) (equal? (lg-conn-get-dir rightconn) (LgConnDirNode "-")))
+			#t
+			#f
+		)
+		#f
+	)
+)
+

--- a/opencog/nlp/sureal/surface-realization.scm
+++ b/opencog/nlp/sureal/surface-realization.scm
@@ -17,21 +17,6 @@
 (define pattern2 "; ##### START OF R2L #####")
 
 ; ---------------------------------------------------------------------
-; Handy function to quickly check if two words' LG entries intersect
-(define (lg-similar? word1 word2)
-    (define (get-set w)
-        (define roots (filter (lambda (l) (equal? (cog-type l) 'LgWordCset)) (cog-incoming-set w)))
-        (map cog-get-partner roots (circular-list w))
-    )
-
-    ; create the dictionary entry as needed
-    (lg-get-dict-entry word1)
-    (lg-get-dict-entry word2)
-    ; check if the two word has common LG dict entry
-    (not (null? (lset-intersection equal? (get-set word1) (get-set word2))))
-)
-
-; ---------------------------------------------------------------------
 ; Splits a string into substring delimited by the a pattern and returns a list
 ; of the substrings.
 ; TODO: make tail recursive, for efficency

--- a/opencog/nlp/types/atom_types.script
+++ b/opencog/nlp/types/atom_types.script
@@ -115,7 +115,7 @@ LG_CONNECTOR_NODE <- PREDICATE_NODE   // e.g. "MX"
 LG_CONN_MULTI_NODE <- NODE  // multi-connector "@"
 LG_CONN_DIR_NODE <- NODE    // e.g. "+"
 
-// Consists of the connector node, the dirction, and possibly the
+// Consists of the connector node, the direction, and possibly the
 // multi-connector node.
 LG_CONNECTOR <- LINK   // e.g. "MX+"
 
@@ -131,8 +131,16 @@ LG_AND <- LG_SEQ      // must be ordered! (like SEQUNTIAL_AND_LINK)
 LG_OR  <- OR_LINK     // Exclusive-OR, completely disjunctive.
 
 // Kind-of-like an EvaluationLink but different.
-// First atom must be a word node.
+// First atom must be a WordNode or WordInstanceNode.
 // Second atom must be a "connector set": that is, a collection of
-// LgConnectors, joined with LgOrLink, LgAndLink.
+// LgConnectors, joined with LgOr, LgAnd links.
 // Ideally, these are fully disjoined before use.
+// In the case of WordInstanceNode, it should always be a
+// LgAnd disjunct used in the corresponding sentence.
 LG_WORD_CSET <- LIST_LINK
+
+// For LG link instance of a specific parse of a sentence
+// LgLinkInstanceNode will be an instance of LinkGrammarRelationshipNode
+// and LgLinkInstanceLink will link the node to the original connectors
+LG_LINK_INSTANCE_NODE <- PREDICATE_NODE
+LG_LINK_INSTANCE_LINK <- LIST_LINK


### PR DESCRIPTION
* Added the atom types used in https://github.com/opencog/relex/pull/207
* Added some preliminary utilities.  Most of them will actually be needed inside the C++ code, so maybe they will be moved to C++ (on which language to put utility functions, I assume this will be a speed related design decision).