### PR TITLE
Modify unit tests to update TV after atom creation

### DIFF
--- a/tests/atomspace/AtomSpaceAsyncUTest.cxxtest
+++ b/tests/atomspace/AtomSpaceAsyncUTest.cxxtest
@@ -76,7 +76,7 @@ private:
 public:
     AtomSpaceAsyncUTest()
     {
-        // Current atomspace can to 50K or 100K atoms/sec, so the 
+        // Current atomspace can to 50K or 100K atoms/sec, so the
         // below should run for at least 2 to 5 seconds each time.
         n_threads = 20;
         num_atoms = 13000;
@@ -167,7 +167,7 @@ public:
         /* Since we're adding *exactly* the same atom, we should get a tv-merged signal */
         logger().debug("before second atom add");
         TruthValuePtr tv(SimpleTruthValue::createTV(0.5, 1.0));
-        atomSpace->addNode(NUMBER_NODE, "1", tv);
+        atomSpace->addNode(NUMBER_NODE, "1")->setTruthValue(tv);
         TS_ASSERT(__testSignalsCounter == 1111);
         TS_ASSERT(atomSpace->getSize() == 1);
 
@@ -228,7 +228,7 @@ public:
             counter++;
 
             TruthValuePtr tv(SimpleTruthValue::createTV(((double) i) / ((double) N), i));
-            atomSpace->addNode(t, oss.str(), tv); 
+            atomSpace->addNode(t, oss.str())->setTruthValue(tv);
         }
     }
 
@@ -273,7 +273,7 @@ public:
             //std::cout << "removing " << oss.str() << std::endl;
             HandleSeq hs;
             atomSpace->getHandlesByName(back_inserter(hs), oss.str(), NODE);
-            TS_ASSERT_EQUALS(hs.size(), 1); 
+            TS_ASSERT_EQUALS(hs.size(), 1);
             if (hs.size() != 0) {
                 //std::cout << " handle " << hs[0] << std::endl;
                 atomSpace->purgeAtom(hs[0], true);
@@ -295,7 +295,7 @@ public:
         TS_ASSERT_EQUALS(size, 0);
         size = atomSpace->getSize();
     }
-    
+
 
     // =================================================================
     // when signals issued in multi-threaded env, make sure all of them arrive.
@@ -328,7 +328,7 @@ public:
         TS_ASSERT_EQUALS((int) __totalAdded, num_atoms);
         // subtract 1, because first time through, there is no change signal,
         // only an add signal.
-        TS_ASSERT_EQUALS((int) __totalChanged, num_atoms * (n_threads-1));
+        TS_ASSERT_EQUALS((int) __totalChanged, num_atoms * n_threads);
     }
 
     // =================================================================
@@ -343,14 +343,14 @@ public:
 
             HandleSeq hs;
             atomSpace->getHandlesByName(back_inserter(hs), oss.str(), NODE);
-            TS_ASSERT_EQUALS(hs.size(), 1); 
+            TS_ASSERT_EQUALS(hs.size(), 1);
             Handle h = hs[0];
 
             bogus ++;
             bogus %= N;
 
             TruthValuePtr tv(SimpleTruthValue::createTV((double) bogus / (double) N, bogus+i));
-            h->setTruthValue(tv); 
+            h->setTruthValue(tv);
         }
     }
 
@@ -407,7 +407,7 @@ public:
 
             HandleSeq hs;
             atomSpace->getHandlesByName(back_inserter(hs), oss.str(), NODE);
-            TS_ASSERT_EQUALS(hs.size(), 1); 
+            TS_ASSERT_EQUALS(hs.size(), 1);
             Handle ha = hs[0];
 
             std::ostringstream ossb;
@@ -415,7 +415,7 @@ public:
 
             HandleSeq hsb;
             atomSpace->getHandlesByName(back_inserter(hsb), ossb.str(), NODE);
-            TS_ASSERT_EQUALS(hsb.size(), 1); 
+            TS_ASSERT_EQUALS(hsb.size(), 1);
 
             bogus ++;
             bogus %= N;
@@ -424,7 +424,7 @@ public:
 
             Type t = LIST_LINK;
             hs.push_back(ha);
-            atomSpace->addLink(t, hs, tv); 
+            atomSpace->addLink(t, hs)->setTruthValue(tv);
         }
     }
 
@@ -452,7 +452,7 @@ public:
         TS_ASSERT_EQUALS(size, 2*num_atoms);
 
         TS_ASSERT_EQUALS((int) __totalAdded, num_atoms);
-        TS_ASSERT_EQUALS((int) __totalChanged, num_atoms * (n_threads-1)); // lots!
+        TS_ASSERT_EQUALS((int) __totalChanged, num_atoms * n_threads); // lots!
     }
 
     // =================================================================
@@ -491,9 +491,9 @@ public:
 
         // Add a node to the AttentionalFocus
         Handle h = atomSpace->addNode(CONCEPT_NODE,
-                                      "test",
-                                      SimpleTruthValue::createTV(0.01,
-                                      SimpleTruthValue::confidenceToCount(1)));
+                                      "test");
+        h->setTruthValue(SimpleTruthValue::createTV(0.01,
+                         SimpleTruthValue::confidenceToCount(1)));
         atomSpace->setSTI(h, 200);
         TS_ASSERT(__testAFSignalsCounter == 1);
 
@@ -523,7 +523,7 @@ public:
 
             Handle hb = atomSpace->addNode(CONCEPT_NODE, ossb.str());
 
-            Handle hl = atomSpace->addLink(LIST_LINK, ha, hb); 
+            Handle hl = atomSpace->addLink(LIST_LINK, ha, hb);
 
             // The goal here is that each ListLink will have an
             // incoming set of size n_threads.  This should make a
@@ -535,7 +535,7 @@ public:
             bogus ++;
             bogus %= N;
             TruthValuePtr tv(SimpleTruthValue::createTV((double) bogus / (double) N, bogus+i));
-            atomSpace->addLink(EVALUATION_LINK, hp, hl, tv); 
+            atomSpace->addLink(EVALUATION_LINK, hp, hl)->setTruthValue(tv);
         }
     }
 
@@ -565,7 +565,7 @@ public:
     // one-another.
     //
     // argument is a pointer, else a build break. See
-    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57716   and 
+    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57716   and
     // http://stackoverflow.com/questions/15235885/invalid-initialization-of-non-const-reference-with-c11-thread
     void threadedEvalRemove(int thread_id, HandleSeq* seq)
     {
@@ -585,7 +585,7 @@ public:
         //logger().debug("atomPurged: %s", h->toString().c_str());
         __totalPurged += 1;
 
-        // A lock is released, to call this signal handler, and is 
+        // A lock is released, to call this signal handler, and is
         // then re-acquired. Perhaps a yield can help scramble things
         // up a bit. So try to stall.
         for (int i=0; i<3*n_threads; i++)
@@ -640,7 +640,7 @@ public:
             //std::cout << "removing " << oss.str() << std::endl;
             HandleSeq hs;
             atomSpace->getHandlesByName(back_inserter(hs), oss.str(), CONCEPT_NODE);
-            TS_ASSERT_EQUALS(hs.size(), 1); 
+            TS_ASSERT_EQUALS(hs.size(), 1);
             if (hs.size() != 0) {
                 //std::cout << " handle " << hs[0] << std::endl;
                 atomSpace->purgeAtom(hs[0], true);
@@ -672,7 +672,7 @@ public:
             // trying to erase the links below.
 #define NEST 16
             for (int k=0; k<NEST; k++) {
-                Handle hl = atomSpace->addLink(LIST_LINK, hs); 
+                Handle hl = atomSpace->addLink(LIST_LINK, hs);
                 hs.push_back(hl);
             }
         }
@@ -683,7 +683,7 @@ public:
         std::cout << "Total created:" << size << std::endl;
         TS_ASSERT_EQUALS(size, (n_threads+NEST)*num_atoms);
 
-        // Now start removing ... 
+        // Now start removing ...
         __totalPurged = 0;
         __altTotalPurged = 0;
 

--- a/tests/atomspace/AtomSpaceImplUTest.cxxtest
+++ b/tests/atomspace/AtomSpaceImplUTest.cxxtest
@@ -110,26 +110,31 @@ HandleSeq createSimpleGraph(AtomSpaceImpl* atomSpace, const char* baseName)
     TruthValuePtr tv2 = SimpleTruthValue::createTV(0.001f, 0.00001f);
     TruthValuePtr tv3 = SimpleTruthValue::createTV(0.5f, 0.99f);
     buf[baseNameLength] = '1';
-    Handle h1 = atomSpace->addNode(CONCEPT_NODE, buf, tv1);
+    Handle h1 = atomSpace->addNode(CONCEPT_NODE, buf);
+    h1->setTruthValue(tv1);
     setSTI(h1, AV1_STI);
     setLTI(h1, AV1_LTI);
     buf[baseNameLength] = '2';
-    Handle h2 = atomSpace->addNode(CONCEPT_NODE, buf, tv2);
+    Handle h2 = atomSpace->addNode(CONCEPT_NODE, buf);
+    h2->setTruthValue(tv2);
     setSTI(h2, AV2_STI);
     setLTI(h2, AV2_LTI);
     buf[baseNameLength] = '3';
-    Handle h3 = atomSpace->addNode(CONCEPT_NODE, buf, tv3);
+    Handle h3 = atomSpace->addNode(CONCEPT_NODE, buf);
+    h3->setTruthValue(tv3);
     setSTI(h3, AV3_STI);
     setLTI(h3, AV3_LTI);
 
     HandleSeq outgoing1;
     outgoing1.push_back(h2);
     outgoing1.push_back(h3);
-    Handle l1 = atomSpace->addLink(LIST_LINK, outgoing1, tv1);
+    Handle l1 = atomSpace->addLink(LIST_LINK, outgoing1);
+    l1->setTruthValue(tv1);
     HandleSeq outgoing2;
     outgoing2.push_back(h1);
     outgoing2.push_back(l1);
-    Handle l2 = atomSpace->addLink(EVALUATION_LINK, outgoing2, tv2);
+    Handle l2 = atomSpace->addLink(EVALUATION_LINK, outgoing2);
+    l2->setTruthValue(tv2);
 
     testAtoms.push_back(h1);
     testAtoms.push_back(h2);
@@ -153,13 +158,17 @@ Handle addRealAtom(AtomSpaceImpl& as, AtomPtr atom,
     if (node) {
         result = as.atomTable.getHandle(node->getType(), node->getName());
         if (result == Handle::UNDEFINED) {
-            return as.addNode(node->getType(), node->getName(), newTV);
+            Handle h = as.addNode(node->getType(), node->getName());
+            h->setTruthValue(newTV);
+            return h;
         }
     } else {
         LinkPtr link(LinkCast(atom));
         result = as.atomTable.getHandle(link->getType(), link->getOutgoingSet());
         if (result == Handle::UNDEFINED) {
-            return as.addLink(link->getType(), link->getOutgoingSet(), newTV);
+            Handle h = as.addLink(link->getType(), link->getOutgoingSet());
+            h->setTruthValue(newTV);
+            return h;
         }
     }
     TruthValuePtr currentTV = result->getTruthValue();
@@ -286,7 +295,8 @@ public:
         };
         Handle h[NUM_NODES];
         for (int i = 0; i < NUM_NODES; i++) {
-            h[i] = atomSpace->addNode (CONCEPT_NODE, nodeNames[i], SimpleTruthValue::createTV(0.001f, SimpleTruthValue::confidenceToCount(0.99f)));
+            h[i] = atomSpace->addNode (CONCEPT_NODE, nodeNames[i]);
+            h[i]->setTruthValue(SimpleTruthValue::createTV(0.001f, SimpleTruthValue::confidenceToCount(0.99f)));
         }
         logger().debug("Nodes created\n");
 
@@ -296,7 +306,8 @@ public:
             HandleSeq temp(2);
             temp[0] = h[i];
             temp[1] = h[4];
-            FU[i] = atomSpace->addLink(SCHEMA_EXECUTION_LINK, temp, SimpleTruthValue::createTV(ForceUser[i], SimpleTruthValue::confidenceToCount(0.99f)));
+            FU[i] = atomSpace->addLink(SCHEMA_EXECUTION_LINK, temp);
+            FU[i]->setTruthValue(SimpleTruthValue::createTV(ForceUser[i], SimpleTruthValue::confidenceToCount(0.99f)));
         }
         logger().debug("ForceUser links created\n");
 
