### PR TITLE
Remove cause of warnings from unused functions

### DIFF
--- a/lib/zmq/zhelpers.hpp
+++ b/lib/zmq/zhelpers.hpp
@@ -62,7 +62,7 @@
 #endif
 
 //  Receive 0MQ string from socket and convert into string
-static std::string
+inline std::string
 s_recv (zmq::socket_t & socket) {
 
     zmq::message_t message;
@@ -72,7 +72,7 @@ s_recv (zmq::socket_t & socket) {
 }
 
 //  Convert string to 0MQ string and send to socket
-static bool
+inline bool
 s_send (zmq::socket_t & socket, const std::string & string) {
 
     zmq::message_t message(string.size());
@@ -83,7 +83,7 @@ s_send (zmq::socket_t & socket, const std::string & string) {
 }
 
 //  Sends string as 0MQ string, as multipart non-terminal
-static bool
+inline bool
 s_sendmore (zmq::socket_t & socket, const std::string & string) {
 
     zmq::message_t message(string.size());
@@ -95,7 +95,7 @@ s_sendmore (zmq::socket_t & socket, const std::string & string) {
 
 //  Receives all message parts from socket, prints neatly
 //
-static void
+inline void
 s_dump (zmq::socket_t & socket)
 {
     std::cout << "----------------------------------------" << std::endl;
@@ -151,7 +151,7 @@ s_set_id (zmq::socket_t & socket)
 
 //  Report 0MQ version number
 //
-static void
+inline void
 s_version (void)
 {
     int major, minor, patch;
@@ -159,7 +159,7 @@ s_version (void)
     std::cout << "Current 0MQ version is " << major << "." << minor << "." << patch << std::endl;
 }
 
-static void
+inline void
 s_version_assert (int want_major, int want_minor)
 {
     int major, minor, patch;
@@ -174,7 +174,7 @@ s_version_assert (int want_major, int want_minor)
 }
 
 //  Return current system clock as milliseconds
-static int64_t
+inline int64_t
 s_clock (void)
 {
 #if (defined (__WINDOWS__))
@@ -189,7 +189,7 @@ s_clock (void)
 }
 
 //  Sleep for a number of milliseconds
-static void
+inline void
 s_sleep (int msecs)
 {
 #if (defined (__WINDOWS__))
@@ -202,7 +202,7 @@ s_sleep (int msecs)
 #endif
 }
 
-static void
+inline void
 s_console (const char *format, ...)
 {
     time_t curtime = time (NULL);
@@ -227,12 +227,12 @@ s_console (const char *format, ...)
 //  zmq_poll.
 
 static int s_interrupted = 0;
-static void s_signal_handler (int signal_value)
+inline void s_signal_handler (int signal_value)
 {
     s_interrupted = 1;
 }
 
-static void s_catch_signals ()
+inline void s_catch_signals ()
 {
 #if (!defined(__WINDOWS__))
     struct sigaction action;

--- a/opencog/cython/CMakeLists.txt
+++ b/opencog/cython/CMakeLists.txt
@@ -3,7 +3,11 @@
 # to avoid nasty compiler warnings about aliasing.  Cython explicitly
 # performs aliasing, in order to emulate python object  inheritance.
 # See, for example, https://groups.google.com/forum/#!topic/cython-users/JV1-KvIUeIg
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-strict-aliasing")
+#
+# Also suppressing unused function warnings for static functions since Cython
+# generates a static function that it puts in a header which causes this warning
+# to appear whenever anyone includes the header and doesn't use all the functions.
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-strict-aliasing -Wno-unused-function")
 
 ADD_SUBDIRECTORY (opencog)
 


### PR DESCRIPTION
The functions in helpers.hpp (which comes from the ZeroMQ examples and is used in a few of the tests) were declared "static" instead of "inline". This has the effect of causing warnings when they are not used. Static is used when you don't want to allow external linkage to a function, so this warning is to let the developer know that they can remove that code.

In this case, the static is in a header file. In general, there is hardly ever reason to put a static function declaration in a header file.

Changing "static" to "inline" here, which does not affect semantics because there are no local static variable decorations in these functions, makes the warnings go away.