### PR TITLE
Fix Python references, add PythonEval unit test

### DIFF
--- a/opencog/cython/PythonEval.h
+++ b/opencog/cython/PythonEval.h
@@ -111,7 +111,7 @@ class PythonEval : public GenericEval
         PyObject* pyLocal;
         PyObject* pyRootModule;
 
-        PyObject* sys_path;
+        PyObject* pySysPath;
 
         std::map <std::string, PyObject*> modules;
 

--- a/tests/cython/CMakeLists.txt
+++ b/tests/cython/CMakeLists.txt
@@ -22,6 +22,22 @@ IF (HAVE_SERVER)
 ENDIF (HAVE_SERVER)
 
 
+# The PythonEvalUTest is derived from the CogServer class, and so 
+# cannot be tested unless the cogserver is actually being built!
+IF (HAVE_SERVER)
+	ADD_CXXTEST(PythonEvalUTest)
+	CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/cython/pyeval.conf
+		${PROJECT_BINARY_DIR}/tests/cython/pyeval.conf)
+
+	TARGET_LINK_LIBRARIES(PythonEvalUTest
+		server
+		cogutil
+	)
+	SET_TESTS_PROPERTIES(PythonEvalUTest
+		PROPERTIES ENVIRONMENT "PYTHONPATH=${PROJECT_BINARY_DIR}/opencog/cython")
+ENDIF (HAVE_SERVER)
+
+
 IF (HAVE_NOSETESTS)
 
 	# Basic test, just does the cython wrapper for opencog/util

--- a/tests/cython/PythonEvalUTest.cxxtest
+++ b/tests/cython/PythonEvalUTest.cxxtest
@@ -1,0 +1,122 @@
+#include <string>
+#include <cstdio>
+
+#include <opencog/server/CogServer.h>
+#include <opencog/server/RequestResult.h>
+#include <opencog/util/Config.h>
+#include <opencog/cython/PyMindAgent.h>
+
+using std::string;
+
+using namespace opencog;
+
+class StringRequestResult : public RequestResult
+{
+public:
+    string result;
+    StringRequestResult(): RequestResult ("text/plain"){};
+    ~StringRequestResult(){};
+    virtual void SendResult(const std::string& res) {
+        result = res;
+    }
+    virtual void OnRequestComplete() {
+    }
+};
+
+class TestCogServer : public CogServer
+{
+    int tickCount;
+    bool tickBased;
+    int maxCount;
+    public: 
+
+        static BaseServer* createInstance() {
+            return new TestCogServer();
+        }
+
+        TestCogServer() : tickCount(1), tickBased(false), maxCount(1000) {}
+
+        void setTickBased(bool _tickBased) {
+            tickBased = _tickBased;
+        }
+
+        void setMaxCount(int _maxCount) {
+            maxCount = _maxCount;
+        }
+
+        bool customLoopRun() {
+            bool runCycle  = tickBased?(tickCount % 100 == 0):true; 
+            if (++tickCount > maxCount) stop();
+            return runCycle;
+        }
+};
+
+class PythonEvalUTest :  public CxxTest::TestSuite
+{
+
+private:
+
+
+public:
+
+    PythonEvalUTest() {
+        logger().setLevel(Logger::DEBUG);
+        logger().setPrintToStdoutFlag(true);
+
+        // Load special config file for the test
+        string configFile = PROJECT_BINARY_DIR"/tests/cython/pyeval.conf";
+        try {
+            config().load(configFile.c_str(), false);
+        } catch (RuntimeException &e) {
+            std::cerr << e.getMessage() << std::endl;
+            exit(1);
+        }
+        // setup global logger
+        logger().setFilename(config()["LOG_FILE"]);
+        logger().setLevel(Logger::getLevelFromString(config()["LOG_LEVEL"]));
+        logger().setBackTraceLevel(Logger::getLevelFromString(config()["BACK_TRACE_LOG_LEVEL"]));
+        logger().setPrintToStdoutFlag(config().get_bool("LOG_TO_STDOUT"));
+
+        // set cycle duration to a smaller value so that this test do not take too long.
+        config().set("SERVER_CYCLE_DURATION", "10");  // in milliseconds
+        TestCogServer& cogserver = static_cast<TestCogServer&>(server(TestCogServer::createInstance)); 
+
+        config().set("MODULES", "opencog/shell/libpy-shell.so");
+        cogserver.loadModules();
+    }
+
+    ~PythonEvalUTest() {
+        TestCogServer& cogserver = static_cast<TestCogServer&>(server(TestCogServer::createInstance)); 
+	    // erase the log file if no assertions failed
+	    if (!CxxTest::TestTracker::tracker().suiteFailed())
+            std::remove(logger().getFilename().c_str());
+        cogserver.unloadModule("opencog::PythonEval");
+    }
+
+    void setUp() {
+    }
+
+    void tearDown() {
+    }
+
+    void testPythonEvalScript() {
+        TestCogServer& cogserver = static_cast<TestCogServer&>(server(TestCogServer::createInstance));
+
+        //  Create the py-eval request.
+        Request* pythonEvalRequest = cogserver.createRequest("py-eval");
+        TS_ASSERT(pythonEvalRequest != NULL);
+        pythonEvalRequest->addParameter("print 'Hello'");
+        StringRequestResult *pythonEvalRequestResult = new StringRequestResult();
+        pythonEvalRequest->setRequestResult(pythonEvalRequestResult);
+
+        // Add request to queue.
+        cogserver.pushRequest(pythonEvalRequest);
+
+        // Process this request.
+        cogserver.runLoopStep();
+
+        // Make sure we get a "Hello" back.
+        TS_ASSERT_DIFFERS(pythonEvalRequestResult->result.find("Hello"), std::string::npos)
+    }
+
+};

--- a/tests/cython/pyeval.conf
+++ b/tests/cython/pyeval.conf
@@ -1,0 +1,6 @@
+
+# cmake replaces this variable
+PYTHON_EXTENSION_DIRS = @CMAKE_SOURCE_DIR@/tests/cython,@CMAKE_SOURCE_DIR@/tests/cython/agents
+
+# Run these python modules on start up
+PYTHON_PRELOAD = pyshell


### PR DESCRIPTION
Fixed many problems with Python object reference counting in PythonEval.

Added PythonEval unit test.

Added a throw of RuntimeError for bad function names in PythonEval::apply
Added a throw of RuntimeError for errors in Python code in PythonEval::apply_script.