### PR TITLE
New NLP pipeline entry point for node count incrementing

### DIFF
--- a/opencog/nlp/learn/link-pipeline.scm
+++ b/opencog/nlp/learn/link-pipeline.scm
@@ -128,12 +128,7 @@
 ; it parsed, and then updates the counts for the observed words and word
 ; pairs.
 (define (observe-text plain-text)
-	(begin
-		(relex-parse plain-text)  ;; send plain-text to server
-		(update-link-counts (get-new-parsed-sentences))
-		(release-new-parsed-sents)
-		(delete-sentences)
-	)
+	(update-link-counts (nlp-parse plain-text))
 )
 
 ; ---------------------------------------------------------------------

--- a/opencog/nlp/scm/processing-utils.scm
+++ b/opencog/nlp/scm/processing-utils.scm
@@ -301,21 +301,6 @@
 	(r2l-parse plain-text)
 	
 	(let ((sent-nodes (get-new-parsed-sentences)))
-		; increment the WordNode's count value
-		(parallel-map-parses
-			(lambda (p)
-				(map-word-instances
-					(lambda (wi)
-						(map-word-node
-							(lambda (w) (cog-atom-incr w 1))
-							wi
-						)
-					)
-					p
-				)
-			)
-			sent-nodes
-		)
 		; increment the R2L's node count value
 		(parallel-map-parses
 			(lambda (p)

--- a/opencog/nlp/scm/processing-utils.scm
+++ b/opencog/nlp/scm/processing-utils.scm
@@ -290,3 +290,37 @@
 	)
 )
 
+; -----------------------------------------------------------------------
+; nlp-parse -- Wrap the whole NLP pipeline in one function.
+; 
+; Call the necessary functions for the full NLP pipeline.
+;
+(define (nlp-parse plain-text)
+	(define sent-nodes)
+
+	(r2l plain-text)
+	
+	; store the SentenceNode
+	(set! sent-nodes (get-new-parsed-sentences))
+	
+	; increment the WordNode's count value
+	(parallel-map-parses
+		(lambda (p)
+			(map-word-instances
+				(lambda (wi)
+					(map-word-node
+						(lambda (w) (cog-atom-incr w 1))
+						wi
+					)
+				)
+				p
+			)
+		)
+		sent-nodes
+	)
+	(release-new-parsed-sents)
+	
+	; return the list of SentenceNode
+	sent-nodes
+)
+

--- a/opencog/nlp/scm/processing-utils.scm
+++ b/opencog/nlp/scm/processing-utils.scm
@@ -21,26 +21,20 @@
    )
 )
 
-; -----------------------------------------------------------------------
-; global vars:
-; new-sent anchor points at the node to which all new sentences are connected
-;
-(define *new-parsed-sent-anchor* (AnchorNode "# New Parsed Sentence" (stv 1 1)))
-
 ; Return the list of SentenceNodes that are attached to the 
 ; freshly-parsed anchor.  This list will be non-empty if relex-parse
 ; has been recently run. This list can be emptied with the call
 ; release-new-parsed-sent below.
 ;
 (define (get-new-parsed-sentences)
-	(cog-chase-link 'ListLink 'SentenceNode *new-parsed-sent-anchor*)
+	(cog-chase-link 'ListLink 'SentenceNode (AnchorNode "# New Parsed Sentence"))
 )
 
 ; release-new-parsed-sents deletes the links that anchor sentences to 
 ; to new-parsed-sent anchor.
 ;
 (define (release-new-parsed-sents)
-	(release-from-anchor *new-parsed-sent-anchor*)
+	(release-from-anchor (AnchorNode "# New Parsed Sentence"))
 )
 
 ; -----------------------------------------------------------------------

