### PR TITLE
Fuzzy hypergraph matching

### DIFF
--- a/opencog/nlp/chatbot/sentence-matching.scm
+++ b/opencog/nlp/chatbot/sentence-matching.scm
@@ -16,7 +16,7 @@
             ; Use SuReal to generate sentences from their corresponding SetLinks
             (generate-sentences
                 ; Search for any similar SetLinks in the atomspace
-                (cog-fuzzy
+                (cog-fuzzy-match
                     ; Get the R2L SetLink of the input sentence
                     (car (cog-chase-link 'ReferenceLink 'SetLink
                         (car (cog-chase-link 'InterpretationLink 'InterpretationNode

--- a/opencog/nlp/chatbot/sentence-matching.scm
+++ b/opencog/nlp/chatbot/sentence-matching.scm
@@ -1,0 +1,32 @@
+; Returns one or more sentences that are structurally similar to the input one.
+;
+; For example:
+;    (get-similar-sentences "What did Pete eat?")
+;
+; Possible result: 
+;    (Pete ate apples .)
+;
+(define (get-similar-sentences input-sentence)
+    ; Generate sentences from each of the R2L-SetLinks
+    (define (generate-sentences r2l-setlinks) (if (> (length r2l-setlinks) 0) (map sureal r2l-setlinks) '()))
+
+    (begin
+        ; Delete identical sentences from the return set
+        (delete-duplicates
+            ; Use SuReal to generate sentences from their corresponding SetLinks
+            (generate-sentences
+                ; Search for any similar SetLinks in the atomspace
+                (cog-fuzzy
+                    ; Get the R2L SetLink of the input sentence
+                    (car (cog-chase-link 'ReferenceLink 'SetLink
+                        (car (cog-chase-link 'InterpretationLink 'InterpretationNode
+                            (car (cog-chase-link 'ParseLink 'ParseNode
+                                (car (nlp-parse input-sentence))
+                            ))
+                        ))
+                    ))
+                )
+            )
+        )
+    )
+)

--- a/opencog/query/CMakeLists.txt
+++ b/opencog/query/CMakeLists.txt
@@ -10,6 +10,10 @@ ADD_LIBRARY(query SHARED
 	PatternUtils.cc
 	VirtualMatch.cc
 	AttentionalFocusCB.cc
+	FuzzyMatch/FuzzyPatternMatch.cc
+	FuzzyMatch/FuzzyPatternMatchCB.cc
+	FuzzyMatch/FuzzyPatternSCM.cc
+	FuzzyMatch/GraphEditDist.cc
 )
 
 ADD_DEPENDENCIES(query

--- a/opencog/query/FuzzyMatch/FuzzyPatternMatch.cc
+++ b/opencog/query/FuzzyMatch/FuzzyPatternMatch.cc
@@ -41,7 +41,7 @@ FuzzyPatternMatch::FuzzyPatternMatch()
  * or more of the candidates that are the most similar to the query hypergraph.
  *
  * @param hg  The query hypergraph
- * @return    One or more hypergraphs that are similar to the query hypergraph (hg)
+ * @return    One or more similar hypergraphs
  */
 HandleSeq FuzzyPatternMatch::find_approximate_matches(Handle hg)
 {

--- a/opencog/query/FuzzyMatch/FuzzyPatternMatch.cc
+++ b/opencog/query/FuzzyMatch/FuzzyPatternMatch.cc
@@ -1,0 +1,66 @@
+/*
+ * FuzzyPatternMatch.cc
+ *
+ * Copyright (C) 2015 OpenCog Foundation
+ *
+ * Author: Leung Man Hin <https://github.com/leungmanhin>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/guile/SchemeSmob.h>
+#include "FuzzyPatternMatchCB.h"
+#include "FuzzyPatternMatch.h"
+
+using namespace opencog;
+
+FuzzyPatternMatch::FuzzyPatternMatch()
+{
+
+}
+
+/**
+ * Implement the "cog-fuzzy" scheme primitive.
+ *
+ * Use Pattern Matcher to find the candidates, estimate the similarity by
+ * computing the edit distance for each of the candidate, eventually return one
+ * or more of the candidates that are the most similar to the query hypergraph.
+ *
+ * @param hg  The query hypergraph
+ * @return    One or more hypergraphs that are similar to the query hypergraph (hg)
+ */
+HandleSeq FuzzyPatternMatch::find_approximate_matches(Handle hg)
+{
+#ifdef HAVE_GUILE
+    AtomSpace* as = SchemeSmob::ss_get_env_as("cog-fuzzy");
+
+    FuzzyPatternMatchCB fpmcb(as);
+
+    std::set<Handle> vars;
+
+    HandleSeq preds;
+    preds.push_back(hg);
+
+    HandleSeq negs;
+
+    pme.match(&fpmcb, vars, preds, negs);
+
+    return fpmcb.solns;
+#else
+    return Handle::UNDEFINED;
+#endif
+}

--- a/opencog/query/FuzzyMatch/FuzzyPatternMatch.cc
+++ b/opencog/query/FuzzyMatch/FuzzyPatternMatch.cc
@@ -34,7 +34,7 @@ FuzzyPatternMatch::FuzzyPatternMatch()
 }
 
 /**
- * Implement the "cog-fuzzy" scheme primitive.
+ * Implement the "cog-fuzzy-match" scheme primitive.
  *
  * Use Pattern Matcher to find the candidates, estimate the similarity by
  * computing the edit distance for each of the candidate, eventually return one
@@ -46,7 +46,7 @@ FuzzyPatternMatch::FuzzyPatternMatch()
 HandleSeq FuzzyPatternMatch::find_approximate_matches(Handle hg)
 {
 #ifdef HAVE_GUILE
-    AtomSpace* as = SchemeSmob::ss_get_env_as("cog-fuzzy");
+    AtomSpace* as = SchemeSmob::ss_get_env_as("cog-fuzzy-match");
 
     FuzzyPatternMatchCB fpmcb(as);
 

--- a/opencog/query/FuzzyMatch/FuzzyPatternMatch.h
+++ b/opencog/query/FuzzyMatch/FuzzyPatternMatch.h
@@ -30,8 +30,7 @@
 namespace opencog
 {
     /**
-     * Find hypergraphs by using Pattern Matcher that are fairly similar to
-     * the query hypergraph.
+     * Find hypergraphs that are structurally similar to the one in the query.
      */
     class FuzzyPatternMatch
     {
@@ -41,7 +40,6 @@ namespace opencog
 
         private:
             PatternMatchEngine pme;
-            HandleSeq start_fuzzy_matching(AtomSpace* as, const Handle& hg);
     };
 }
 

--- a/opencog/query/FuzzyMatch/FuzzyPatternMatch.h
+++ b/opencog/query/FuzzyMatch/FuzzyPatternMatch.h
@@ -1,0 +1,48 @@
+/*
+ * FuzzyPatternMatch.h
+ *
+ * Copyright (C) 2015 OpenCog Foundation
+ *
+ * Author: Leung Man Hin <https://github.com/leungmanhin>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef FUZZYPATTERNMATCH_H
+#define FUZZYPATTERNMATCH_H
+
+#include <opencog/atomspace/Handle.h>
+#include <opencog/query/PatternMatchEngine.h>
+
+namespace opencog
+{
+    /**
+     * Find hypergraphs by using Pattern Matcher that are fairly similar to
+     * the query hypergraph.
+     */
+    class FuzzyPatternMatch
+    {
+        public:
+            FuzzyPatternMatch();
+            HandleSeq find_approximate_matches(Handle hg);
+
+        private:
+            PatternMatchEngine pme;
+            HandleSeq start_fuzzy_matching(AtomSpace* as, const Handle& hg);
+    };
+}
+
+#endif // FUZZYPATTERNMATCH_H

--- a/opencog/query/FuzzyMatch/FuzzyPatternMatchCB.cc
+++ b/opencog/query/FuzzyMatch/FuzzyPatternMatchCB.cc
@@ -1,0 +1,152 @@
+/*
+ * FuzzyPatternMatchCB.cc
+ *
+ * Copyright (C) 2015 OpenCog Foundation
+ *
+ * Author: Leung Man Hin <https://github.com/leungmanhin>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "FuzzyPatternMatchCB.h"
+
+using namespace opencog;
+
+//#define DEBUG
+
+FuzzyPatternMatchCB::FuzzyPatternMatchCB(AtomSpace* as) : DefaultPatternMatchCB(as)
+{
+
+}
+
+/**
+ * Override the link_match callback.
+ *
+ * This is for finding similar links/hypergraphs in the atomspace. The possible
+ * grounding link (gLink) will be compared with the pattern link (pLink) and see
+ * if it should be accepted, based on the similarity between them.
+ *
+ * @param pLink  The link from the query
+ * @param gLink  A possible grounding link found by the Pattern Matcher
+ * @return       Always return false to search for more solutions
+ */
+bool FuzzyPatternMatchCB::link_match(LinkPtr& pLink, LinkPtr& gLink)
+{
+    // Check if the types of the links are the same before going further into
+    // the similarity estimation.
+    // This is mainly for reducing the amount of hypergraphs being processed
+    // as the content of two links with different types are likely to be quite
+    // different.
+    if (pLink->getType() != gLink->getType()) return false;
+
+    check_if_accept(pLink->getHandle(), gLink->getHandle());
+
+    return false;
+}
+
+/**
+ * Override the node_match callback.
+ *
+ * This is for finding similar nodes in the atomspace. The possible grounding
+ * node (gNode) will be compared with the pattern node (pNode) and see if it
+ * should be accepted, based on the similarity between them.
+ *
+ * @param pNode  A handle of the node form the query
+ * @param gNode  A handle of a possible grounding node
+ * @return       Always return false to search for more solutions
+ */
+bool FuzzyPatternMatchCB::node_match(Handle& pNode, Handle& gNode)
+{
+    check_if_accept(pNode, gNode);
+
+    return false;
+}
+
+/**
+ * Implement the grounding callback.
+ *
+ * Always return false to search for more solutions.
+ *
+ * @param var_soln   The variable & links mapping
+ * @param pred_soln  The clause mapping
+ * @return           Always return false to search for more solutions
+ */
+bool FuzzyPatternMatchCB::grounding(const std::map<Handle, Handle>& var_soln,
+                                    const std::map<Handle, Handle>& pred_soln)
+{
+    return false;
+}
+
+/**
+ * Check how similar the two hypergraphs are by computing the edit distance. If
+ * the edit distance is smaller than or equals to the previous minimum, then
+ * it will be accepted.
+ *
+ * @param ph  A handle of the hypergraph from the query
+ * @param gh  A handle of a possible grounding hypergraph
+ * @return    True if it is accepted, false otherwise
+ */
+bool FuzzyPatternMatchCB::check_if_accept(const Handle& ph, const Handle& gh)
+{
+    // Compute the edit distance
+    cand_edit_dist = ged.compute(ph, gh);
+
+    // Skip identical hypergraphs, if any
+    if (cand_edit_dist == 0)
+    {
+#ifdef DEBUG
+        printf("Cost = %.3f\nSkipped!\n\n", cand_edit_dist);
+#endif
+        return false;
+    }
+
+    // If the edit distance of the current hypergraph is smaller than the
+    // previous minimum, it becomes the new minimum
+    else if (cand_edit_dist < min_edit_dist)
+    {
+#ifdef DEBUG
+        printf("Cost = %.3f\nMin. Cost = %.3f\nAccepted!\n\n",
+               cand_edit_dist, min_edit_dist);
+#endif
+        min_edit_dist = cand_edit_dist;
+        solns.clear();
+        solns.push_back(gh);
+        return true;
+    }
+
+    // If the edit distance of the current hypergraph is the same as the
+    // previous minimum, add it to the solution-list
+    else if (cand_edit_dist == min_edit_dist)
+    {
+#ifdef DEBUG
+        printf("Cost = %.3f\nMin. Cost = %.3f\nAccepted!\n\n",
+               cand_edit_dist, min_edit_dist);
+#endif
+        solns.push_back(gh);
+        return true;
+    }
+
+    // If the edit distance of the current hypergraph is greater than the
+    // previous minimum, reject it
+    else
+    {
+#ifdef DEBUG
+        printf("Cost = %.3f\nMin. Cost = %.3f\nRejected!\n\n",
+               cand_edit_dist, min_edit_dist);
+#endif
+        return false;
+    }
+}

--- a/opencog/query/FuzzyMatch/FuzzyPatternMatchCB.h
+++ b/opencog/query/FuzzyMatch/FuzzyPatternMatchCB.h
@@ -1,0 +1,57 @@
+/*
+ * FuzzyPatternMatchCB.h
+ *
+ * Copyright (C) 2015 OpenCog Foundation
+ *
+ * Author: Leung Man Hin <https://github.com/leungmanhin>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef FUZZYPATTERNMATCHCB_H
+#define FUZZYPATTERNMATCHCB_H
+
+#include <opencog/query/DefaultPatternMatchCB.h>
+#include "GraphEditDist.h"
+
+namespace opencog
+{
+    class FuzzyPatternMatchCB : public DefaultPatternMatchCB
+    {
+        public:
+            // Storing the hypergraphs that are similar to the input one
+            HandleSeq solns;
+
+            FuzzyPatternMatchCB(AtomSpace* as);
+
+            virtual bool link_match(LinkPtr& pLink, LinkPtr& gLink);
+            virtual bool node_match(Handle& pNode, Handle& gNode);
+            virtual bool grounding(const std::map<Handle, Handle>& var_soln,
+                                   const std::map<Handle, Handle>& pred_soln);
+
+        private:
+            // Min. edit distance of the query hypergraph and the candidate
+            double cand_edit_dist = 0;
+
+            // Min. edit distance among all the candidates
+            double min_edit_dist = SIZE_MAX;
+
+            GraphEditDist ged;
+            bool check_if_accept(const Handle& ph, const Handle& gh);
+    };
+}
+
+#endif // FUZZYPATTERNMATCHCB_H

--- a/opencog/query/FuzzyMatch/FuzzyPatternSCM.cc
+++ b/opencog/query/FuzzyMatch/FuzzyPatternSCM.cc
@@ -1,0 +1,37 @@
+/*
+ * FuzzyPatternSCM.cc
+ *
+ * Copyright (C) 2015 OpenCog Foundation
+ *
+ * Author: Leung Man Hin <https://github.com/leungmanhin>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/guile/SchemePrimitive.h>
+#include "FuzzyPatternMatch.h"
+#include "FuzzyPatternSCM.h"
+
+using namespace opencog;
+
+FuzzyPatternSCM::FuzzyPatternSCM()
+{
+#ifdef HAVE_GUILE
+    define_scheme_primitive("cog-fuzzy",
+                            &FuzzyPatternMatch::find_approximate_matches,
+                            new FuzzyPatternMatch);
+#endif
+}

--- a/opencog/query/FuzzyMatch/FuzzyPatternSCM.cc
+++ b/opencog/query/FuzzyMatch/FuzzyPatternSCM.cc
@@ -30,7 +30,7 @@ using namespace opencog;
 FuzzyPatternSCM::FuzzyPatternSCM()
 {
 #ifdef HAVE_GUILE
-    define_scheme_primitive("cog-fuzzy",
+    define_scheme_primitive("cog-fuzzy-match",
                             &FuzzyPatternMatch::find_approximate_matches,
                             new FuzzyPatternMatch);
 #endif

--- a/opencog/query/FuzzyMatch/FuzzyPatternSCM.h
+++ b/opencog/query/FuzzyMatch/FuzzyPatternSCM.h
@@ -27,7 +27,7 @@
 namespace opencog
 {
     /**
-     * Define a scheme primitive (cog-fuzzy), which finds hypergraphs that
+     * Define a scheme primitive (cog-fuzzy-match), which finds hypergraphs that
      * are similar to the query hypergraph.
      */
     class FuzzyPatternSCM

--- a/opencog/query/FuzzyMatch/FuzzyPatternSCM.h
+++ b/opencog/query/FuzzyMatch/FuzzyPatternSCM.h
@@ -1,0 +1,40 @@
+/*
+ * FuzzyPatternSCM.h
+ *
+ * Copyright (C) 2015 OpenCog Foundation
+ *
+ * Author: Leung Man Hin <https://github.com/leungmanhin>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef FUZZYPATTERNSCM_H
+#define FUZZYPATTERNSCM_H
+
+namespace opencog
+{
+    /**
+     * Define a scheme primitive (cog-fuzzy), which finds hypergraphs that
+     * are similar to the query hypergraph.
+     */
+    class FuzzyPatternSCM
+    {
+        public:
+            FuzzyPatternSCM();
+    };
+}
+
+#endif // FUZZYPATTERNSCM_H

--- a/opencog/query/FuzzyMatch/GraphEditDist.cc
+++ b/opencog/query/FuzzyMatch/GraphEditDist.cc
@@ -1,0 +1,228 @@
+/*
+ * GraphEditDist.cc
+ *
+ * Copyright (C) 2015 OpenCog Foundation
+ *
+ * Author: Leung Man Hin <https://github.com/leungmanhin>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atomspace/Link.h>
+#include <opencog/atomspace/ProbabilisticTruthValue.h>
+#include "GraphEditDist.h"
+
+using namespace opencog;
+
+//#define DEBUG
+
+GraphEditDist::GraphEditDist()
+{
+
+}
+
+
+/**
+ * A dynamic programming approach for computing the edit distance between two
+ * hypergraphs, i.e., how many operations do we need to transform one
+ * hypergraph (hg1) into another one (hg2), which implies how similar the two
+ * hypergraphs are. The available operations are:
+ *
+ *   Insertion    Inserting an atom into a hypergraph
+ *   Deletion     Deleting an atom from a hypergraph
+ *   Replacement  Replacing an atom with another one
+ *
+ * Each operation has a cost. The resulting edit distance is the min. cost of
+ * the transformation. The smaller the edit distance, the more similar the two
+ * hypergraphs are.
+ *
+ * Note: This function only computes the edit distance, no actual
+ *       "hypergraph transformation" is taken place in the atomspace.
+ *
+ * @param hg1  A query hypergraph
+ * @param hg2  Another hypergraph that's being compared with
+ * @return     The min. cost (edit distance) of transforming hg1 into hg2
+ */
+double GraphEditDist::compute(const Handle& hg1, const Handle& hg2)
+{
+#ifdef DEBUG
+    printf("Computing the edit distance between these two hypergraphs:\n\n%s\n%s",
+            hg1->toShortString().c_str(), hg2->toShortString().c_str());
+#endif
+
+    // Examine the two hypergraphs and store their atoms into the
+    // corresponding HandleSeq
+    HandleSeq hg1_seq;
+    HandleSeq hg2_seq;
+    examine_graph(hg1, hg1_seq);
+    examine_graph(hg2, hg2_seq);
+
+    // Initialize the cost matrix
+    size_t row_size = hg1_seq.size() + 1;
+    size_t col_size = hg2_seq.size() + 1;
+    double cost_matrix[row_size][col_size];
+
+    // Compute the costs and store them in the cost matrix
+    for (size_t i = 0; i < row_size; i++)
+    {
+        for (size_t j = 0; j < col_size; j++)
+        {
+            if (i == 0 and j == 0) cost_matrix[i][j] = 0;
+
+            // Base case. It can be viewed as transforming a hypergraph from
+            // one that contains no atoms, so the operations are solely insertions
+            else if (i == 0)
+            {
+                cost_matrix[i][j] = j * INSERT_COST;
+            }
+
+            // Base case. It can be viewed as transforming a hypergraph into
+            // one that contains no atoms, so the operations are solely deletions
+            else if (j == 0)
+            {
+                cost_matrix[i][j] = i * DELETE_COST;
+            }
+
+            // At any point the cost[i][j] is the minimum of (c1, c2, c3)
+            else
+            {
+                double c1 = cost_matrix[i-1][j] + DELETE_COST;
+                double c2 = cost_matrix[i][j-1] + INSERT_COST;
+                double c3 = cost_matrix[i-1][j-1]
+                              + get_replacement_cost(hg1_seq[i-1], hg2_seq[j-1]);
+
+                cost_matrix[i][j] = std::min(c1, std::min(c2, c3));
+            }
+        }
+    }
+
+#ifdef DEBUG
+    // Print out the cost matrix
+    printf("\nCost Matrix:\n");
+    for (size_t i = 0; i < row_size; i++)
+    {
+        for (size_t j = 0; j < col_size; j++)
+            printf("%.1f, ", cost_matrix[i][j]);
+        printf("\n");
+    }
+    printf("\nEdit Distance = %.3f\n", cost_matrix[row_size-1][col_size-1]);
+#endif
+
+    return cost_matrix[row_size-1][col_size-1];
+}
+
+
+/**
+ * Traverse the hypergraph and insert the atoms into a HandleSeq, which is then
+ * used for the edit distance computation.
+ *
+ * @param hg      The hypergraph that's being traversed
+ * @param hg_seq  HandleSeq that stores the atoms
+ */
+void GraphEditDist::examine_graph(const Handle& hg, HandleSeq& hg_seq)
+{
+    if (Handle::UNDEFINED == hg) return;
+
+    hg_seq.push_back(hg);
+
+    // Traverse its outgoing set if it is a link
+    LinkPtr lp(LinkCast(hg));
+    if (NULL != lp)
+    {
+        const HandleSeq& vh = lp->getOutgoingSet();
+        size_t sz = vh.size();
+        for (size_t i = 0; i < sz; i++)
+            examine_graph(vh[i], hg_seq);
+    }
+}
+
+
+/**
+ * Estimate the cost of replacing an atom with another one.
+ *
+ * The replacement cost should be directly related to the similarity between
+ * the two atoms. The more similar they are, the lower the replacement cost
+ * would be.
+ *
+ * The current atom-similarity estimation:
+ *   For links, check if they are having the same type.
+ *   For nodes, check if they are having the same type and same name.
+ *
+ * Currently this similarity estimation is a bit crude. In the near future,
+ * it will be replaced by some other heuristic, for instance truth values of
+ * the atoms, in order to get more accurate results.
+ *
+ * @param h1  Handle of an atom from a hypergraph
+ * @param h2  Handle of an atom from another hypergraph
+ * @return    The cost of replacing h1 with h2
+ */
+double GraphEditDist::get_replacement_cost(const Handle& h1, const Handle& h2)
+{
+    // For links
+    LinkPtr lp1(LinkCast(h1));
+    LinkPtr lp2(LinkCast(h2));
+    if (lp1 and lp2)
+    {
+        // Check if both of them are of the same type
+        return (lp1->getType() != lp2->getType()) * REPLACE_COST;
+    }
+
+    // For nodes
+    NodePtr np1(NodeCast(h1));
+    NodePtr np2(NodeCast(h2));
+    if (np1 and np2)
+    {
+        Type t1 = np1->getType();
+        Type t2 = np2->getType();
+
+        // Let's make an exception for VariableNode
+        if (t1 == VARIABLE_NODE and t2 == VARIABLE_NODE) return 0;
+
+        // If both types and names are different, cost = REPLACE_COST
+        // If only one of them is different, cost = (REPLACE_COST / 2)
+        // Else, they are considered to be identical, cost = 0
+        return ((t1 != t2) + !is_same_name(np1, np2)) * (REPLACE_COST / 2);
+    }
+
+    // Else, they probably are a node and a link
+    else return REPLACE_COST;
+}
+
+
+/**
+ * Check if the names of the two nodes, ignoring their UUIDs, are identical.
+ *
+ * For instance,
+ *
+ *  (ConceptNode "she@13781c75-caf4-42c6-bcad-bc01e48ac657")
+ *  (ConceptNode "she@21c4eb76-60f1-4c8d-acf9-26e88173222c")
+ *
+ * would be considered identical, i.e., returns true.
+ *
+ * A reason of doing this is to avoid matching similar hypergraphs with
+ * "identical content", if any, which normally are not what we're expecting.
+ *
+ * @param node1  A query node
+ * @param node2  Another node that's being compared with
+ * @return       True if their names are identical, false if not
+ */
+bool GraphEditDist::is_same_name(const NodePtr& node1, const NodePtr& node2)
+{
+    size_t pos1 = node1->getName().find_first_of('@');
+    size_t pos2 = node2->getName().find_first_of('@');
+
+    return (node1->getName().substr(0, pos1) == node2->getName().substr(0, pos2));
+}

--- a/opencog/query/FuzzyMatch/GraphEditDist.h
+++ b/opencog/query/FuzzyMatch/GraphEditDist.h
@@ -1,0 +1,61 @@
+/*
+ * GraphEditDist.h
+ *
+ * Copyright (C) 2015 OpenCog Foundation
+ *
+ * Author: Leung Man Hin <https://github.com/leungmanhin>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef GRAPHEDITDIST_H
+#define GRAPHEDITDIST_H
+
+#include <opencog/atomspace/Handle.h>
+#include <opencog/atomspace/Node.h>
+
+namespace opencog
+{
+    /**
+     * Estimate how similar two hypergraphs are by computing the edit distance
+     * between them.
+     */
+    class GraphEditDist
+    {
+        public:
+            GraphEditDist();
+            double compute(const Handle& hg1, const Handle& hg2);
+
+        private:
+            /**
+             * The (max.) costs of performaing different operations for the
+             * edit distance computation.
+             *
+             * The costs are in the range of 0 to 1.
+             *
+             * More can be added if necessary.
+             */
+            double INSERT_COST = 1;
+            double DELETE_COST = 1;
+            double REPLACE_COST = 1;
+
+            void examine_graph(const Handle& hg, HandleSeq& hg_seq);
+            double get_replacement_cost(const Handle& h1, const Handle& h2);
+            bool is_same_name(const NodePtr& node1, const NodePtr& node2);
+    };
+}
+
+#endif // GRAPHEDITDIST_H

--- a/opencog/query/QueryModule.cc
+++ b/opencog/query/QueryModule.cc
@@ -12,16 +12,18 @@ using namespace opencog;
 
 DECLARE_MODULE(QueryModule);
 
-QueryModule::QueryModule(CogServer& cs) : Module(cs), _pat(NULL)
+QueryModule::QueryModule(CogServer& cs) : Module(cs), _pat(NULL), _fpat(NULL)
 {
 }
 
 QueryModule::~QueryModule()
 {
 	delete _pat;
+    delete _fpat;
 }
 
 void QueryModule::init(void)
 {
-	_pat = new PatternSCM();
+    _pat = new PatternSCM();
+    _fpat = new FuzzyPatternSCM();
 }

--- a/opencog/query/QueryModule.cc
+++ b/opencog/query/QueryModule.cc
@@ -19,11 +19,11 @@ QueryModule::QueryModule(CogServer& cs) : Module(cs), _pat(NULL), _fpat(NULL)
 QueryModule::~QueryModule()
 {
 	delete _pat;
-    delete _fpat;
+	delete _fpat;
 }
 
 void QueryModule::init(void)
 {
-    _pat = new PatternSCM();
-    _fpat = new FuzzyPatternSCM();
+	_pat = new PatternSCM();
+	_fpat = new FuzzyPatternSCM();
 }

--- a/opencog/query/QueryModule.h
+++ b/opencog/query/QueryModule.h
@@ -11,6 +11,7 @@
 #include <vector>
 #include <opencog/server/Module.h>
 #include <opencog/query/PatternSCM.h>
+#include <opencog/query/FuzzyMatch/FuzzyPatternSCM.h>
 
 namespace opencog {
 
@@ -18,6 +19,7 @@ class QueryModule : public Module
 {
 	private:
 		PatternSCM* _pat;
+        FuzzyPatternSCM* _fpat;
 	public:
 		QueryModule(CogServer&);
 		virtual ~QueryModule();

--- a/opencog/query/QueryModule.h
+++ b/opencog/query/QueryModule.h
@@ -19,7 +19,7 @@ class QueryModule : public Module
 {
 	private:
 		PatternSCM* _pat;
-        FuzzyPatternSCM* _fpat;
+		FuzzyPatternSCM* _fpat;
 	public:
 		QueryModule(CogServer&);
 		virtual ~QueryModule();

--- a/tests/query/CMakeLists.txt
+++ b/tests/query/CMakeLists.txt
@@ -22,6 +22,7 @@ LINK_LIBRARIES (
 # Each test gets progressively more complex, and exercises
 # features that the later tests depend on.
 ADD_CXXTEST(PatternUTest)
+ADD_CXXTEST(FuzzyPatternUTest)
 ADD_CXXTEST(StackUTest)
 ADD_CXXTEST(BigPatternUTest)
 ADD_CXXTEST(BiggerPatternUTest)

--- a/tests/query/FuzzyPatternUTest.cxxtest
+++ b/tests/query/FuzzyPatternUTest.cxxtest
@@ -169,16 +169,16 @@ void FuzzyPatternUTest::test_basic_link(void)
 
 	FuzzyPatternMatchCB fpmcb(as);
 
-    std::set<Handle> vars;
+	std::set<Handle> vars;
 
-    HandleSeq preds;
-    preds.push_back(query);
+	HandleSeq preds;
+	preds.push_back(query);
 
-    HandleSeq negs;
+	HandleSeq negs;
 
-    pme.match(&fpmcb, vars, preds, negs);
+	pme.match(&fpmcb, vars, preds, negs);
 
-    TSM_ASSERT_EQUALS("Wrong number of solutions", fpmcb.solns.size(), 1);
+	TSM_ASSERT_EQUALS("Wrong number of solutions", fpmcb.solns.size(), 1);
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
@@ -192,16 +192,16 @@ void FuzzyPatternUTest::test_basic_node(void)
 
 	FuzzyPatternMatchCB fpmcb(as);
 
-    std::set<Handle> vars;
+	std::set<Handle> vars;
 
-    HandleSeq preds;
-    preds.push_back(query);
+	HandleSeq preds;
+	preds.push_back(query);
 
-    HandleSeq negs;
+	HandleSeq negs;
 
-    pme.match(&fpmcb, vars, preds, negs);
+	pme.match(&fpmcb, vars, preds, negs);
 
-    TSM_ASSERT_EQUALS("Wrong number of solutions", fpmcb.solns.size(), 1);
+	TSM_ASSERT_EQUALS("Wrong number of solutions", fpmcb.solns.size(), 1);
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/FuzzyPatternUTest.cxxtest
+++ b/tests/query/FuzzyPatternUTest.cxxtest
@@ -1,0 +1,208 @@
+/*
+ * tests/query/FuzzyPatternUTest.cxxtest
+ *
+ * Copyright (C) 2015 OpenCog Foundation
+ * All Rights Reserved
+ *
+ * Author: Leung Man Hin <https://github.com/leungmanhin>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/nlp/types/atom_types.h>
+#include <opencog/query/FuzzyMatch/FuzzyPatternMatchCB.h>
+#include <opencog/query/FuzzyMatch/FuzzyPatternMatch.h>
+#include <opencog/util/Config.h>
+#include <opencog/util/Logger.h>
+
+using namespace opencog;
+
+class FuzzyPatternUTest : public CxxTest::TestSuite
+{
+	private:
+		PatternMatchEngine pme;
+		FuzzyPatternMatch fpm;
+		AtomSpace* as;
+
+		Handle hwn1;
+		Handle hwn2;
+		Handle hwin;
+		Handle hpn;
+		Handle hel1;
+		Handle hel2;
+		Handle hel3;
+
+	public:
+		FuzzyPatternUTest(void)
+		{
+			try
+			{
+				config().load("opencog-test.conf");
+			}
+			catch (RuntimeException &e)
+			{
+				std::cerr << e.getMessage() << std::endl;
+			}
+			logger().setFilename(config()["LOG_FILE"]);
+			logger().setLevel(Logger::getLevelFromString(config()["LOG_LEVEL"]));
+			logger().setPrintToStdoutFlag(config().get_bool("LOG_TO_STDOUT"));
+
+			as = new AtomSpace();
+		}
+
+		~FuzzyPatternUTest()
+		{
+			delete as;
+			// Erase the log file if no assertions failed.
+			if (!CxxTest::TestTracker::tracker().suiteFailed())
+				std::remove(logger().getFilename().c_str());
+		}
+
+		void setUp(void);
+		void tearDown(void);
+
+		void test_basic_link(void);
+		void test_basic_node(void);
+};
+
+/*
+ * This function sets up the following structures:
+ *
+ *    WordNode "Tea"
+ *    WordNode "Water"
+ *    WordInstanceNode "Tea"
+ *    ParseNode "sentence@123"
+ *
+ *    EvaluationLink
+ *       PredicateNode "read"
+ *       ListLink
+ *          ConceptNode "they"
+ *          ConceptNode "books"
+ *
+ *    EvaluationLink
+ *       PredicateNode "read"
+ *       ListLink
+ *          ConceptNode "they"
+ *          ConceptNode "magazines"
+ *
+ *    EvaluationLink
+ *       PredicateNode "eat"
+ *       ListLink
+ *          ConceptNode "they"
+ *          ConceptNode "burgers"
+ *
+ */
+void FuzzyPatternUTest::tearDown(void)
+{
+
+}
+
+#define an as->addNode
+#define al as->addLink
+void FuzzyPatternUTest::setUp(void)
+{
+	// The solution of test_basic_node
+	hwn1 = an(WORD_NODE, "Tea");
+
+	// Identical to the node in the query,
+	// and is not supposed to be matched
+	hwn2 = an(WORD_NODE, "Water");
+
+	hwin = an(WORD_INSTANCE_NODE, "Tea@456");
+
+	hpn = an(PARSE_NODE, "sentence@123");
+
+	// The solution of test_basic_link
+	hel1 = al(EVALUATION_LINK,
+			an(PREDICATE_NODE, "read"),
+			al(LIST_LINK,
+				an(CONCEPT_NODE, "they"),
+				an(CONCEPT_NODE, "books")
+			)
+		   );
+
+	// Identical to the link in the query,
+	// and is not supposed to be matched
+	hel2 = al(EVALUATION_LINK,
+			an(PREDICATE_NODE, "read"),
+			al(LIST_LINK,
+				an(CONCEPT_NODE, "they"),
+				an(CONCEPT_NODE, "magazines")
+			)
+		   );
+
+	hel3 = al(EVALUATION_LINK,
+			an(PREDICATE_NODE, "eat"),
+			al(LIST_LINK,
+				an(CONCEPT_NODE, "they"),
+				an(CONCEPT_NODE, "burgers")
+			)
+		   );
+}
+
+void FuzzyPatternUTest::test_basic_link(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	// Construct the query
+	Handle query = al(EVALUATION_LINK,
+					an(PREDICATE_NODE, "read"),
+					al(LIST_LINK,
+						an(CONCEPT_NODE, "they"),
+						an(CONCEPT_NODE, "magazines")
+					)
+				  );
+
+	FuzzyPatternMatchCB fpmcb(as);
+
+    std::set<Handle> vars;
+
+    HandleSeq preds;
+    preds.push_back(query);
+
+    HandleSeq negs;
+
+    pme.match(&fpmcb, vars, preds, negs);
+
+    TSM_ASSERT_EQUALS("Wrong number of solutions", fpmcb.solns.size(), 1);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void FuzzyPatternUTest::test_basic_node(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	// Construct the query
+	Handle query = an(WORD_NODE, "Water");
+
+	FuzzyPatternMatchCB fpmcb(as);
+
+    std::set<Handle> vars;
+
+    HandleSeq preds;
+    preds.push_back(query);
+
+    HandleSeq negs;
+
+    pme.match(&fpmcb, vars, preds, negs);
+
+    TSM_ASSERT_EQUALS("Wrong number of solutions", fpmcb.solns.size(), 1);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+


### PR DESCRIPTION
Two scheme primitives are added:

**cog-fuzzy**: Find similar hypergraphs in the atomspace
Basic example:
(cog-fuzzy (ListLink (ConceptNode "A") (ConceptNode "B")))

Possible result:
(ListLink (ConceptNode "A") (ConceptNode "C"))

**get-similar-sentences**: Find similar sentences in the atomspace
Basic example:
(get-similar-sentences "What did Pete eat?")

Possible result:
(Pete ate apples .)