@@ -306,7 +317,8 @@ public:
         for (int i = 0; i < 4; i++) {
             out[i].push_back(h[i]);
             out[i].push_back(h[5]);
-            H[i] = atomSpace->addLink(INHERITANCE_LINK, out[i], SimpleTruthValue::createTV(Human[i], SimpleTruthValue::confidenceToCount(0.99f)));
+            H[i] = atomSpace->addLink(INHERITANCE_LINK, out[i]);
+            H[i]->setTruthValue(SimpleTruthValue::createTV(Human[i], SimpleTruthValue::confidenceToCount(0.99f)));
         }
         logger().debug("Human links created\n");
 
@@ -411,7 +423,9 @@ public:
 
         if (head_handle_ptr != NULL) {
             OC_ASSERT(as.atomTable.holds(*head_handle_ptr), "head_handle_ptr is not valid");
-            return addRealAtom(as, *head_handle_ptr, tvn);
+            Handle h = addRealAtom(as, *head_handle_ptr);
+            h->setTruthValue(tvn);
+            return h;
         }
 
         for (tree<Vertex>::sibling_iterator i = a.begin(it); i != a.end(it); i++) {
@@ -424,7 +438,9 @@ public:
             }
         }
 
-        return as.addLink(*head_type_ptr, handles, tvn);
+        Handle h = as.addLink(*head_type_ptr, handles);
+        h->setTruthValue(tvn);
+        return h;
     }
 
     static inline Handle addAtom(AtomSpaceImpl& as, tree<Vertex>& a, TruthValuePtr tvn)
@@ -444,10 +460,14 @@ public:
      * virtual Handle addAtom(tree<Vertex>& a, const TruthValue& tvn, bool fresh=false, bool managed=true);
      */
 #define mva makeVirtualAtom