--- a/opencog/nlp/sureal/README.md
+++ b/opencog/nlp/sureal/README.md
@@ -14,8 +14,8 @@ or `WordInstanceNode` before calling `sureal`.
 For example, you can do
 
 ```
-(r2l "He eats.")
-(r2l "He eats quickly.")
+(nlp-parse "He eats.")
+(nlp-parse "He eats quickly.")
 (WordNode "she")
 (WordNode "drinks")
 (sureal (SetLink (EvaluationLink (PredicateNode "drinks") (ListLink (ConceptNode "she")))))
@@ -29,8 +29,9 @@ which will return all possible sentence is words list, like
 ## Algorithm
 
 SuReal does pattern matching on existing sentences in the atomspace.  Existing
-sentences mean those that were inputed with `(r2l ...)` calls.  The `r2l` call
-will uses LG, RelEx, and RelEx2Logic to generate the necessary atoms.
+sentences mean those that were inputed with `(nlp-parse ...)` calls.  The
+`nlp-parse` call will uses LG, RelEx, and RelEx2Logic to generate the necessary
+atoms.
 
 Especially important is the LG outputs.  For each sentence, a bunch of links of
 the style

--- a/tests/nlp/microplanning/test-atomspace.scm
+++ b/tests/nlp/microplanning/test-atomspace.scm
@@ -8,29 +8,29 @@ For now, most of the results are in r2l-atomspace.scm
 ; =========================
 ; Exact knowledge
 ; =========================
-;(r2l "The brown cat climbs the table and grabs the orange.")  ; disable conjunction for now
+;(nlp-parse "The brown cat climbs the table and grabs the orange.")  ; disable conjunction for now
 
-(r2l "The brown cat climbs the table.")
+(nlp-parse "The brown cat climbs the table.")
 
-;(r2l "John steals the orange and eats it.")          ; need support for the next sentence (the same sentendce w/ and w/o anaphora)
-;(r2l "John steals and eats the orange.")             ; need R2L/RelEx to add proper support for this type of sentence
-;(r2l "John steals the orange and eats the orange.")  ; unless R2L puts the two orange to one instance, will never match this sentence
+;(nlp-parse "John steals the orange and eats it.")          ; need support for the next sentence (the same sentendce w/ and w/o anaphora)
+;(nlp-parse "John steals and eats the orange.")             ; need R2L/RelEx to add proper support for this type of sentence
+;(nlp-parse "John steals the orange and eats the orange.")  ; unless R2L puts the two orange to one instance, will never match this sentence
 
-(r2l "John steals the orange.")
-(r2l "John steals it.")
+(nlp-parse "John steals the orange.")
+(nlp-parse "John steals it.")
 
-;(r2l "Sam collects the tiny bones and plants them.")
-;(r2l "Sam collects and plants the tiny bones.")      ; same thing, need R2L/RelEx support
+;(nlp-parse "Sam collects the tiny bones and plants them.")
+;(nlp-parse "Sam collects and plants the tiny bones.")      ; same thing, need R2L/RelEx support
 
-(r2l "Sam collects the tiny bones.")
+(nlp-parse "Sam collects the tiny bones.")
 
-;(r2l "The cat hurts the dog.")                       ; reflexive test
+;(nlp-parse "The cat hurts the dog.")                       ; reflexive test
 
-(r2l "They grow.")
-(r2l "Apple's dogs grow.")                            ; possession test
+(nlp-parse "They grow.")
+(nlp-parse "Apple's dogs grow.")                            ; possession test
 
-(r2l "What burns the tree?")
-(r2l "I mean the tall man.")
+(nlp-parse "What burns the tree?")
+(nlp-parse "I mean the tall man.")
 
 
 ; =========================


### PR DESCRIPTION
The PTV count increment doesn't work yet since R2L rule-helpers are rewriting each node with a new STV everytime.  They need to be removed.

* Changed `(r2l ...)` to `(r2l-parse ...)` to notify ppl of new entry point
* `(nlp-parse ...)` is the new entry point for parsing text, it will return the sentence-nodes