### PR TITLE
SuReal: use original LG connectors usage for word replacement

### DIFF
--- a/lib/opencog.conf
+++ b/lib/opencog.conf
@@ -87,6 +87,7 @@ SCM_PRELOAD           = scm/config.scm,
                         nlp/relex2logic/utilities.scm,
                         nlp/relex2logic/rule-helpers.scm,
                         nlp/relex2logic/post-processing.scm,
+                        nlp/lg-dict/utilities.scm,
                         nlp/sureal/surface-realization.scm
 #                        viterbi/viterbi_types.scm
 

--- a/opencog/guile/SchemeEval.h
+++ b/opencog/guile/SchemeEval.h
@@ -80,6 +80,7 @@ class SchemeEval : public GenericEval
 		static void * c_wrap_poll(void *);
 		const std::string *pexpr;
 		std::string answer;
+		HandleSeq qanswer;
 		SCM _rc;
 		bool _eval_done;
 		bool _poll_done;
@@ -92,6 +93,7 @@ class SchemeEval : public GenericEval
 		// Straight-up evaluation
 		SCM do_scm_eval(SCM, SCM (*)(void *));
 		static void * c_wrap_eval_h(void *);
+		static void * c_wrap_eval_q(void *);
 
 		// Handle apply
 		Handle do_apply(const std::string& func, Handle& varargs);
@@ -140,6 +142,7 @@ class SchemeEval : public GenericEval
 
 		Handle eval_h(const std::string&);
 		Handle eval_h(const std::stringstream& ss) { return eval_h(ss.str()); }
+		HandleSeq eval_q(const std::string&);
 
 		Handle apply(const std::string& func, Handle varargs);
 		std::string apply_generic(const std::string& func, Handle& varargs);

--- a/opencog/nlp/lg-dict/LGDictExpContainer.cc
+++ b/opencog/nlp/lg-dict/LGDictExpContainer.cc
@@ -199,47 +199,6 @@ void LGDictExpContainer::basic_normal_order()
 }
 
 /**
- * Output the scm representation of the LG dictionary entry.
- *
- * @return the scm string
- */
-std::string LGDictExpContainer::to_scm_string()
-{
-    if (m_type == CONNECTOR_type)
-    {
-        if (m_string == "OPTIONAL")
-            return "(LgConnector (LgConnectorNode \"0\"))\n";
-
-        std::stringstream ss;
-        ss << "(LgConnector (LgConnectorNode ";
-        ss << "\"" << m_string << "\") ";
-        ss << "(LgConnDirNode \"" << m_direction << "\") ";
-
-        if (m_multi)
-            ss << "(LgConnMultiNode \"@\")";
-
-        ss << ")\n";
-
-        return ss.str();
-    }
-
-    std::string alist;
-
-    if (m_type == AND_type)
-        alist = "(LgAnd ";
-
-    if (m_type == OR_type)
-        alist = "(LgOr ";
-
-    for (auto& exp : m_subexps)
-        alist += exp.to_scm_string();
-
-    alist.append(")\n");
-
-    return alist;
-}
-
-/**
  * Create the OpenCog atom for the LG dictionary expression.
  *
  * @param as   pointer to the AtomSpace

--- a/opencog/nlp/lg-dict/LGDictExpContainer.h
+++ b/opencog/nlp/lg-dict/LGDictExpContainer.h
@@ -44,7 +44,6 @@ public:
     LGDictExpContainer(Exp_type t, Exp* exp) throw (InvalidParamException);
     LGDictExpContainer(Exp_type t, std::vector<LGDictExpContainer> s) throw (InvalidParamException);
 
-    std::string to_scm_string();
     Handle to_handle(AtomSpace* as);
 
 private:

--- a/opencog/nlp/lg-dict/LGDictReader.cc
+++ b/opencog/nlp/lg-dict/LGDictReader.cc
@@ -37,7 +37,7 @@ using namespace opencog;
  * @param pAS     the AtomSpace where atoms will be created
  */
 LGDictReader::LGDictReader(Dictionary pDict, AtomSpace* pAS)
-    : _dictionary(pDict), _as(pAS), _scm_eval(new SchemeEval(pAS))
+    : _dictionary(pDict), _as(pAS)
 {
 
 }