-    void testAddAtomVtreeTruthValueBool() {
-        Handle h1 = atomSpace->addNode(PREDICATE_NODE, "barkingAt", SimpleTruthValue::createTV(0.001f, 0.00001f));
-        Handle h2 = atomSpace->addNode(CONCEPT_NODE, "dog1", SimpleTruthValue::createTV(0.001f, 0.00001f));
-        Handle h3 = atomSpace->addNode(CONCEPT_NODE, "tree", SimpleTruthValue::createTV(0.5f, 0.99f));
+    void testAddAtomVtreeTruthValueBool()
+    {
+        Handle h1 = atomSpace->addNode(PREDICATE_NODE, "barkingAt");
+        h1->setTruthValue(SimpleTruthValue::createTV(0.001f, 0.00001f));
+        Handle h2 = atomSpace->addNode(CONCEPT_NODE, "dog1");
+        h2->setTruthValue(SimpleTruthValue::createTV(0.001f, 0.00001f));
+        Handle h3 = atomSpace->addNode(CONCEPT_NODE, "tree");
+        h3->setTruthValue(SimpleTruthValue::createTV(0.5f, 0.99f));
 
 
         tree<Vertex>* tr = mva(EVALUATION_LINK,
@@ -505,20 +525,30 @@ public:
      * virtual Handle addNode(Type t,const string& name,const TruthValue& tvn,bool fresh=false,bool managed=true)=0;
      *
      */
-    void testAddNode() {
+    void testAddNode()
+    {
         TruthValuePtr tv1 = SimpleTruthValue::createTV(0.001f, 0.00001f);
         TruthValuePtr tv2 = SimpleTruthValue::createTV(0.001f, 0.00001f);
         TruthValuePtr tv3 = SimpleTruthValue::createTV(0.5f, 0.99f);
-        Handle h1 = atomSpace->addNode(PREDICATE_NODE, "barkingAt", tv1);
-        Handle h2 = atomSpace->addNode(CONCEPT_NODE, "dog1", tv2);
-        Handle h3 = atomSpace->addNode(CONCEPT_NODE, "tree", tv3);
+        Handle h1 = atomSpace->addNode(PREDICATE_NODE, "barkingAt");
+        h1->setTruthValue(tv1);
+        Handle h2 = atomSpace->addNode(CONCEPT_NODE, "dog1");
+        h2->setTruthValue(tv2);
+        Handle h3 = atomSpace->addNode(CONCEPT_NODE, "tree");
+        h3->setTruthValue(tv3);
 
         TruthValuePtr tv1_ = SimpleTruthValue::createTV(0.002f, 0.00002f);
         TruthValuePtr tv2_ = SimpleTruthValue::createTV(0.1f, 0.0f);
         TruthValuePtr tv3_ = SimpleTruthValue::createTV(0.6f, 0.90f);
-        Handle h1_ = atomSpace->addNode(PREDICATE_NODE, "barkingAt", tv1_);
-        Handle h2_ = atomSpace->addNode(CONCEPT_NODE, "dog1", tv2_);
-        Handle h3_ = atomSpace->addNode(CONCEPT_NODE, "tree", tv3_);
+        Handle h1_ = atomSpace->addNode(PREDICATE_NODE, "barkingAt");
+        tv1->merge(tv1_);
+        h1_->setTruthValue(tv1);
+        Handle h2_ = atomSpace->addNode(CONCEPT_NODE, "dog1");
+        tv2->merge(tv2_);
+        h2_->setTruthValue(tv2);
+        Handle h3_ = atomSpace->addNode(CONCEPT_NODE, "tree");
+        tv3->merge(tv3_);
+        h3_->setTruthValue(tv3);
 
         TS_ASSERT(h1 == h1_);
         TruthValuePtr h1tv = h1->getTruthValue();
@@ -577,20 +607,28 @@ public:
      *
      * virtual Handle addLink(Type t,const HandleSeq& outgoing,TruthValuePtr tvn,bool fresh=false,bool managed=true)=0;
      */
-    void testAddLink() {
-        Handle h1 = atomSpace->addNode(PREDICATE_NODE, "barkingAt", SimpleTruthValue::createTV(0.001f, 0.00001f));
-        Handle h2 = atomSpace->addNode(CONCEPT_NODE, "dog1", SimpleTruthValue::createTV(0.001f, 0.00001f));
-        Handle h3 = atomSpace->addNode(CONCEPT_NODE, "tree", SimpleTruthValue::createTV(0.5f, 0.99f));
+    void testAddLink()
+    {
+        Handle h1 = atomSpace->addNode(PREDICATE_NODE, "barkingAt");
+        h1->setTruthValue(SimpleTruthValue::createTV(0.001f, 0.00001f));
+        Handle h2 = atomSpace->addNode(CONCEPT_NODE, "dog1");
+        h2->setTruthValue(SimpleTruthValue::createTV(0.001f, 0.00001f));
+        Handle h3 = atomSpace->addNode(CONCEPT_NODE, "tree");
+        h3->setTruthValue(SimpleTruthValue::createTV(0.5f, 0.99f));
+
         TruthValuePtr tv1 = SimpleTruthValue::createTV(0.001f, 0.00001f);
         TruthValuePtr tv2 = SimpleTruthValue::createTV(0.001f, 0.00001f);
         HandleSeq outgoing1;
         outgoing1.push_back(h2);
         outgoing1.push_back(h3);
-        Handle l1 = atomSpace->addLink(LIST_LINK, outgoing1, tv1);
+        Handle l1 = atomSpace->addLink(LIST_LINK, outgoing1);
+        l1->setTruthValue(tv1);
+
         HandleSeq outgoing2;
         outgoing2.push_back(h1);
         outgoing2.push_back(l1);
-        Handle l2 = atomSpace->addLink(EVALUATION_LINK, outgoing2, tv2);
+        Handle l2 = atomSpace->addLink(EVALUATION_LINK, outgoing2);
+        l2->setTruthValue(tv2);
 
         // Check that isNode returns false
         TS_ASSERT(!isNode(l2));
@@ -598,9 +636,14 @@ public:
         TS_ASSERT(isLink(l2));
 
         TruthValuePtr tv1_ = SimpleTruthValue::createTV(0.002f, 0.00002f);
-        Handle l1_ = atomSpace->addLink(LIST_LINK, outgoing1, tv1_);
+        Handle l1_ = atomSpace->addLink(LIST_LINK, outgoing1);
+        tv1->merge(tv1_);
+        l1_->setTruthValue(tv1);
+
         TruthValuePtr tv2_ = SimpleTruthValue::createTV(0.1f, 0.0f);
-        Handle l2_ = atomSpace->addLink(EVALUATION_LINK, outgoing2, tv2_);
+        Handle l2_ = atomSpace->addLink(EVALUATION_LINK, outgoing2);
+        tv2->merge(tv2_);
+        l2_->setTruthValue(tv2);
 
         TS_ASSERT(l1 == l1_);
         TruthValuePtr l1tv = l1->getTruthValue();
@@ -613,20 +656,26 @@ public:
 
     }
 
-    void testIsSource() {
-        Handle h1 = atomSpace->addNode(PREDICATE_NODE, "barkingAt", SimpleTruthValue::createTV(0.001f, 0.00001f));
-        Handle h2 = atomSpace->addNode(CONCEPT_NODE, "dog1", SimpleTruthValue::createTV(0.001f, 0.00001f));
-        Handle h3 = atomSpace->addNode(CONCEPT_NODE, "tree", SimpleTruthValue::createTV(0.5f, 0.99f));
+    void testIsSource()
+    {
+        Handle h1 = atomSpace->addNode(PREDICATE_NODE, "barkingAt");
+        h1->setTruthValue(SimpleTruthValue::createTV(0.001f, 0.00001f));
+        Handle h2 = atomSpace->addNode(CONCEPT_NODE, "dog1");
+        h2->setTruthValue(SimpleTruthValue::createTV(0.001f, 0.00001f));
+        Handle h3 = atomSpace->addNode(CONCEPT_NODE, "tree");
+        h3->setTruthValue(SimpleTruthValue::createTV(0.5f, 0.99f));
         TruthValuePtr tv1 = SimpleTruthValue::createTV(0.001f, 0.00001f);
         TruthValuePtr tv2 = SimpleTruthValue::createTV(0.001f, 0.00001f);
         HandleSeq outgoing1;
         outgoing1.push_back(h2);
         outgoing1.push_back(h3);
-        Handle l1 = atomSpace->addLink(SET_LINK, outgoing1, tv1);
+        Handle l1 = atomSpace->addLink(SET_LINK, outgoing1);
+        l1->setTruthValue(tv1);
         HandleSeq outgoing2;
         outgoing2.push_back(h1);
         outgoing2.push_back(l1);
-        Handle l2 = atomSpace->addLink(EVALUATION_LINK, outgoing2, tv2);
+        Handle l2 = atomSpace->addLink(EVALUATION_LINK, outgoing2);
+        l2->setTruthValue(tv2);
 
         // Ensure first in outgoing is the source
         TS_ASSERT(isSource(h1,l2));
@@ -639,20 +688,26 @@ public:
 
     }
 
-    void testGetNeighbors() {
-        Handle h1 = atomSpace->addNode(PREDICATE_NODE, "barkingAt", SimpleTruthValue::createTV(0.001f, 0.00001f));
-        Handle h2 = atomSpace->addNode(CONCEPT_NODE, "dog1", SimpleTruthValue::createTV(0.001f, 0.00001f));
-        Handle h3 = atomSpace->addNode(CONCEPT_NODE, "tree", SimpleTruthValue::createTV(0.5f, 0.99f));
+    void testGetNeighbors()
+    {
+        Handle h1 = atomSpace->addNode(PREDICATE_NODE, "barkingAt");
+        h1->setTruthValue(SimpleTruthValue::createTV(0.001f, 0.00001f));
+        Handle h2 = atomSpace->addNode(CONCEPT_NODE, "dog1");
+        h2->setTruthValue(SimpleTruthValue::createTV(0.001f, 0.00001f));
+        Handle h3 = atomSpace->addNode(CONCEPT_NODE, "tree");
+        h3->setTruthValue(SimpleTruthValue::createTV(0.5f, 0.99f));
         TruthValuePtr tv1 = SimpleTruthValue::createTV(0.001f, 0.00001f);
         TruthValuePtr tv2 = SimpleTruthValue::createTV(0.001f, 0.00001f);
         HandleSeq outgoing1;
         outgoing1.push_back(h2);
         outgoing1.push_back(h3);
-        Handle l1 = atomSpace->addLink(SET_LINK, outgoing1, tv1);
+        Handle l1 = atomSpace->addLink(SET_LINK, outgoing1);
+        l1->setTruthValue(tv1);
         HandleSeq outgoing2;
         outgoing2.push_back(h1);
         outgoing2.push_back(l1);
-        Handle l2 = atomSpace->addLink(EVALUATION_LINK, outgoing2, tv2);
+        Handle l2 = atomSpace->addLink(EVALUATION_LINK, outgoing2);
+        l2->setTruthValue(tv2);
 
         TS_ASSERT(atomSpace->getNeighbors(h1).size() == 1);
         Handle badHandle(10000); 

--- a/tests/atomspace/AtomSpaceUTest.cxxtest
+++ b/tests/atomspace/AtomSpaceUTest.cxxtest
@@ -76,13 +76,17 @@ Handle addRealAtom(AtomSpace& as, AtomPtr atom,
     if (node) {
         result = as.getHandle(node->getType(), node->getName());
         if (result == Handle::UNDEFINED) {
-            return as.addNode(node->getType(), node->getName(), newTV);
+            result = as.addNode(node->getType(), node->getName());
+            result->setTruthValue(newTV);
+            return result;
         }
     } else {
         LinkPtr link(LinkCast(atom));
         result = as.getHandle(link->getType(), link->getOutgoingSet());
         if (result == Handle::UNDEFINED) {
-            return as.addLink(link->getType(), link->getOutgoingSet(), newTV);
+            result = as.addLink(link->getType(), link->getOutgoingSet());
+            result->setTruthValue(newTV);
+            return result;
         }
     }
     const TruthValuePtr currentTV = as.getTV(result);
@@ -127,7 +131,9 @@ static inline Handle addAtomIter(AtomSpace& as, tree<Vertex>& a, tree<Vertex>::i
         }
     }
 
-    return as.addLink(*head_type_ptr, handles, tvn);
+    Handle hh = as.addLink(*head_type_ptr, handles);
+    hh->setTruthValue(tvn);
+    return hh;
 }
 
 static inline Handle addAtom(AtomSpace& as, tree<Vertex>& a, TruthValuePtr tvn)
@@ -155,26 +161,31 @@ HandleSeq createSimpleGraph(AtomSpace* atomSpace, const char* baseName)
     TruthValuePtr tv2 = SimpleTruthValue::createTV(0.001f, 0.00001f);
     TruthValuePtr tv3 = SimpleTruthValue::createTV(0.5f, 0.99f);
     buf[baseNameLength] = '1';
-    Handle h1 = atomSpace->addNode(CONCEPT_NODE, buf, tv1);
+    Handle h1 = atomSpace->addNode(CONCEPT_NODE, buf);
+    h1->setTruthValue(tv1);
     atomSpace->setSTI(h1, AV1_STI);
     atomSpace->setLTI(h1, AV1_LTI);
     buf[baseNameLength] = '2';
-    Handle h2 = atomSpace->addNode(CONCEPT_NODE, buf, tv2);
+    Handle h2 = atomSpace->addNode(CONCEPT_NODE, buf);
+    h2->setTruthValue(tv2);
     atomSpace->setSTI(h2, AV2_STI);
     atomSpace->setLTI(h2, AV2_LTI);
     buf[baseNameLength] = '3';
-    Handle h3 = atomSpace->addNode(CONCEPT_NODE, buf, tv3);
+    Handle h3 = atomSpace->addNode(CONCEPT_NODE, buf);
+    h3->setTruthValue(tv3);
     atomSpace->setSTI(h3, AV3_STI);
     atomSpace->setLTI(h3, AV3_LTI);
 
     HandleSeq outgoing1;
     outgoing1.push_back(h2);
     outgoing1.push_back(h3);
-    Handle l1 = atomSpace->addLink(LIST_LINK, outgoing1, tv1);
+    Handle l1 = atomSpace->addLink(LIST_LINK, outgoing1);
+    l1->setTruthValue(tv1);
     HandleSeq outgoing2;
     outgoing2.push_back(h1);
     outgoing2.push_back(l1);
-    Handle l2 = atomSpace->addLink(EVALUATION_LINK, outgoing2, tv2);
+    Handle l2 = atomSpace->addLink(EVALUATION_LINK, outgoing2);
+    l2->setTruthValue(tv2);
 
     testAtoms.push_back(h1);
     testAtoms.push_back(h2);
@@ -356,7 +367,8 @@ public:
         };
         Handle h[NUM_NODES];
         for (int i = 0; i < NUM_NODES; i++) {
-            h[i] = atomSpace->addNode (CONCEPT_NODE, nodeNames[i], SimpleTruthValue::createTV(0.001f, SimpleTruthValue::confidenceToCount(0.99f)));
+            h[i] = atomSpace->addNode(CONCEPT_NODE, nodeNames[i]);
+            h[i]->setTruthValue(SimpleTruthValue::createTV(0.001f, SimpleTruthValue::confidenceToCount(0.99f)));
         }
         //logger().debug("Nodes created\n");
 
@@ -366,7 +378,8 @@ public:
             HandleSeq temp(2);
             temp[0] = h[i];
             temp[1] = h[4];
-            FU[i] = atomSpace->addLink(SCHEMA_EXECUTION_LINK, temp, SimpleTruthValue::createTV(ForceUser[i], SimpleTruthValue::confidenceToCount(0.99f)));
+            FU[i] = atomSpace->addLink(SCHEMA_EXECUTION_LINK, temp);
+            FU[i]->setTruthValue(SimpleTruthValue::createTV(ForceUser[i], SimpleTruthValue::confidenceToCount(0.99f)));
         }
         //logger().debug("ForceUser links created\n");
 
@@ -376,7 +389,8 @@ public:
         for (int i = 0; i < 4; i++) {
             out[i].push_back(h[i]);
             out[i].push_back(h[5]);
-            H[i] = atomSpace->addLink(INHERITANCE_LINK, out[i], SimpleTruthValue::createTV(Human[i], SimpleTruthValue::confidenceToCount(0.99f)));
+            H[i] = atomSpace->addLink(INHERITANCE_LINK, out[i]);
+            H[i]->setTruthValue(SimpleTruthValue::createTV(Human[i], SimpleTruthValue::confidenceToCount(0.99f)));
         }
         //logger().debug("Human links created\n");
 
@@ -540,9 +554,12 @@ public:
      */
 #define mva makeVirtualAtom
     void testAddAtomVtreeTruthValueBool() {
-        Handle h1 = atomSpace->addNode(PREDICATE_NODE, "barkingAt", SimpleTruthValue::createTV(0.001f, 0.00001f));
-        Handle h2 = atomSpace->addNode(CONCEPT_NODE, "dog1", SimpleTruthValue::createTV(0.001f, 0.00001f));
-        Handle h3 = atomSpace->addNode(CONCEPT_NODE, "tree", SimpleTruthValue::createTV(0.5f, 0.99f));
+        Handle h1 = atomSpace->addNode(PREDICATE_NODE, "barkingAt");
+        h1->setTruthValue(SimpleTruthValue::createTV(0.001f, 0.00001f));
+        Handle h2 = atomSpace->addNode(CONCEPT_NODE, "dog1");
+        h2->setTruthValue(SimpleTruthValue::createTV(0.001f, 0.00001f));
+        Handle h3 = atomSpace->addNode(CONCEPT_NODE, "tree");
+        h3->setTruthValue(SimpleTruthValue::createTV(0.5f, 0.99f));
 
 
         tree<Vertex>* tr = mva(EVALUATION_LINK,
@@ -570,6 +587,7 @@ public:
         Handle hn = atomSpace->addNode(PREDICATE_NODE, "barkingAt");
         tr = mva(hn, NULL);
         Handle h1_ = addAtom(*atomSpace, *tr, SimpleTruthValue::createTV(0.5f, 0.5f));
+        h1_->setTruthValue(SimpleTruthValue::createTV(0.5f, 0.5f));
         TS_ASSERT(h1_ != Handle::UNDEFINED);
         // In this case, the expected behavior is to perform a merge and return the
         // handle was inserted previously.
@@ -602,16 +620,25 @@ public:
         TruthValuePtr tv1 = SimpleTruthValue::createTV(0.001f, 0.00001f);
         TruthValuePtr tv2 = SimpleTruthValue::createTV(0.001f, 0.00001f);
         TruthValuePtr tv3 = SimpleTruthValue::createTV(0.5f, 0.99f);
-        Handle h1 = atomSpace->addNode(PREDICATE_NODE, "barkingAt", tv1);
-        Handle h2 = atomSpace->addNode(CONCEPT_NODE, "dog1", tv2);
-        Handle h3 = atomSpace->addNode(CONCEPT_NODE, "tree", tv3);
+        Handle h1 = atomSpace->addNode(PREDICATE_NODE, "barkingAt");
+        h1->setTruthValue(tv1);
+        Handle h2 = atomSpace->addNode(CONCEPT_NODE, "dog1");
+        h2->setTruthValue(tv2);
+        Handle h3 = atomSpace->addNode(CONCEPT_NODE, "tree");
+        h3->setTruthValue(tv3);
 
         TruthValuePtr tv1_ = SimpleTruthValue::createTV(0.002f, 0.00002f);
         TruthValuePtr tv2_ = SimpleTruthValue::createTV(0.1f, 0.0f);
         TruthValuePtr tv3_ = SimpleTruthValue::createTV(0.6f, 0.90f);
-        Handle h1_ = atomSpace->addNode(PREDICATE_NODE, "barkingAt", tv1_);
-        Handle h2_ = atomSpace->addNode(CONCEPT_NODE, "dog1", tv2_);
-        Handle h3_ = atomSpace->addNode(CONCEPT_NODE, "tree", tv3_);
+        tv1->merge(tv1_);
+        tv2->merge(tv2_);
+        tv3->merge(tv3_);
+        h1->setTruthValue(tv1);
+        h2->setTruthValue(tv2);
+        h3->setTruthValue(tv3);
+        Handle h1_ = atomSpace->addNode(PREDICATE_NODE, "barkingAt");
+        Handle h2_ = atomSpace->addNode(CONCEPT_NODE, "dog1");
+        Handle h3_ = atomSpace->addNode(CONCEPT_NODE, "tree");
 
         TS_ASSERT(h1 == h1_);
         TruthValuePtr h1tv = h1->getTruthValue();
@@ -672,25 +699,35 @@ public:
      *
      * virtual Handle addLink(Type t,const HandleSeq& outgoing,TruthValuePtr tvn)=0;
      */
-    void testAddLink() {
-        Handle h1 = atomSpace->addNode(PREDICATE_NODE, "barkingAt", SimpleTruthValue::createTV(0.001f, 0.00001f));
-        Handle h2 = atomSpace->addNode(CONCEPT_NODE, "dog1", SimpleTruthValue::createTV(0.001f, 0.00001f));
-        Handle h3 = atomSpace->addNode(CONCEPT_NODE, "tree", SimpleTruthValue::createTV(0.5f, 0.99f));
+    void testAddLink()
+    {
+        Handle h1 = atomSpace->addNode(PREDICATE_NODE, "barkingAt");
+        h1->setTruthValue(SimpleTruthValue::createTV(0.001f, 0.00001f));
+        Handle h2 = atomSpace->addNode(CONCEPT_NODE, "dog1");
+        h2->setTruthValue(SimpleTruthValue::createTV(0.001f, 0.00001f));
+        Handle h3 = atomSpace->addNode(CONCEPT_NODE, "tree");
+        h3->setTruthValue(SimpleTruthValue::createTV(0.5f, 0.99f));
         TruthValuePtr tv1 = SimpleTruthValue::createTV(0.001f, 0.00001f);
         TruthValuePtr tv2 = SimpleTruthValue::createTV(0.001f, 0.00001f);
         HandleSeq outgoing1;
         outgoing1.push_back(h2);
         outgoing1.push_back(h3);
-        Handle l1 = atomSpace->addLink(LIST_LINK, outgoing1, tv1);
+        Handle l1 = atomSpace->addLink(LIST_LINK, outgoing1);
+        l1->setTruthValue(tv1);
         HandleSeq outgoing2;
         outgoing2.push_back(h1);
         outgoing2.push_back(l1);
-        Handle l2 = atomSpace->addLink(EVALUATION_LINK, outgoing2, tv2);
+        Handle l2 = atomSpace->addLink(EVALUATION_LINK, outgoing2);
+        l2->setTruthValue(tv2);
 
         TruthValuePtr tv1_ = SimpleTruthValue::createTV(0.002f, 0.00002f);
-        Handle l1_ = atomSpace->addLink(LIST_LINK, outgoing1, tv1_);
+        tv1->merge(tv1_);
+        l1->setTruthValue(tv1);
+        Handle l1_ = atomSpace->addLink(LIST_LINK, outgoing1);
         TruthValuePtr tv2_ = SimpleTruthValue::createTV(0.1f, 0.0f);
-        Handle l2_ = atomSpace->addLink(EVALUATION_LINK, outgoing2, tv2_);
+        tv2->merge(tv2_);
+        l2->setTruthValue(tv2);
+        Handle l2_ = atomSpace->addLink(EVALUATION_LINK, outgoing2);
 
         TS_ASSERT(l1 == l1_);
         TruthValuePtr l1tv = l1->getTruthValue();
@@ -703,7 +740,8 @@ public:
 
     }
 
-    void testGetHandle_bugfix1() {
+    void testGetHandle_bugfix1()
+    {
         HandleSeq emptyOutgoing;
         Handle result = atomSpace->getHandle(LIST_LINK, emptyOutgoing);
         TS_ASSERT(result == Handle::UNDEFINED);
@@ -874,9 +912,12 @@ public:
 
     void testGetHandleSetByName()
     {
-        Handle h1 = atomSpace->addNode(PREDICATE_NODE, "dog1", SimpleTruthValue::createTV(0.001f, 0.00001f));
-        Handle h2 = atomSpace->addNode(CONCEPT_NODE, "dog1", SimpleTruthValue::createTV(0.001f, 0.00001f));
-        Handle h3 = atomSpace->addNode(NODE, "dog1", SimpleTruthValue::createTV(0.5f, 0.99f));
+        Handle h1 = atomSpace->addNode(PREDICATE_NODE, "dog1");
+        h1->setTruthValue(SimpleTruthValue::createTV(0.001f, 0.00001f));
+        Handle h2 = atomSpace->addNode(CONCEPT_NODE, "dog1");
+        h2->setTruthValue(SimpleTruthValue::createTV(0.001f, 0.00001f));
+        Handle h3 = atomSpace->addNode(NODE, "dog1");
+        h3->setTruthValue(SimpleTruthValue::createTV(0.5f, 0.99f));
 
         HandleSeq namedAtoms;
         atomSpace->getHandlesByType(back_inserter(namedAtoms), NODE, true);

--- a/tests/atomspace/AtomTableUTest.cxxtest
+++ b/tests/atomspace/AtomTableUTest.cxxtest
@@ -409,11 +409,11 @@ public:
         NodePtr n1(createNode(NUMBER_NODE, "1", SimpleTruthValue::createTV(0.1f, 0.2f)));
         Handle hn1 = table->add(n1, false);
 
-        NodePtr n2(createNode(NUMBER_NODE, "1", SimpleTruthValue::createTV(0.3f, 0.4f)));
-        TS_ASSERT_THROWS_NOTHING(table->add(n2, false));
+        NodePtr n2(createNode(NUMBER_NODE, "1"));
+        TS_ASSERT_THROWS_NOTHING(table->add(n2, false)->merge(SimpleTruthValue::createTV(0.3f, 0.4f)));
 
-        NodePtr n3(createNode(NUMBER_NODE, "1", SimpleTruthValue::createTV(0.8f, 0.3f)));
-        TS_ASSERT_THROWS_NOTHING(table->add(n3, false));
+        NodePtr n3(createNode(NUMBER_NODE, "1"));
+        TS_ASSERT_THROWS_NOTHING(table->add(n3, false)->merge(SimpleTruthValue::createTV(0.8f, 0.3f)));
 
         Handle h = table->getHandlex("1", NUMBER_NODE);
         TS_ASSERT(h == hn1);

--- a/tests/atomspace/AttentionValueUTest.cxxtest
+++ b/tests/atomspace/AttentionValueUTest.cxxtest
@@ -268,19 +268,23 @@ public:
         TruthValuePtr tv3 = SimpleTruthValue::createTV(0.05f, 0.005f);
         TruthValuePtr tv4 = SimpleTruthValue::createTV(0.5f, 0.05f);
         buf[baseNameLength] = '1';
-        Handle h1 = atomSpace->addNode(CONCEPT_NODE, buf, tv1);
+        Handle h1 = atomSpace->addNode(CONCEPT_NODE, buf);
+        h1->setTruthValue(tv1);
         setSTI(h1, 0);
         setLTI(h1, 300);
         buf[baseNameLength] = '2';
-        Handle h2 = atomSpace->addNode(CONCEPT_NODE, buf, tv2);
+        Handle h2 = atomSpace->addNode(CONCEPT_NODE, buf);
+        h2->setTruthValue(tv2);
         setSTI(h2, 500);
         setLTI(h2, 7000);
         buf[baseNameLength] = '3';
-        Handle h3 = atomSpace->addNode(CONCEPT_NODE, buf, tv3);
+        Handle h3 = atomSpace->addNode(CONCEPT_NODE, buf);
+        h3->setTruthValue(tv3);
         setSTI(h3, 500);
         setLTI(h3, 7000);
         buf[baseNameLength] = '4';
-        Handle h4 = atomSpace->addNode(CONCEPT_NODE, buf, tv4);
+        Handle h4 = atomSpace->addNode(CONCEPT_NODE, buf);
+        h4->setTruthValue(tv4);
         setSTI(h4, 500);
         setLTI(h4, 20000);
 
@@ -292,7 +296,8 @@ public:
         return testAtoms;
     }
 
-    void testgetDefault() {
+    void testgetDefault()
+    {
         AttentionValuePtr av = AttentionValue::DEFAULT_AV();
 
         TS_ASSERT(av->getSTI() == sti[0]);

--- a/tests/atomspace/MultiSpaceUTest.cxxtest
+++ b/tests/atomspace/MultiSpaceUTest.cxxtest
@@ -57,9 +57,12 @@ public:
 		TruthValuePtr tv3(SimpleTruthValue::createTV(0.5, 3.0));
 
 		// Create three atoms in three different atomspaces
-		Handle h1 = as1.addNode(CONCEPT_NODE, "1", tv1);
-		Handle h2 = as2.addNode(NUMBER_NODE, "2", tv2);
-		Handle h3 = as3.addNode(VARIABLE_NODE, "3", tv3);
+		Handle h1 = as1.addNode(CONCEPT_NODE, "1");
+		h1->setTruthValue(tv1);
+		Handle h2 = as2.addNode(NUMBER_NODE, "2");
+		h2->setTruthValue(tv2);
+		Handle h3 = as3.addNode(VARIABLE_NODE, "3");
+		h3->setTruthValue(tv3);
 
 		// Forget about the atoms, remember thier UUID's only
 		// UUID's are just long ints ...
@@ -120,9 +123,12 @@ public:
 		TruthValuePtr tv3(SimpleTruthValue::createTV(0.4, 3.0));
 
 		// Create three nodes
-		NodePtr n1(createNode(CONCEPT_NODE, "uni-1", tv1));
-		NodePtr n2(createNode(NUMBER_NODE, "uni-2", tv2));
-		NodePtr n3(createNode(VARIABLE_NODE, "uni-3", tv3));
+		NodePtr n1(createNode(CONCEPT_NODE, "uni-1"));
+		n1->setTruthValue(tv1);
+		NodePtr n2(createNode(NUMBER_NODE, "uni-2"));
+		n2->setTruthValue(tv2);
+		NodePtr n3(createNode(VARIABLE_NODE, "uni-3"));
+		n3->setTruthValue(tv3);
 
 		Handle hnd1(n1);
 		Handle hnd2(n2);
@@ -132,9 +138,12 @@ public:
 		TruthValuePtr tv(SimpleTruthValue::createTV(0.33, 3.0));
 
 		// Create three copies of this link in three atomspaces
-		Handle h1 = as1.addLink(LIST_LINK, hnd1, hnd2, hnd3, tv);
-		Handle h2 = as2.addLink(LIST_LINK, hnd1, hnd2, hnd3, tv);
-		Handle h3 = as3.addLink(LIST_LINK, hnd1, hnd2, hnd3, tv);
+		Handle h1 = as1.addLink(LIST_LINK, hnd1, hnd2, hnd3);
+		h1->setTruthValue(tv);
+		Handle h2 = as2.addLink(LIST_LINK, hnd1, hnd2, hnd3);
+		h2->setTruthValue(tv);
+		Handle h3 = as3.addLink(LIST_LINK, hnd1, hnd2, hnd3);
+		h3->setTruthValue(tv);
 
 		// Forget about the link atoms, remember thier UUID's only
 		// UUID's are just long ints ...
@@ -224,18 +233,23 @@ public:
 		TruthValuePtr tv3(SimpleTruthValue::createTV(0.4, 3.0));
 
 		// Create three nodes in the base atomspace
-		Handle hnd1 = nas1.addNode(CONCEPT_NODE, "nest-1", tv1);
-		Handle hnd2 = nas1.addNode(NUMBER_NODE, "nest-2", tv2);
-		Handle hnd3 = nas1.addNode(VARIABLE_NODE, "nest-3", tv3);
+		Handle hnd1 = nas1.addNode(CONCEPT_NODE, "nest-1");
+		hnd1->setTruthValue(tv1);
+		Handle hnd2 = nas1.addNode(NUMBER_NODE, "nest-2");
+		hnd2->setTruthValue(tv2);
+		Handle hnd3 = nas1.addNode(VARIABLE_NODE, "nest-3");
+		hnd3->setTruthValue(tv3);
 
 		// Create three links holding these three
 		TruthValuePtr tv(SimpleTruthValue::createTV(0.33, 3.0));
 
 		// Create a link in the middle atomspace
-		Handle h2 = nas2.addLink(LIST_LINK, hnd1, hnd2, hnd3, tv);
+		Handle h2 = nas2.addLink(LIST_LINK, hnd1, hnd2, hnd3);
+		h2->setTruthValue(tv);
 
 		// Try to create a link in the grandchild atomspace
-		Handle h3 = nas3.addLink(LIST_LINK, hnd1, hnd2, hnd3, tv);
+		Handle h3 = nas3.addLink(LIST_LINK, hnd1, hnd2, hnd3);
+		h3->setTruthValue(tv);
 
 		// The middle and grand-child links should be one and the same.
 		TS_ASSERT(h2 == h3);

--- a/tests/dynamics/ForgettingAgentUTest.cxxtest
+++ b/tests/dynamics/ForgettingAgentUTest.cxxtest
@@ -43,7 +43,8 @@ vector<Handle> createNodes(AtomSpace* atomSpace, std::string baseName, int numbe
         std::ostringstream buf;
         TruthValuePtr tv1 = SimpleTruthValue::createTV(0.5f, 0.99f);
         buf << baseName << i;
-        Handle h1 = atomSpace->addNode(CONCEPT_NODE, buf.str().c_str(), tv1);
+        Handle h1 = atomSpace->addNode(CONCEPT_NODE, buf.str().c_str());
+        h1->setTruthValue(tv1);
         //printf("add atom %d: %s\n", i, buf.str().c_str());
         testAtoms.push_back(h1);
     }
@@ -62,20 +63,25 @@ vector<Handle> createSimpleGraph(AtomSpace* atomSpace, const char* baseName)
 
     TruthValuePtr tv1 = SimpleTruthValue::createTV(0.5f, 0.99f);
     buf[baseNameLength] = '1';
-    Handle h1 = atomSpace->addNode(CONCEPT_NODE, buf, tv1);
+    Handle h1 = atomSpace->addNode(CONCEPT_NODE, buf);
+    h1->setTruthValue(tv1);
     buf[baseNameLength] = '2';
-    Handle h2 = atomSpace->addNode(CONCEPT_NODE, buf, tv1);
+    Handle h2 = atomSpace->addNode(CONCEPT_NODE, buf);
+    h2->setTruthValue(tv1);
     buf[baseNameLength] = '3';
-    Handle h3 = atomSpace->addNode(CONCEPT_NODE, buf, tv1);
+    Handle h3 = atomSpace->addNode(CONCEPT_NODE, buf);
+    h3->setTruthValue(tv1);
 
     HandleSeq outgoing1;
     outgoing1.push_back(h2);
     outgoing1.push_back(h3);
-    Handle l1 = atomSpace->addLink(LIST_LINK, outgoing1, tv1);
+    Handle l1 = atomSpace->addLink(LIST_LINK, outgoing1);
+    l1->setTruthValue(tv1);
     HandleSeq outgoing2;
     outgoing2.push_back(h1);
     outgoing2.push_back(l1);
-    Handle l2 = atomSpace->addLink(EVALUATION_LINK, outgoing2, tv1);
+    Handle l2 = atomSpace->addLink(EVALUATION_LINK, outgoing2);
+    l2->setTruthValue(tv1);
 
     testAtoms.push_back(h1);
     testAtoms.push_back(h2);

--- a/tests/dynamics/HebbianCreationModuleUTest.cxxtest
+++ b/tests/dynamics/HebbianCreationModuleUTest.cxxtest
@@ -82,38 +82,50 @@ public:
 
         // Populate the AtomSpace with the example atoms
         Handle kermit = as->addNode(
-            CONCEPT_NODE, "Kermit", SimpleTruthValue::createTV(0.001, conf90));
+            CONCEPT_NODE, "Kermit");
+        kermit->setTruthValue( SimpleTruthValue::createTV(0.001, conf90));
         Handle frog = as->addNode(
-            CONCEPT_NODE, "Frog", SimpleTruthValue::createTV(0.01, conf90));
+            CONCEPT_NODE, "Frog");
+        frog->setTruthValue( SimpleTruthValue::createTV(0.01, conf90));
         Handle animal = as->addNode(
-            CONCEPT_NODE, "Animal", SimpleTruthValue::createTV(0.1, conf90));
+            CONCEPT_NODE, "Animal");
+        animal->setTruthValue( SimpleTruthValue::createTV(0.1, conf90));
         Handle alive = as->addNode(
-            PREDICATE_NODE, "alive", SimpleTruthValue::createTV(0.01, conf90));
+            PREDICATE_NODE, "alive");
+        alive->setTruthValue( SimpleTruthValue::createTV(0.01, conf90));
         Handle slimy = as->addNode(
-            PREDICATE_NODE, "slimy", SimpleTruthValue::createTV(0.01, conf90));
+            PREDICATE_NODE, "slimy");
+        slimy->setTruthValue( SimpleTruthValue::createTV(0.01, conf90));
 
         Handle kermitFrog = as->addLink(
-                    INHERITANCE_LINK, kermit, frog,
+                    INHERITANCE_LINK, kermit, frog);
+        kermitFrog->setTruthValue(
                     SimpleTruthValue::createTV(0.9, conf90));
         Handle frogAnimal = as->addLink(
-                    INHERITANCE_LINK, frog, animal,
+                    INHERITANCE_LINK, frog, animal);
+        frogAnimal->setTruthValue(
                     SimpleTruthValue::createTV(0.9, conf90));
         Handle frogAlive = as->addLink(
-                    EVALUATION_LINK, frog, alive,
+                    EVALUATION_LINK, frog, alive);
+        frogAlive->setTruthValue(
                     SimpleTruthValue::createTV(0.9, conf90));
         Handle frogSlimy = as->addLink(
-                    EVALUATION_LINK, frog, slimy,
+                    EVALUATION_LINK, frog, slimy);
+        frogSlimy->setTruthValue(
                     SimpleTruthValue::createTV(0.9, conf90));
 
         // Populate the AtomSpace with some additional dummy atoms
         Handle dummy1 = as->addNode(
-                    CONCEPT_NODE, "Dummy1",
+                    CONCEPT_NODE, "Dummy1");
+        dummy1->setTruthValue(
                     SimpleTruthValue::createTV(0.001, conf90));
         Handle dummy2 = as->addNode(
-                    CONCEPT_NODE, "Dummy1",
+                    CONCEPT_NODE, "Dummy2");
+        dummy2->setTruthValue(
                     SimpleTruthValue::createTV(0.001, conf90));
         Handle dummyLink = as->addLink(
-                    INHERITANCE_LINK, dummy1, dummy2,
+                    INHERITANCE_LINK, dummy1, dummy2);
+        dummyLink->setTruthValue(
                     SimpleTruthValue::createTV(0.9, conf90));
 
         // Put these atoms in the AttentionalFocus:

--- a/tests/dynamics/HebbianUpdatingAgentUTest.cxxtest
+++ b/tests/dynamics/HebbianUpdatingAgentUTest.cxxtest
@@ -45,7 +45,8 @@ vector<Handle> createHebbianGraph(AtomSpace* atomSpace, std::string baseName)
         std::ostringstream buf;
         TruthValuePtr tv1 = SimpleTruthValue::createTV(0.5f, 0.99f);
         buf << baseName << i;
-        Handle h1 = atomSpace->addNode(CONCEPT_NODE, buf.str().c_str(), tv1);
+        Handle h1 = atomSpace->addNode(CONCEPT_NODE, buf.str().c_str());
+        h1->setTruthValue(tv1);
         //printf("add atom %d: %s\n", i, buf.str().c_str());
         testAtoms.push_back(h1);
     }
@@ -55,12 +56,14 @@ vector<Handle> createHebbianGraph(AtomSpace* atomSpace, std::string baseName)
     HandleSeq outgoing1;
     outgoing1.push_back(testAtoms[0]);
     outgoing1.push_back(testAtoms[1]);
-    Handle l1 = atomSpace->addLink(SYMMETRIC_HEBBIAN_LINK, outgoing1, tv2);
+    Handle l1 = atomSpace->addLink(SYMMETRIC_HEBBIAN_LINK, outgoing1);
+    l1->setTruthValue(tv2);
 
     HandleSeq outgoing2;
     outgoing2.push_back(testAtoms[2]);
     outgoing2.push_back(testAtoms[3]);
-    Handle l2 = atomSpace->addLink(INVERSE_HEBBIAN_LINK, outgoing2, tv2);
+    Handle l2 = atomSpace->addLink(INVERSE_HEBBIAN_LINK, outgoing2);
+    l2->setTruthValue(tv2);
 
     testAtoms.push_back(l1);
     testAtoms.push_back(l2);
@@ -78,7 +81,8 @@ std::vector<Handle> createCase(bool srcInAF, int srcSTI, bool targInAF,
     std::ostringstream buf2;
     TruthValuePtr tv1 = SimpleTruthValue::createTV(0.5f, 0.99f);
     buf1 << baseName << 1;
-    Handle h1 = a->addNode(CONCEPT_NODE, buf1.str().c_str(), tv1);
+    Handle h1 = a->addNode(CONCEPT_NODE, buf1.str().c_str());
+    h1->setTruthValue(tv1);
     a->setSTI(h1,srcSTI);
     if (srcSTI >= bank.getMaxSTI())
         bank.updateMaxSTI(srcSTI);
@@ -86,7 +90,8 @@ std::vector<Handle> createCase(bool srcInAF, int srcSTI, bool targInAF,
         bank.updateMinSTI(srcSTI);
     testAtoms.push_back(h1);
     buf2 << baseName << 2;
-    Handle h2 = a->addNode(CONCEPT_NODE, buf2.str().c_str(), tv1);
+    Handle h2 = a->addNode(CONCEPT_NODE, buf2.str().c_str());
+    h2->setTruthValue(tv1);
     a->setSTI(h2,targSTI);
     if (targSTI >= bank.getMaxSTI())
         bank.updateMaxSTI(targSTI);
@@ -94,16 +99,14 @@ std::vector<Handle> createCase(bool srcInAF, int srcSTI, bool targInAF,
         bank.updateMinSTI(targSTI);
     testAtoms.push_back(h2);
 
-    HandleSeq outgoing1;
-    TruthValuePtr linkTV = SimpleTruthValue::createTV(linkStr, 0.99f);
     Handle l;
-    outgoing1.push_back(testAtoms[0]);
-    outgoing1.push_back(testAtoms[1]);
     if (inverse) {
-        l = a->addLink(INVERSE_HEBBIAN_LINK, outgoing1, linkTV);
+        l = a->addLink(INVERSE_HEBBIAN_LINK, testAtoms[0], testAtoms[1]);
     } else {
-        l = a->addLink(SYMMETRIC_HEBBIAN_LINK, outgoing1, linkTV);
+        l = a->addLink(SYMMETRIC_HEBBIAN_LINK, testAtoms[0], testAtoms[1]);
     }
+    TruthValuePtr linkTV = SimpleTruthValue::createTV(linkStr, 0.99f);
+    l->setTruthValue(linkTV);
     testAtoms.push_back(l);
 
     return testAtoms;

--- a/tests/dynamics/ImportanceDiffusionAgentUTest.cxxtest
+++ b/tests/dynamics/ImportanceDiffusionAgentUTest.cxxtest
@@ -46,7 +46,8 @@ vector<Handle> createHebbianGraph(AtomSpace* atomSpace, std::string baseName)
         std::ostringstream buf;
         TruthValuePtr tv1 = SimpleTruthValue::createTV(0.5f, 0.99f);
         buf << baseName << i;
-        Handle h1 = atomSpace->addNode(CONCEPT_NODE, buf.str().c_str(), tv1);
+        Handle h1 = atomSpace->addNode(CONCEPT_NODE, buf.str().c_str());
+        h1->setTruthValue(tv1);
         //printf("add atom %d: %s\n", i, buf.str().c_str());
         testAtoms.push_back(h1);
     }
@@ -56,12 +57,14 @@ vector<Handle> createHebbianGraph(AtomSpace* atomSpace, std::string baseName)
     HandleSeq outgoing1;
     outgoing1.push_back(testAtoms[0]);
     outgoing1.push_back(testAtoms[1]);
-    Handle l1 = atomSpace->addLink(SYMMETRIC_HEBBIAN_LINK, outgoing1, tv2);
+    Handle l1 = atomSpace->addLink(SYMMETRIC_HEBBIAN_LINK, outgoing1);
+    l1->setTruthValue(tv2);
 
     HandleSeq outgoing2;
     outgoing2.push_back(testAtoms[2]);
     outgoing2.push_back(testAtoms[3]);
-    Handle l2 = atomSpace->addLink(INVERSE_HEBBIAN_LINK, outgoing2, tv2);
+    Handle l2 = atomSpace->addLink(INVERSE_HEBBIAN_LINK, outgoing2);
+    l2->setTruthValue(tv2);
 
     testAtoms.push_back(l1);
     testAtoms.push_back(l2);

--- a/tests/dynamics/ImportanceUpdatingAgentUTest.cxxtest
+++ b/tests/dynamics/ImportanceUpdatingAgentUTest.cxxtest
@@ -50,20 +50,25 @@ vector<Handle> createSimpleGraph(AtomSpace* atomSpace, const char* baseName)
     TruthValuePtr tv2 = SimpleTruthValue::createTV(0.001f, 0.00001f);
     TruthValuePtr tv3 = SimpleTruthValue::createTV(0.5f, 0.99f);
     buf[baseNameLength] = '1';
-    Handle h1 = atomSpace->addNode(CONCEPT_NODE, buf, tv1);
+    Handle h1 = atomSpace->addNode(CONCEPT_NODE, buf);
+    h1->setTruthValue(tv1);
     buf[baseNameLength] = '2';
-    Handle h2 = atomSpace->addNode(CONCEPT_NODE, buf, tv2);
+    Handle h2 = atomSpace->addNode(CONCEPT_NODE, buf);
+    h2->setTruthValue(tv2);
     buf[baseNameLength] = '3';
-    Handle h3 = atomSpace->addNode(CONCEPT_NODE, buf, tv3);
+    Handle h3 = atomSpace->addNode(CONCEPT_NODE, buf);
+    h3->setTruthValue(tv3);
 
     HandleSeq outgoing1;
     outgoing1.push_back(h2);
     outgoing1.push_back(h3);
-    Handle l1 = atomSpace->addLink(LIST_LINK, outgoing1, tv1);
+    Handle l1 = atomSpace->addLink(LIST_LINK, outgoing1);
+    l1->setTruthValue(tv1);
     HandleSeq outgoing2;
     outgoing2.push_back(h1);
     outgoing2.push_back(l1);
-    Handle l2 = atomSpace->addLink(EVALUATION_LINK, outgoing2, tv2);
+    Handle l2 = atomSpace->addLink(EVALUATION_LINK, outgoing2);
+    l2->setTruthValue(tv2);
 
     testAtoms.push_back(h1);
     testAtoms.push_back(h2);

--- a/tests/learning/dimensionalembedding/DimEmbedUTest.cxxtest
+++ b/tests/learning/dimensionalembedding/DimEmbedUTest.cxxtest
@@ -57,10 +57,14 @@ public:
         AtomSpace* atomSpace = &cs.getAtomSpace();
         atomSpace->clear();
         DimEmbedModule dimEmbed = DimEmbedModule(cs);
-        Handle h1 = atomSpace->addNode(CONCEPT_NODE, "dog1", SimpleTruthValue::createTV(0.001f, 0.00001f));
-        Handle h2 = atomSpace->addNode(CONCEPT_NODE, "dog2", SimpleTruthValue::createTV(0.001f, 0.00001f));
-        Handle h3 = atomSpace->addNode(CONCEPT_NODE, "dog3", SimpleTruthValue::createTV(0.001f, 0.00001f));
-        Handle h4 = atomSpace->addNode(CONCEPT_NODE, "dog4", SimpleTruthValue::createTV(0.001f, 0.00001f));
+        Handle h1 = atomSpace->addNode(CONCEPT_NODE, "dog1");
+        h1->merge(SimpleTruthValue::createTV(0.001f, 0.00001f));
+        Handle h2 = atomSpace->addNode(CONCEPT_NODE, "dog2");
+        h2->merge(SimpleTruthValue::createTV(0.001f, 0.00001f));
+        Handle h3 = atomSpace->addNode(CONCEPT_NODE, "dog3");
+        h3->merge(SimpleTruthValue::createTV(0.001f, 0.00001f));
+        Handle h4 = atomSpace->addNode(CONCEPT_NODE, "dog4");
+        h4->merge(SimpleTruthValue::createTV(0.001f, 0.00001f));
 
         link(atomSpace, h1, h2, 0.5, 1.0);
         link(atomSpace, h1, h3, 0.7, 1.0);
@@ -74,8 +78,10 @@ public:
 
         //add some more atoms after embedding in such a way that they should
         //not affect the tests we do later...
-        Handle d1 = atomSpace->addNode(CONCEPT_NODE, "distraction1", SimpleTruthValue::createTV(0.001f, 0.00001f));
-        Handle d2 = atomSpace->addNode(CONCEPT_NODE, "distraction2", SimpleTruthValue::createTV(0.001f, 0.00001f));
+        Handle d1 = atomSpace->addNode(CONCEPT_NODE, "distraction1");
+        d1->merge(SimpleTruthValue::createTV(0.001f, 0.00001f));
+        Handle d2 = atomSpace->addNode(CONCEPT_NODE, "distraction2");
+        d2->merge(SimpleTruthValue::createTV(0.001f, 0.00001f));
         link(atomSpace, d1, d2, 0.7, 0.9);
         link(atomSpace, d1, h1, 1.0, 0.9);
         inhLink(atomSpace, h1, h3, .9, .9);

--- a/tests/persist/file/SavingLoadingUTest.cxxtest
+++ b/tests/persist/file/SavingLoadingUTest.cxxtest
@@ -97,14 +97,19 @@ public:
         SavingLoading savingLoading;
 
         // Insert 3 basic concept nodes with the already declared names and tvs.
-        Handle h1 = atomSpace.addNode(CONCEPT_NODE, (string)NODE1_NAME, tvs[0]);
-        Handle h2 = atomSpace.addNode(CONCEPT_NODE, (string)NODE2_NAME, tvs[1]);
-        Handle h3 = atomSpace.addNode(CONCEPT_NODE, (string)NODE3_NAME, tvs[2]);
+        Handle h1 = atomSpace.addNode(CONCEPT_NODE, (string)NODE1_NAME);
+        h1->setTruthValue(tvs[0]);
+        Handle h2 = atomSpace.addNode(CONCEPT_NODE, (string)NODE2_NAME);
+        h2->setTruthValue(tvs[1]);
+        Handle h3 = atomSpace.addNode(CONCEPT_NODE, (string)NODE3_NAME);
+        h3->setTruthValue(tvs[2]);
         //logger().debug("runSaving() 1");
 
         //logger().debug("runSaving() 2");
-        Handle h4 = atomSpace.addNode(CONCEPT_NODE, (string)NODE4_NAME, tvs[3]);
-        Handle h5 = atomSpace.addNode(CONCEPT_NODE, (string)NODE5_NAME, tvs[4]);
+        Handle h4 = atomSpace.addNode(CONCEPT_NODE, (string)NODE4_NAME);
+        h4->setTruthValue(tvs[3]);
+        Handle h5 = atomSpace.addNode(CONCEPT_NODE, (string)NODE5_NAME);
+        h5->setTruthValue(tvs[4]);
         //logger().debug("runSaving() 3");
 
         // Insert some links
@@ -278,7 +283,6 @@ public:
 
     void testSavingLoading()
     {
-        
         AtomSpace *atomSpace1 = new AtomSpace();
         ss = new SpaceServer(*atomSpace1);
         ts = new TimeServer(*atomSpace1, ss);

--- a/tests/persist/sql/PersistUTest.cxxtest
+++ b/tests/persist/sql/PersistUTest.cxxtest
@@ -220,15 +220,18 @@ void PersistUTest::add_to_space(int idx, AtomSpace *as, std::string id)
 {
 	// Create an atom ... 
 	TruthValuePtr stv(SimpleTruthValue::createTV(0.11, 100+idx));
-	h1[idx] = as->addNode(WORD_NODE, id + "fromNode", stv);
+	h1[idx] = as->addNode(WORD_NODE, id + "fromNode");
+	h1[idx]->setTruthValue(stv);
 	n1[idx] = NodeCast(h1[idx]);
 
 	TruthValuePtr stv2(SimpleTruthValue::createTV(0.22, 200+idx));
-	h2[idx] = as->addNode(WORD_NODE, id + "toNode", stv2);
+	h2[idx] = as->addNode(WORD_NODE, id + "toNode");
+	h2[idx]->setTruthValue(stv2);
 	n2[idx] = NodeCast(h2[idx]);
 
 	TruthValuePtr stv3(SimpleTruthValue::createTV(0.33, 300+idx));
-	h3[idx] = as->addNode(WORD_NODE, id + "third wheel", stv3);
+	h3[idx] = as->addNode(WORD_NODE, id + "third wheel");
+	h3[idx]->setTruthValue(stv3);
 	n3[idx] = NodeCast(h3[idx]);
 
 	std::vector<Handle> hvec;

--- a/tests/persist/zmq/events/AtomSpacePublisherModuleUTest.cxxtest
+++ b/tests/persist/zmq/events/AtomSpacePublisherModuleUTest.cxxtest
@@ -124,7 +124,8 @@ public:
 
         // Add an atom
         TruthValuePtr tv = SimpleTruthValue::createTV(2.1, 3.1);
-        Handle h = as->addNode(CONCEPT_NODE, "ExampleNode", tv);
+        Handle h = as->addNode(CONCEPT_NODE, "ExampleNode");
+        h->setTruthValue(tv);
 
         // Receive the event
         std::string address = s_recv (subscriberAdd);   // Message topic
@@ -144,6 +145,10 @@ public:
                         ("truthvalue.details.strength", 0), 2.1, precision);
         TS_ASSERT_DELTA(ptAtom.get<count_t>
                         ("truthvalue.details.count", 0), 3.1, precision);
+
+        // Receive the event
+        address = s_recv (subscriberTVChanged);
+        contents = s_recv (subscriberTVChanged);
 
         // Modify the atom's TruthValue
         TruthValuePtr newTV = SimpleTruthValue::createTV(5.1, 7.1);

--- a/tests/query/Boolean2NotUTest.cxxtest
+++ b/tests/query/Boolean2NotUTest.cxxtest
@@ -149,44 +149,37 @@ void Boolean2NotUTest::setUp(void)
 	// This is an assertion "Berlin is a city"
 	al(INHERITANCE_LINK,
 		an(CONCEPT_NODE, "Berlin"),
-		an(CONCEPT_NODE, "definite"),
-		TruthValue::TRUE_TV()
+		an(CONCEPT_NODE, "definite")
 	);
 	al(EVALUATION_LINK,
 		an(PREDICATE_NODE, "_subj"),
 		al(LIST_LINK,
 			an(CONCEPT_NODE, "be@1111"),
 			hberlin = an(CONCEPT_NODE, "Berlin")
-		),
-		TruthValue::TRUE_TV()
+		)
 	);
 	al(EVALUATION_LINK,
 		an(PREDICATE_NODE, "_obj"),
 		al(LIST_LINK,
 			an(CONCEPT_NODE, "be@1111"),
 			hcity = an(CONCEPT_NODE, "city")
-		),
-		TruthValue::TRUE_TV()
+		)
 	);
 	al(MEMBER_LINK,
 		an(CONCEPT_NODE, "Berlin"),
-		an(CONCEPT_NODE, "sentence-AAA"),
-		TruthValue::TRUE_TV()
+		an(CONCEPT_NODE, "sentence-AAA")
 	);
 	al(MEMBER_LINK,
 		an(CONCEPT_NODE, "city"),
-		an(CONCEPT_NODE, "sentence-AAA"),
-		TruthValue::TRUE_TV()
+		an(CONCEPT_NODE, "sentence-AAA")
 	);
 	al(MEMBER_LINK,
 		an(CONCEPT_NODE, "be@1111"),
-		an(CONCEPT_NODE, "sentence-AAA"),
-		TruthValue::TRUE_TV()
+		an(CONCEPT_NODE, "sentence-AAA")
 	);
 	al(CONTEXT_LINK,
 		an(CONCEPT_NODE, "be@1111"),
-		an(CONCEPT_NODE, "be"),
-		TruthValue::TRUE_TV()
+		an(CONCEPT_NODE, "be")
 	);
 
 	// Create data on which the above pattern should fail
@@ -195,54 +188,45 @@ void Boolean2NotUTest::setUp(void)
 	// of this "hyp" clause.
 	al(INHERITANCE_LINK,
 		an(CONCEPT_NODE, "Madrid"),
-		an(CONCEPT_NODE, "definite"),
-		TruthValue::TRUE_TV()
+		an(CONCEPT_NODE, "definite")
 	);
 	al(INHERITANCE_LINK,
 		an(CONCEPT_NODE, "be@2222"),
-		an(CONCEPT_NODE, "hyp"),
-		TruthValue::TRUE_TV()
+		an(CONCEPT_NODE, "hyp")
 	);
 	al(INHERITANCE_LINK,
 		an(CONCEPT_NODE, "be@2222"),
-		an(CONCEPT_NODE, "truth-query"),
-		TruthValue::TRUE_TV()
+		an(CONCEPT_NODE, "truth-query")
 	);
 	al(EVALUATION_LINK,
 		an(PREDICATE_NODE, "_subj"),
 		al(LIST_LINK,
 			an(CONCEPT_NODE, "be@2222"),
 			an(CONCEPT_NODE, "Madrid")
-		),
-		TruthValue::TRUE_TV()
+		)
 	);
 	al(EVALUATION_LINK,
 		an(PREDICATE_NODE, "_obj"),
 		al(LIST_LINK,
 			an(CONCEPT_NODE, "be@2222"),
 			an(CONCEPT_NODE, "city")
-		),
-		TruthValue::TRUE_TV()
+		)
 	);
 	al(MEMBER_LINK,
 		an(CONCEPT_NODE, "Madrid"),
-		an(CONCEPT_NODE, "sentence-BBB"),
-		TruthValue::TRUE_TV()
+		an(CONCEPT_NODE, "sentence-BBB")
 	);
 	al(MEMBER_LINK,
 		an(CONCEPT_NODE, "city"),
-		an(CONCEPT_NODE, "sentence-BBB"),
-		TruthValue::TRUE_TV()
+		an(CONCEPT_NODE, "sentence-BBB")
 	);
 	al(MEMBER_LINK,
 		an(CONCEPT_NODE, "be@2222"),
-		an(CONCEPT_NODE, "sentence-BBB"),
-		TruthValue::TRUE_TV()
+		an(CONCEPT_NODE, "sentence-BBB")
 	);
 	al(CONTEXT_LINK,
 		an(CONCEPT_NODE, "be@2222"),
-		an(CONCEPT_NODE, "be"),
-		TruthValue::TRUE_TV()
+		an(CONCEPT_NODE, "be")
 	);
 }
 

--- a/tests/query/BooleanUTest.cxxtest
+++ b/tests/query/BooleanUTest.cxxtest
@@ -132,85 +132,72 @@ void BooleanUTest::setUp(void)
 	// Create data on which the above pattern should match
 	al(INHERITANCE_LINK,
 		an(CONCEPT_NODE, "Berlin"),
-		an(CONCEPT_NODE, "definite"),
-		TruthValue::TRUE_TV()
+		an(CONCEPT_NODE, "definite")
 	);
 	al(EVALUATION_LINK,
 		an(PREDICATE_NODE, "_subj"),
 		al(LIST_LINK,
 			an(CONCEPT_NODE, "be"),
 			hberlin = an(CONCEPT_NODE, "Berlin")
-		),
-		TruthValue::TRUE_TV()
+		)
 	);
 	al(EVALUATION_LINK,
 		an(PREDICATE_NODE, "_obj"),
 		al(LIST_LINK,
 			an(CONCEPT_NODE, "be"),
 			hcity = an(CONCEPT_NODE, "city")
-		),
-		TruthValue::TRUE_TV()
+		)
 	);
 	al(MEMBER_LINK,
 		an(CONCEPT_NODE, "Berlin"),
-		an(CONCEPT_NODE, "sentence-AAA"),
-		TruthValue::TRUE_TV()
+		an(CONCEPT_NODE, "sentence-AAA")
 	);
 	al(MEMBER_LINK,
 		an(CONCEPT_NODE, "city"),
-		an(CONCEPT_NODE, "sentence-AAA"),
-		TruthValue::TRUE_TV()
+		an(CONCEPT_NODE, "sentence-AAA")
 	);
 
 	// Create data on which the above pattern should fail
 	al(INHERITANCE_LINK,
 		an(CONCEPT_NODE, "Spain"),
-		an(CONCEPT_NODE, "definite"),
-		TruthValue::TRUE_TV()
+		an(CONCEPT_NODE, "definite")
 	);
 	al(INHERITANCE_LINK,
 		an(CONCEPT_NODE, "Madrid"),
-		an(CONCEPT_NODE, "definite"),
-		TruthValue::TRUE_TV()
+		an(CONCEPT_NODE, "definite")
 	);
 	al(INHERITANCE_LINK,
 		an(CONCEPT_NODE, "capital"),
-		an(CONCEPT_NODE, "definite"),
-		TruthValue::TRUE_TV()
+		an(CONCEPT_NODE, "definite")
 	);
 	al(EVALUATION_LINK,
 		an(PREDICATE_NODE, "_subj"),
 		al(LIST_LINK,
 			an(CONCEPT_NODE, "be"),
 			an(CONCEPT_NODE, "capital")
-		),
-		TruthValue::TRUE_TV()
+		)
 	);
 	al(EVALUATION_LINK,
 		an(PREDICATE_NODE, "_obj"),
 		al(LIST_LINK,
 			an(CONCEPT_NODE, "be"),
 			an(CONCEPT_NODE, "Madrid")
-		),
-		TruthValue::TRUE_TV()
+		)
 	);
 	al(EVALUATION_LINK,
 		an(PREDICATE_NODE, "of"),
 		al(LIST_LINK,
 			an(CONCEPT_NODE, "capital"),
 			an(CONCEPT_NODE, "Spain")
-		),
-		TruthValue::TRUE_TV()
+		)
 	);
 	al(MEMBER_LINK,
 		an(CONCEPT_NODE, "Madrid"),
-		an(CONCEPT_NODE, "sentence-BBB"),
-		TruthValue::TRUE_TV()
+		an(CONCEPT_NODE, "sentence-BBB")
 	);
 	al(MEMBER_LINK,
 		an(CONCEPT_NODE, "capital"),
-		an(CONCEPT_NODE, "sentence-BBB"),
-		TruthValue::TRUE_TV()
+		an(CONCEPT_NODE, "sentence-BBB")
 	);
 }
 

