### PR TITLE
guile: reverted some module changes

### DIFF
--- a/lib/OpenCogAtomTypes.cmake
+++ b/lib/OpenCogAtomTypes.cmake
@@ -60,6 +60,7 @@ FILE(APPEND "${SCM_FILE}" "; generated from atom definitions in types.script by 
 FILE(APPEND "${SCM_FILE}" ";\n")
 FILE(APPEND "${SCM_FILE}" "; This file contains basic scheme wrappers for atom creation.\n")
 FILE(APPEND "${SCM_FILE}" ";\n")
+FILE(APPEND "${SCM_FILE}" "(define-module (opencog))\n")
 
 FILE(STRINGS "${SCRIPT_FILE}" TYPE_SCRIPT_CONTENTS)
 FOREACH (LINE ${TYPE_SCRIPT_CONTENTS})

--- a/opencog/atomspace/atom_types.script
+++ b/opencog/atomspace/atom_types.script
@@ -1,6 +1,6 @@
 //
-// Script for automatic "atom type" generation. For more more
-// information, consult the opencog/atomspace/README file.
+// Script for automatic "atom type" generation. For more information,
+// consult the opencog/atomspace/README file.
 //
 // Please note: some of the types below are used only via the scheme
 // bindings. Thus, just because you can comment some of these out, and

--- a/opencog/dynamics/attention/atom_types.script
+++ b/opencog/dynamics/attention/atom_types.script
@@ -1,5 +1,5 @@
 //
-// Script for automatic "atom type" generation. For more more information,
+// Script for automatic "atom type" generation. For more information,
 // consult  the documentation in the opencog/atomspace/README file.
 //
 // Please note: some of the types below are used only via the scheme bindings.

--- a/opencog/embodiment/AtomSpaceExtensions/atom_types.script
+++ b/opencog/embodiment/AtomSpaceExtensions/atom_types.script
@@ -1,5 +1,6 @@
 // ====================================================================
 // Embodiment atoms
+//
 
 PET_NODE <- OBJECT_NODE
 AVATAR_NODE <- OBJECT_NODE

--- a/opencog/guile/README
+++ b/opencog/guile/README
@@ -102,14 +102,17 @@ have to consult the individual scm files for more info.
 
 == Modules ==
 -------------
-Currently OpenCog's scheme functions are broken into 3 different scheme
-modules: (opencog), (opencog extension), and (opencog atomtypes).  Each
-one can be listed with the following code:
+Currently OpenCog's scheme functions are broken into 2 different scheme
+modules: (opencog), and (opencog extension).  Each one can be listed
+with the following code:
 
 (module-for-each (lambda (symbol value) (display symbol) (newline))
 (resolve-interface '(opencog)))
 
 Replace '(opencog) with the corresponding module name.
+
+Currently only the (opencog) module can be used in standalone guile (see
+examples/guile/basic.scm).
 
 
 == Core Functions ==

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -45,7 +45,8 @@ void SchemeSmob::init()
 	if (is_inited.test_and_set()) return;
 
 	init_smob_type();
-	register_procs();
+	scm_c_define_module("opencog", register_procs, NULL);
+	scm_c_use_module("opencog");
 
 	atomspace_fluid = scm_make_fluid();
 	atomspace_fluid = scm_permanent_object(atomspace_fluid);
@@ -183,7 +184,7 @@ void SchemeSmob::throw_exception(const char *msg, const char * func)
  #define C(X) ((SCM (*) ()) X)
 #endif
 
-void SchemeSmob::register_procs()
+void SchemeSmob::register_procs(void*)
 {
 	register_proc("cog-atom",              1, 0, 0, C(ss_atom));
 	register_proc("cog-handle",            1, 0, 0, C(ss_handle));

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -51,7 +51,7 @@ class SchemeSmob
 		};
 
 		static std::atomic_flag is_inited;
-		static void register_procs();
+		static void register_procs(void*);
 		static void register_proc(const char*, int, int, int, scm_t_subr);
 
 		// The cog_misc_tag are for all other opencog types, such

--- a/opencog/nlp/types/atom_types.script
+++ b/opencog/nlp/types/atom_types.script
@@ -1,6 +1,6 @@
 //
-// Script for automatic "atom type" generation. For more more
-// information, consult the opencog/atomspace/README file.
+// Script for automatic "atom type" generation. For more information,
+// consult the opencog/atomspace/README file.
 //
 // Please note: some of the types below are used only via the scheme
 // bindings. Thus, just because you can comment some of these out, and

--- a/opencog/nlp/viterbi/atom_types.script
+++ b/opencog/nlp/viterbi/atom_types.script
@@ -1,3 +1,4 @@
 // A pair, consisting of a sequence of unconnected connectors,
 // and a sequence of output words.
 LG_STATE_PAIR <- LIST_LINK
+

--- a/opencog/reasoning/pln/atom_types.script
+++ b/opencog/reasoning/pln/atom_types.script
@@ -1,5 +1,6 @@
 //
 // Assorted atom types that are used by PLN.
+//
 // TODO XXX: Review, and see if these are acutally being used.
 //
 PREDICTIVE_IMPLICATION_LINK <- ORDERED_LINK

--- a/opencog/scm/opencog.scm
+++ b/opencog/scm/opencog.scm
@@ -26,6 +26,7 @@
 
 ; Load other grunge too
 ; Lots of these things should probably be modules ...
+; Also they need to be defined "public" to be useable in guile...
 (load-from-path "config.scm")
 (load-from-path "utilities.scm")
 (load-from-path "apply.scm")

--- a/opencog/spacetime/atom_types.script
+++ b/opencog/spacetime/atom_types.script
@@ -1,6 +1,7 @@
 //
 // Atom type definitions for the varouts space & time server types.
 //
+
 // ====================================================================
 // SpaceServer atoms
 SPACE_MAP_NODE <- NODE
@@ -9,7 +10,7 @@ BLOCK_ENTITY_NODE <- OBJECT_NODE
 STRUCTURE_NODE <- OBJECT_NODE
 IMAGINARY_STRUCTURE_NODE <- OBJECT_NODE
 
-// Time-related atoms:
+// Time-related atoms
 TIME_NODE <- NODE
 AT_TIME_LINK <- ORDERED_LINK
 LATEST_LINK <- ORDERED_LINK


### PR DESCRIPTION
Reverted some changes to allow scheme modules usage within cogserver.  Still works with standalone guile.

Doing it this way because loading "opencog.scm" in opencog.conf does cause weird conflicts.