### PR TITLE
Fix exception handling for ExecutionOutputLink

### DIFF
--- a/examples/guile/except.scm
+++ b/examples/guile/except.scm
@@ -1,0 +1,42 @@
+;
+; Guile excpetion handling example.
+; The cog-execute! function is demonstrated.
+;
+
+(use-modules (opencog))
+
+; First, just give it some broken junk.  See what happens.
+(cog-execute!
+   (ExecutionOutputLink
+      (GroundedSchemaNode "py:b0rk3n_junk")
+      (ListLink
+         (ConceptNode "1")
+         (ConceptNode "2"))))
+
+; C++ exceptions are converted into scheme exceptions, and can be
+; caught, as usual.
+(catch
+   #t
+   (lambda ()
+      (cog-execute!
+         (ExecutionOutputLink
+            (GroundedSchemaNode "py:b0rk3n_junk")
+            (ListLink
+               (ConceptNode "1")
+               (ConceptNode "2")))))
+   (lambda (key . args)
+      (display "Ohhh noooo Mr. Bill!!! ") (display key)
+		(newline)
+		(display "Sluggo says to ... ") (display args)
+		(newline) (newline)
+   ))
+
+
+; Exception-producing code, but for mal-formed scheme.
+;
+(cog-execute!
+   (ExecutionOutputLink
+      (GroundedSchemaNode "scm:(((((uber-badf")
+      (ListLink
+         (ConceptNode "1")
+         (ConceptNode "2"))))

--- a/opencog/execution/ExecutionOutputLink.cc
+++ b/opencog/execution/ExecutionOutputLink.cc
@@ -120,7 +120,14 @@ Handle ExecutionOutputLink::do_execute(AtomSpace* as, Handle gsn, Handle args)
         while (' ' == schema[pos]) pos++;
 
         SchemeEval* applier = get_evaluator(as);
-        return applier->apply(schema.substr(pos), args);
+        Handle h(applier->apply(schema.substr(pos), args));
+
+        // Exceptions were already caught, before leaving guile mode,
+        // so we can't rethrow.  Just throw a new exception.
+        if (applier->eval_error())
+            throw RuntimeException(TRACE_INFO,
+                "Failed evaluation; see logfile for stack trace.");
+        return h;
 #else
         throw RuntimeException(TRACE_INFO,
             "Cannot evaluate scheme GroundedSchemaNode!");

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -14,7 +14,7 @@
 #define _OPENCOG_SCHEME_SMOB_H
 
 #include <atomic>
-#include <set>
+#include <map>
 #include <string>
 #include <vector>
 #include <libguile.h>
@@ -132,7 +132,8 @@ class SchemeSmob
 		static SCM take_as(AtomSpace *);
 		static SCM make_as(AtomSpace *);
 		static AtomSpace* ss_to_atomspace(SCM);
-		static std::set<AtomSpace*> deleteable_as;
+		static std::mutex as_mtx;
+		static std::map<AtomSpace*, int> deleteable_as;
 
 		// Attention values
 		static SCM ss_new_av(SCM, SCM, SCM);

--- a/opencog/guile/SchemeSmobGC.cc
+++ b/opencog/guile/SchemeSmobGC.cc
@@ -63,8 +63,9 @@ size_t SchemeSmob::free_misc(SCM node)
 		case COG_AS:
 		{
 			AtomSpace *as = (AtomSpace *) SCM_SMOB_DATA(node);
+			std::lock_guard<std::mutex> lck(as_mtx);
 			auto has = deleteable_as.find(as);
-			if (deleteable_as.end() != has)
+			if (deleteable_as.end() != has and 0 == deleteable_as[as])
 			{
 				deleteable_as.erase(has);
 				scm_gc_unregister_collectable_memory (as,


### PR DESCRIPTION
This pursues exception handling issues that arise after bug #1131 gets fixed.  See /examples/guile/except.scm for a demo.  Works both for 'bare' sessions and for telnet localhost 17001 sessions