--- a/tests/query/ExecutionOutputUTest.cxxtest
+++ b/tests/query/ExecutionOutputUTest.cxxtest
@@ -119,18 +119,16 @@ void ExecutionOutputUTest::setUp(void)
 		al(LIST_LINK,
 			an(CONCEPT_NODE, "be"),
 			hcapital = an(CONCEPT_NODE, "capital")
-		),
-		TruthValue::TRUE_TV()
-	);
+		)
+	)->setTruthValue(TruthValue::TRUE_TV());
 
 	al(EVALUATION_LINK,
 		hprep = an(PREDICATE_NODE, "of"),
 		al(LIST_LINK,
 			an(CONCEPT_NODE, "capital"),
 			an(CONCEPT_NODE, "Spain")
-		),
-		TruthValue::TRUE_TV()
-	);
+		)
+	)->setTruthValue(TruthValue::TRUE_TV());
 
 #ifdef HAVE_GUILE
 	const char * str = 

--- a/tests/scm/BasicSCMUTest.cxxtest
+++ b/tests/scm/BasicSCMUTest.cxxtest
@@ -416,23 +416,8 @@ void BasicSCMUTest::test_link_tv_setting(void)
 	TS_ASSERT_LESS_THAN_EQUALS(fabs(c - 0.25), 1.0e-6);
 
 	// Add it again, but with stronger confidence.