@@ -47,7 +47,7 @@ LGDictReader::LGDictReader(Dictionary pDict, AtomSpace* pAS)
  */
 LGDictReader::~LGDictReader()
 {
-    delete _scm_eval;
+
 }
 
 /**
@@ -94,31 +94,6 @@ Handle LGDictReader::getAtom(const std::string& word)
     free_lookup_list(_dictionary, dn_head);
 
     return _as->addLink(SET_LINK, outgoing);
-
-#ifdef LG_OLD_SCM_METHOD
-    std::string set = "(SetLink\n";
-
-    for (Dict_node* dn = dn_head; dn; dn = dn->right)
-    {
-        Exp* exp = dn->exp;
-
-        // First atom at the front of the outgoing set is the word itself.
-        // Second atom is the first disjuct that must be fulfilled.
-        std::string word_cset = " (LgWordCset (WordNode \"";
-        word_cset += word;
-        word_cset += "\")\n";
-        word_cset += lg_exp_to_container(exp).to_scm_string();
-        word_cset += ")\n";
-
-        set += word_cset;
-    }
-
-    set += ")\n";
-
-    free_lookup_list(_dictionary, dn_head);
-
-    return _scm_eval->eval_h(set);
-#endif
 }
 
 /**

--- a/opencog/nlp/lg-dict/LGDictReader.h
+++ b/opencog/nlp/lg-dict/LGDictReader.h
@@ -27,7 +27,6 @@
 #include <link-grammar/dict-api.h>
 
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/guile/SchemeEval.h>
 
 #include "LGDictExpContainer.h"
 
@@ -53,7 +52,6 @@ private:
 
     Dictionary _dictionary;
     AtomSpace* _as;
-    SchemeEval* _scm_eval;
 };
 
 }

--- a/opencog/nlp/lg-dict/utilities.scm
+++ b/opencog/nlp/lg-dict/utilities.scm
@@ -91,14 +91,14 @@
 ; ---------------------------------------------------------------------
 ; lg-conn-linkable? - Check if two connectors can be linked
 ;
-(define (lg-conn-linkable? leftconn rightconn)
+; The two connectors must have different directions, but does not matter
+; which one is + and which one is -.
+;
+(define (lg-conn-linkable? conn1 conn2)
 	; check if the two connectors type match
-	(if (lg-conn-type-match? leftconn rightconn)
+	(if (lg-conn-type-match? conn1 conn2)
 		; check if the directions are correct
-		(if (and (equal? (lg-conn-get-dir leftconn) (LgConnDirNode "+")) (equal? (lg-conn-get-dir rightconn) (LgConnDirNode "-")))
-			#t
-			#f
-		)
+		(not (equal? (lg-conn-get-dir conn1) (lg-conn-get-dir conn2)))
 		#f
 	)
 )

--- a/opencog/nlp/microplanning/anaphora-noun-item.scm
+++ b/opencog/nlp/microplanning/anaphora-noun-item.scm
@@ -172,7 +172,6 @@
 (define-method (get-lexical-node (ni <noun-item>))
 	(define (determine-lexical)
 		(define the-noun-node (get-noun-node ni))
-		(define the-noun-word-node (car (word-inst-get-word (r2l-get-word-inst the-noun-node))))
 		; XXX also accept links that inherit the abstracted version? currently not doing that
 		; since the anchor is also a ConceptNode, cog-get-link will return each link twice, so need to delete duplicates
 		(define all-inheritances (delete-duplicates (cog-get-link 'InheritanceLink 'ConceptNode the-noun-node)))
@@ -182,10 +181,6 @@
 
 			; remove links in subsets that are not about a noun
 			(set! subsets (filter (lambda (l) (word-inst-is-noun? (r2l-get-word-inst (gar l)))) subsets))
-			
-			; remove links to words with incompatible LG dictionary entry
-			; TODO probably need more advanced checking here
-			(set! subsets (filter (lambda (l) (lg-similar? (car (word-inst-get-word (r2l-get-word-inst (gar l)))) the-noun-word-node)) subsets))
 		
 			; remove close to false or low confidence links base on TruthValue
 			(set! subsets (filter (lambda (l) (and (> (tv-mean (cog-tv l)) 0.5) (> (tv-conf (cog-tv l)) 0.5))) subsets))

--- a/opencog/nlp/microplanning/anaphora.scm
+++ b/opencog/nlp/microplanning/anaphora.scm
@@ -81,9 +81,7 @@
 				       (temp-set-link (SetLink (get-utterance-link ut chunk) chunk)))
 					; failed to SuReal? bring back the old chunk
 					(if (null? (sureal temp-set-link))
-						(being (display "Reverting change")(newline)
 						(mod-chunk results-set index (get-chunk inputs-set index))
-						)
 					)
 				
 					(cog-delete temp-set-link)

--- a/opencog/nlp/sureal/README.md
+++ b/opencog/nlp/sureal/README.md
@@ -1,9 +1,74 @@
 # Surface Realization
 
-Functions for surface realization of output from micro-planner's output.
-The main function is sureal which takes in a `SetLink` and returns a
-sentence. Presently in alpha stage of development.
+Functions for surface realization (SuReal) of output from microplanner's output.
+The microplanner also uses SuReal to determine whether a chunk (a set of atoms)
+can be translated into a sentence, so the two projects are dependent on each
+other.
+
+The main function is `sureal` which takes in a `SetLink` and returns a
+sentence.
 
 The words used in the input `SetLink` need to have the corresponding `WordNode`
 or `WordInstanceNode` before calling `sureal`.
+
+For example, you can do
+
+```
+(r2l "He eats.")
+(r2l "He eats quickly.")
+(WordNode "she")
+(WordNode "drinks")
+(sureal (SetLink (EvaluationLink (PredicateNode "drinks") (ListLink (ConceptNode "she")))))
+```
+which will return all possible sentence is words list, like
+
+```
+((she drinks .) (she drinks quickly .))
+```
+
+## Algorithm
+
+SuReal does pattern matching on existing sentences in the atomspace.  Existing
+sentences mean those that were inputed with `(r2l ...)` calls.  The `r2l` call
+will uses LG, RelEx, and RelEx2Logic to generate the necessary atoms.
+
+Especially important is the LG outputs.  For each sentence, a bunch of links of
+the style
+
+```
+(EvaluationLink (stv 1.0 1.0)
+   (LgLinkInstanceNode "Ds**c@4432ef3-3c4e-42a9-8072-9975d168a12c")
+   (ListLink
+      (WordInstanceNode "the@da65d87c-22b9-4af2-89f4-60042816c579")
+      (WordInstanceNode "man@1a6d58eb-e9c0-4c8e-af01-8d4304e3430c")
+   )
+)
+(LgLinkInstanceLink
+   (LgLinkInstanceNode "Ds**c@4432ef3-3c4e-42a9-8072-9975d168a12c")
+   (LgConnector
+      (LgConnectorNode "D")
+      (LgConnDirNode "+")
+   )
+   (LgConnector
+      (LgConnectorNode "Ds**c")
+      (LgConnDirNode "-")
+   )
+)
+(EvaluationLink
+   (PredicateNode "LgLinkInstanceType"
+   (ListLink
+      (LgLinkInstanceNode "Ds**c@4432ef3-3c4e-42a9-8072-9975d168a12c")
+      (LinkGrammarRelaationshipNode "Ds**c")
+   )
+)
+
+```
+
+are generated.  They contain all the information of the LG connectors used for
+a particalar word of a particalar sentence.
+
+Given a new `SetLink` as input, SuReal matches each atom in the link to the
+structure inside the old sentences.  In addition, for each node that it
+matches, it check the word corresponding to the node and see if its LG disjuncts
+agree with the usage of the word it is replacing.
 

--- a/opencog/nlp/sureal/SuRealModule.cc
+++ b/opencog/nlp/sureal/SuRealModule.cc
@@ -179,10 +179,10 @@ HandleSeq SuRealModule::do_sureal_match(Handle h)
             {
                 for (auto& am: appendMaps)
                 {
-                    // at this point, we would know nothing in em & am would
-                    // map the same variable because they are from two
-                    // disconnected clauses.  Instead, we want to check to make
-                    // sure no two variables get mapping to the same node.
+                    // at this point, we know nothing in em & am would map the
+                    // same variable because they are from two disconnected
+                    // clauses.  Instead, we want to check to make sure no two
+                    // variables get mapping to the same node.
                     auto checker = [&](const std::pair<Handle, Handle>& ekv)
                     {
                         return std::any_of(am.begin(), am.end(),

--- a/opencog/nlp/sureal/SuRealPMCB.cc
+++ b/opencog/nlp/sureal/SuRealPMCB.cc
@@ -106,10 +106,18 @@ bool SuRealPMCB::variable_match(Handle &hPat, Handle &hSoln)
 
     std::for_each(qOr.begin(), qOr.end(), insertHelper);
 
+    logger().debug("[SuReal] Looking at %d disjuncts of %s", qDisjuncts.size(), hPat->toShortString().c_str());
+
     // for each disjunct, get its outgoing set, and match 1-to-1 with qConns
     auto matchHelper = [&](const Handle& hDisjunct)
     {
-        HandleSeq qSourceConns = _as->getOutgoing(hDisjunct);
+        HandleSeq qSourceConns;
+
+        // check if hDisjunct is LgAnd or just a lone connector
+        if (hDisjunct->getType() == LG_AND)
+            qSourceConns = _as->getOutgoing(hDisjunct);
+        else
+            qSourceConns.push_back(hDisjunct);
 
         if (qSourceConns.size() != qTargetConns.size())
             return false;

--- a/opencog/nlp/sureal/SuRealPMCB.h
+++ b/opencog/nlp/sureal/SuRealPMCB.h
@@ -26,6 +26,7 @@
 
 
 #include <opencog/query/DefaultPatternMatchCB.h>
+#include <opencog/guile/SchemeEval.h>
 
 
 namespace opencog
@@ -43,6 +44,7 @@ class SuRealPMCB : public DefaultPatternMatchCB
 {
 public:
     SuRealPMCB(AtomSpace* as, std::set<Handle> vars);
+    ~SuRealPMCB();
 
     virtual bool variable_match(Handle& hPat, Handle& hSoln);
     virtual bool clause_match(Handle& pattrn_link_h, Handle& grnd_link_h);
@@ -59,6 +61,8 @@ private:
     virtual Handle find_starter(Handle, size_t&, Handle&, size_t&);
 
     std::set<Handle> m_vars;   // store nodes that are variables
+
+    SchemeEval* m_eval;
 };
 
 }

--- a/opencog/nlp/sureal/surface-realization.scm
+++ b/opencog/nlp/sureal/surface-realization.scm
@@ -200,8 +200,8 @@
         (define mappings (sureal-get-mapping itpr))
         ; helper to generate sentence using one mapping
         (define (construct-sntc-mapping w-seq vars mapping)
-        	; make a clone of the w-seq to avoid changing when list-set!
-        	(define w-seq-copy (list-copy w-seq))
+            ; make a clone of the w-seq to avoid changing when list-set!
+            (define w-seq-copy (list-copy w-seq))
             (for-each
                 (lambda (old-logic-node new-logic-node)
                     (let ((old-word-inst (r2l-get-word-inst old-logic-node))

--- a/opencog/nlp/sureal/surface-realization.scm
+++ b/opencog/nlp/sureal/surface-realization.scm
@@ -104,13 +104,19 @@
                 (eval-string (list-ref a-list 0))
                 (let* ((parse-name (parse-str (list-ref a-list 0)))
                        (parse-node (ParseNode parse-name)))
-                    ; generate the LG dictionary entries for each word
-                    (let ((words (parse-get-words parse-node)))
-                        (map-word-instances
-                            (lambda (word-inst) (map-word-node lg-get-dict-entry word-inst))
-                            parse-node
-                        )
-                    )
+;
+; XXX not really necessary at this point since we will only need the LG
+; entries for the word-inst, which is emitted by the RelEx server already.
+; The full LG disjuncts entries are needed only by SuReal, which already
+; calls (lg-get-dict-entry ...) on its node.
+;
+;                    ; generate the LG dictionary entries for each word
+;                    (let ((words (parse-get-words parse-node)))
+;                        (map-word-instances
+;                            (lambda (word-inst) (map-word-node lg-get-dict-entry word-inst))
+;                            parse-node
+;                        )
+;                    )
                     (ReferenceLink 
                         (InterpretationNode (string-append parse-name "_interpretation_$X"))
                         ; The function in the SetLink returns a list of outputs that

--- a/opencog/nlp/sureal/surface-realization.scm
+++ b/opencog/nlp/sureal/surface-realization.scm
@@ -200,6 +200,8 @@
         (define mappings (sureal-get-mapping itpr))
         ; helper to generate sentence using one mapping
         (define (construct-sntc-mapping w-seq vars mapping)
+        	; make a clone of the w-seq to avoid changing when list-set!
+        	(define w-seq-copy (list-copy w-seq))
             (for-each
                 (lambda (old-logic-node new-logic-node)
                     (let ((old-word-inst (r2l-get-word-inst old-logic-node))
@@ -213,8 +215,8 @@
                                 (lambda (x idx)
                                     (if (equal? x old-word-inst)
                                         (if (null? new-word-inst)
-                                            (list-set! w-seq idx new-word)
-                                            (list-set! w-seq idx new-word-inst)
+                                            (list-set! w-seq-copy idx new-word)
+                                            (list-set! w-seq-copy idx new-word-inst)
                                         )
                                     )
                                 )
@@ -235,7 +237,7 @@
                         (cog-name w)
                     )
                 )
-                w-seq
+                w-seq-copy
             )
         )
 

--- a/tests/scm/BasicSCMUTest.cxxtest
+++ b/tests/scm/BasicSCMUTest.cxxtest
@@ -307,20 +307,6 @@ void BasicSCMUTest::check_link(const char * tipo, Type type,
 	eval->clear_pending();
 	TSM_ASSERT("Failed to create a link", !eval_err);
 
-	HandleSeq links;
-	as->getHandlesByType(back_inserter(links), type, true);
-	//printf("Number of links found: %d\n",links.size());
-	HandleSeq::const_iterator i;
-	for (i = links.begin(); i != links.end(); ++i)
-	{
-		TruthValuePtr tv = as->getTV(*i);
-		float m = tv->getMean();
-		float c = tv->getConfidence();
-		TS_ASSERT_LESS_THAN_EQUALS(fabs(m - truth), 1.0e-6);
-		TS_ASSERT_LESS_THAN_EQUALS(fabs(c - conf), 1.0e-6);
-		//printf("Link TruthValue: %f -- %f\n", m, c);
-	}
-
 	Type t1 = classserver().getType(nodename1);
 	Handle h1 = as->getHandle(t1, value1);
 	TSM_ASSERT("Failed to find handle", h1 != NULL);
@@ -334,6 +320,30 @@ void BasicSCMUTest::check_link(const char * tipo, Type type,
 
 	NodePtr n2 = NodeCast(h2);
 	TSM_ASSERT("Failed to find node", n2 != NULL);
+
+	HandleSeq links;
+	as->getHandlesByType(back_inserter(links), type, true);
+	//printf("Number of links found: %d\n",links.size());
+	HandleSeq::const_iterator i;
+	for (i = links.begin(); i != links.end(); ++i)
+	{
+		TruthValuePtr tv = as->getTV(*i);
+		float m = tv->getMean();
+		float c = tv->getConfidence();
+		TS_ASSERT_LESS_THAN_EQUALS(fabs(m - truth), 1.0e-6);
+		TS_ASSERT_LESS_THAN_EQUALS(fabs(c - conf), 1.0e-6);
+		//printf("Link TruthValue: %f -- %f\n", m, c);
+
+		// Test the eval_q function also -- it returns a HandleSeq.
+		snprintf(buff, 500, "(cog-outgoing-set (cog-atom %lu))", (*i).value());
+		HandleSeq q = eval->eval_q(buff);
+
+		eval_err = eval->eval_error();
+		eval->clear_pending();
+		TSM_ASSERT("Failed to eval_q", !eval_err);
+		TSM_ASSERT("Failed to get correct link's outgoing set size", q.size() == 2);
+		TSM_ASSERT("Failed to get the correct link's outgoing set", q[0] == h1 && q[1] == h2);
+	}
 }
 
 // ============================================================


### PR DESCRIPTION
This will make SuReal easier to use.  For example, given
```
(r2l "He drinks.")
```
it is now possible to generate `I eat.`, `John danced.`, etc.

I realized LG entries are actually a bit too forgiving in some cases.   For example, given
```
(r2l "The bird flew upward.")
```
then giving SuReal
```
(WordNode "Sam")
(WordNode "laughed")
(sureal (SetLink (EvaluationLink (PredicateNode "laughed") (ListLink (ConceptNode "Sam")))))
```
will generate
```
((the Sam laughed upward .))
```
because according to LG this is a valid sentence.... maybe when there are multiple "Sam" and the laughing is toward the sky...

# TODO
* update unit tests (done, in upcoming pull request)
* change to use native C++ code instead of scheme code with eval_h, eval_q

# To think about
* is it possible to have the microplanner not depends on using SuReal to test whether a "chunk" of atoms is "sayable"?  Because right now with SuReal doing more works, the microplanner calling SuReal repeatedly is quite slow.  It will be even slower when there is a huge atomspace for SuReal to pattern match against.