-	// Make sure the new values grab hold (because tv merge should use
-	// the stronger confidence value).
+	// Make sure the new values grab hold
 	inh = eval->eval_h("(ListLink (stv 0.6 0.42) (ConceptNode \"Linas\") (ConceptNode \"human\"))");
-	eval_err = eval->eval_error();
-	eval->clear_pending();
-	TSM_ASSERT("Failed to update a link", !eval_err);
-
-	tv = as->getTV(inh);
-	m = tv->getMean();
-	c = tv->getConfidence();
-	TS_ASSERT_LESS_THAN_EQUALS(fabs(m - 0.6), 1.0e-6);
-	TS_ASSERT_LESS_THAN_EQUALS(fabs(c - 0.42), 1.0e-6);
-
-	// Add it again, but with weaker confidence.
-	// Make sure the new values DO NOT grab hold (because tv merge
-	// should use the stronger confidence value).
-	inh = eval->eval_h("(ListLink (stv 0.9 0.16) (ConceptNode \"Linas\") (ConceptNode \"human\"))");
 	eval_err = eval->eval_error();
 	eval->clear_pending();
 	TSM_ASSERT("Failed to update a link", !eval_err);

--- a/tests/server/AgentUTest.cxxtest
+++ b/tests/server/AgentUTest.cxxtest
@@ -56,26 +56,31 @@ vector<Handle> createSimpleGraph(AtomSpace* atomSpace, const char* baseName)
     TruthValuePtr tv2 = SimpleTruthValue::createTV(0.001f, 0.00001f);
     TruthValuePtr tv3 = SimpleTruthValue::createTV(0.5f, 0.99f);
     buf[baseNameLength] = '1';
-    Handle h1 = atomSpace->addNode(CONCEPT_NODE, buf, tv1);
+    Handle h1 = atomSpace->addNode(CONCEPT_NODE, buf);
+    h1->setTruthValue(tv1);
     atomSpace->setSTI(h1, AV1_STI);
     atomSpace->setLTI(h1, AV1_LTI);
     buf[baseNameLength] = '2';
-    Handle h2 = atomSpace->addNode(CONCEPT_NODE, buf, tv2);
+    Handle h2 = atomSpace->addNode(CONCEPT_NODE, buf);
+    h2->setTruthValue(tv2);
     atomSpace->setSTI(h2, AV2_STI);
     atomSpace->setLTI(h2, AV2_LTI);
     buf[baseNameLength] = '3';
-    Handle h3 = atomSpace->addNode(CONCEPT_NODE, buf, tv3);
+    Handle h3 = atomSpace->addNode(CONCEPT_NODE, buf);
+    h3->setTruthValue(tv3);
     atomSpace->setSTI(h3, AV3_STI);
     atomSpace->setLTI(h3, AV3_LTI);
 
     HandleSeq outgoing1;
     outgoing1.push_back(h2);
     outgoing1.push_back(h3);
-    Handle l1 = atomSpace->addLink(LIST_LINK, outgoing1, tv1);
+    Handle l1 = atomSpace->addLink(LIST_LINK, outgoing1);
+    l1->setTruthValue(tv1);
     HandleSeq outgoing2;
     outgoing2.push_back(h1);
     outgoing2.push_back(l1);
-    Handle l2 = atomSpace->addLink(EVALUATION_LINK, outgoing2, tv2);
+    Handle l2 = atomSpace->addLink(EVALUATION_LINK, outgoing2);
+    l2->setTruthValue(tv2);
 
     testAtoms.push_back(h1);
     testAtoms.push_back(h2);


### PR DESCRIPTION
Pursuant to discussions in bug #1279.  This is in preparation for
removing merge from the atomspace itself.