### PR TITLE
Completely reworked Python initialization 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -632,7 +632,7 @@ IF (CXXTEST_FOUND)
 		)
 	ENDIF (CMAKE_BUILD_TYPE STREQUAL "Coverage")
 	ADD_CUSTOM_TARGET(test_python
-		DEPENDS PythonModuleUTest PythonEvalUTest CogServerUTest
+		DEPENDS PythonModuleUTest PyEvalUTest PythonEvalUTest CogServerUTest
 		WORKING_DIRECTORY tests/cython
 		COMMAND ${CMAKE_CTEST_COMMAND} $(ARGS)
 		COMMENT "Running Python and Cython tests..."

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,9 @@ set(CMAKE_LEGACY_CYGWIN_WIN32 0)
 # uncomment to build in profile mode
 # SET(CMAKE_BUILD_TYPE Profile)
 
+# uncomment to build in release mode with debug information
+# SET(CMAKE_BUILD_TYPE RelWithDebInfo)
+
 # default build type
 IF (CMAKE_BUILD_TYPE STREQUAL "")
 	SET(CMAKE_BUILD_TYPE Release)
@@ -628,6 +631,12 @@ IF (CXXTEST_FOUND)
 			COMMENT "Running tests..."
 		)
 	ENDIF (CMAKE_BUILD_TYPE STREQUAL "Coverage")
+	ADD_CUSTOM_TARGET(test_python
+		DEPENDS PythonModuleUTest PythonEvalUTest CogServerUTest
+		WORKING_DIRECTORY tests/cython
+		COMMAND ${CMAKE_CTEST_COMMAND} $(ARGS)
+		COMMENT "Running Python and Cython tests..."
+	)
 ENDIF (CXXTEST_FOUND)
 
 ADD_SUBDIRECTORY(examples EXCLUDE_FROM_ALL)

--- a/opencog/benchmark/AtomSpaceBenchmark.cc
+++ b/opencog/benchmark/AtomSpaceBenchmark.cc
@@ -327,9 +327,9 @@ void AtomSpaceBenchmark::startBenchmark(int numThreads)
             if (pymo == NULL) pymo = new PythonModule(*cogs);
             pymo->init();
             asp = &cogs->getAtomSpace();
-            pyev = &PythonEval::instance(asp);
+            pyev = &PythonEval::instance();
 
-            // And now ... create an instance of the atomspace.
+            // And now ... create a Python instance of the atomspace.
             // Pass in the raw C++ atomspace address into cython.
             // Kind-of tacky, but I don't see any better way.
             // (We must do this because otherwise, the benchmark would

--- a/opencog/cython/PyRequest.cc
+++ b/opencog/cython/PyRequest.cc
@@ -15,15 +15,17 @@ PyRequest::PyRequest(CogServer& cs,
 {
     _cci = cci;
 
-    PyGILState_STATE gstate = PyGILState_Ensure(); 
-
-    import_opencog__agent_finder();
     _moduleName = moduleName;
     _className = className;
-    // call out to our helper module written in cython
-    _pyrequest = instantiate_request(moduleName, className, this);
 
-    PyGILState_Release(gstate); 
+    // NOTE: You need to call the import functions in each separate
+    // shared library that accesses Cython defined api. If you don't
+    // then you get a crash when you call an api function.
+    import_opencog__agent_finder();
+
+    // Call out to our helper module written in cython  NOTE: Cython api calls
+    // defined "with gil" can be called without grabbing the GIL manually.
+    _pyrequest = instantiate_request(moduleName, className, this);
 
     if (_pyrequest == Py_None)
         logger().error() << "Error creating python request "

--- a/opencog/execution/ExecutionOutputLink.cc
+++ b/opencog/execution/ExecutionOutputLink.cc
@@ -141,6 +141,10 @@ Handle ExecutionOutputLink::do_execute(AtomSpace* as, Handle gsn, Handle args)
         size_t pos = 3;
         while (' ' == schema[pos]) pos++;
 
+        // Get a reference to the python evaluator. NOTE: We are
+        // passing in a reference to our atom space to invoke
+        // the safety checking to make sure the singleton instance
+        // is using the same atom space.
         PythonEval &applier = PythonEval::instance(as);
 
         Handle h = applier.apply(schema.substr(pos), args);

--- a/opencog/server/NetworkServer.cc
+++ b/opencog/server/NetworkServer.cc
@@ -43,8 +43,6 @@ NetworkServer::NetworkServer()
 NetworkServer::~NetworkServer()
 {
     logger().debug("[NetworkServer] enter destructor");
-    if (_thread != 0)
-        pthread_join(_thread, NULL);
 
     for (SocketPort* sp : _listeners) delete sp;
     logger().debug("[NetworkServer] all threads joined, exit destructor");
@@ -90,7 +88,8 @@ void NetworkServer::stop()
     logger().debug("[NetworkServer] stop");
     _running = false;
     io_service.stop();
-    while (_started) { usleep(10000); }
+    if (_thread != 0)
+        pthread_join(_thread, NULL);
 } 
 
 void NetworkServer::run()

--- a/opencog/server/SystemActivityTable.cc
+++ b/opencog/server/SystemActivityTable.cc
@@ -41,7 +41,6 @@ SystemActivityTable::~SystemActivityTable()
 {
     logger().debug("[SystemActivityTable] enter destructor");
     _conn.disconnect();
-    clearActivity();
     logger().debug("[SystemActivityTable] exit destructor");
 }
 

--- a/opencog/shell/CMakeLists.txt
+++ b/opencog/shell/CMakeLists.txt
@@ -16,6 +16,7 @@ TARGET_LINK_LIBRARIES(py-shell
 	server
 	atomspace
 	cogutil
+	PythonEval
 	${Boost_SYSTEM_LIBRARY}
 	${PYTHON_LIBRARIES}
 )

--- a/tests/cython/CMakeLists.txt
+++ b/tests/cython/CMakeLists.txt
@@ -22,20 +22,35 @@ IF (HAVE_SERVER)
 ENDIF (HAVE_SERVER)
 
 
-# The PythonEvalUTest is derived from the CogServer class, and so 
+# The PyEvalUTest is derived from the CogServer class, and so 
 # cannot be tested unless the cogserver is actually being built!
 IF (HAVE_SERVER)
-	ADD_CXXTEST(PythonEvalUTest)
+	ADD_CXXTEST(PyEvalUTest)
 	CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/cython/pyeval.conf
 		${PROJECT_BINARY_DIR}/tests/cython/pyeval.conf)
 
-	TARGET_LINK_LIBRARIES(PythonEvalUTest
+	TARGET_LINK_LIBRARIES(PyEvalUTest
+		py-shell
 		server
 		cogutil
 	)
-	SET_TESTS_PROPERTIES(PythonEvalUTest
+	SET_TESTS_PROPERTIES(PyEvalUTest
 		PROPERTIES ENVIRONMENT "PYTHONPATH=${PROJECT_BINARY_DIR}/opencog/cython")
 ENDIF (HAVE_SERVER)
+
+
+# The PythonEvalUTest tests PythonEval independent of the CogServer.
+ADD_CXXTEST(PythonEvalUTest)
+CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/cython/pythoneval.conf
+	${PROJECT_BINARY_DIR}/tests/cython/pythoneval.conf)
+
+TARGET_LINK_LIBRARIES(PythonEvalUTest
+	atomspace
+	PythonEval
+	cogutil
+)
+SET_TESTS_PROPERTIES(PythonEvalUTest
+	PROPERTIES ENVIRONMENT "PYTHONPATH=${PROJECT_BINARY_DIR}/opencog/cython")
 
 
 IF (HAVE_NOSETESTS)

--- a/tests/cython/PyEvalUTest.cxxtest
+++ b/tests/cython/PyEvalUTest.cxxtest
@@ -1,0 +1,122 @@
+#include <string>
+#include <cstdio>
+
+#include <opencog/server/CogServer.h>
+#include <opencog/server/RequestResult.h>
+#include <opencog/util/Config.h>
+#include <opencog/cython/PyMindAgent.h>
+
+using std::string;
+
+using namespace opencog;
+
+class StringRequestResult : public RequestResult
+{
+public:
+    string result;
+    StringRequestResult(): RequestResult ("text/plain"){};
+    ~StringRequestResult(){};
+    virtual void SendResult(const std::string& res) {
+        result = res;
+    }
+    virtual void OnRequestComplete() {
+    }
+};
+
+class TestCogServer : public CogServer
+{
+    int tickCount;
+    bool tickBased;
+    int maxCount;
+    public: 
+
+        static BaseServer* createInstance() {
+            return new TestCogServer();
+        }
+
+        TestCogServer() : tickCount(1), tickBased(false), maxCount(1000) {}
+
+        void setTickBased(bool _tickBased) {
+            tickBased = _tickBased;
+        }
+
+        void setMaxCount(int _maxCount) {
+            maxCount = _maxCount;
+        }
+
+        bool customLoopRun() {
+            bool runCycle  = tickBased?(tickCount % 100 == 0):true; 
+            if (++tickCount > maxCount) stop();
+            return runCycle;
+        }
+};
+
+class PyEvalUTest :  public CxxTest::TestSuite
+{
+
+private:
+
+
+public:
+
+    PyEvalUTest() {
+        logger().setLevel(Logger::DEBUG);
+        logger().setPrintToStdoutFlag(true);
+
+        // Load special config file for the test
+        string configFile = PROJECT_BINARY_DIR"/tests/cython/pyeval.conf";
+        try {
+            config().load(configFile.c_str(), false);
+        } catch (RuntimeException &e) {
+            std::cerr << e.getMessage() << std::endl;
+            exit(1);
+        }
+        // Setup global logger
+        logger().setFilename(config()["LOG_FILE"]);
+        logger().setLevel(Logger::getLevelFromString(config()["LOG_LEVEL"]));
+        logger().setBackTraceLevel(Logger::getLevelFromString(config()["BACK_TRACE_LOG_LEVEL"]));
+        logger().setPrintToStdoutFlag(config().get_bool("LOG_TO_STDOUT"));
+
+        // Set cycle duration to a smaller value so that this test does not take too long.
+        config().set("SERVER_CYCLE_DURATION", "10");  // in milliseconds
+        TestCogServer& cogserver = static_cast<TestCogServer&>(server(TestCogServer::createInstance)); 
+
+        config().set("MODULES", "opencog/shell/libpy-shell.so");
+        cogserver.loadModules();
+    }
+
+    ~PyEvalUTest() {
+        TestCogServer& cogserver = static_cast<TestCogServer&>(server(TestCogServer::createInstance)); 
+	    // erase the log file if no assertions failed
+	    if (!CxxTest::TestTracker::tracker().suiteFailed())
+            std::remove(logger().getFilename().c_str());
+        cogserver.unloadModule("opencog::py-shell");
+    }
+
+    void setUp() {
+    }
+
+    void tearDown() {
+    }
+
+    void testPyEvalScript() {
+        TestCogServer& cogserver = static_cast<TestCogServer&>(server(TestCogServer::createInstance));
+
+        //  Create the py-eval request.
+        Request* pythonEvalRequest = cogserver.createRequest("py-eval");
+        TS_ASSERT_DIFFERS(pythonEvalRequest, (Request*) NULL);
+        pythonEvalRequest->addParameter("print 'Hello'");
+        StringRequestResult *pythonEvalRequestResult = new StringRequestResult();
+        pythonEvalRequest->setRequestResult(pythonEvalRequestResult);
+
+        // Add request to queue.
+        cogserver.pushRequest(pythonEvalRequest);
+
+        // Process this request.
+        cogserver.runLoopStep();
+
+        // Make sure we get a "Hello" back.
+        TS_ASSERT_DIFFERS(pythonEvalRequestResult->result.find("Hello"), std::string::npos)
+    }
+
+};

--- a/tests/cython/PythonEvalUTest.cxxtest
+++ b/tests/cython/PythonEvalUTest.cxxtest
@@ -90,7 +90,7 @@ public:
 	    // erase the log file if no assertions failed
 	    if (!CxxTest::TestTracker::tracker().suiteFailed())
             std::remove(logger().getFilename().c_str());
-        cogserver.unloadModule("opencog::PythonEval");
+        cogserver.unloadModule("opencog::py-shell");
     }
 
     void setUp() {

--- a/tests/cython/PythonEvalUTest.cxxtest
+++ b/tests/cython/PythonEvalUTest.cxxtest
@@ -1,55 +1,16 @@
 #include <string>
 #include <cstdio>
 
-#include <opencog/server/CogServer.h>
-#include <opencog/server/RequestResult.h>
 #include <opencog/util/Config.h>
-#include <opencog/cython/PyMindAgent.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/cython/PythonEval.h>
 
 using std::string;
 
 using namespace opencog;
 
-class StringRequestResult : public RequestResult
-{
-public:
-    string result;
-    StringRequestResult(): RequestResult ("text/plain"){};
-    ~StringRequestResult(){};
-    virtual void SendResult(const std::string& res) {
-        result = res;
-    }
-    virtual void OnRequestComplete() {
-    }
-};
+const int NO_SIGNAL_HANDLERS = 0;
 
-class TestCogServer : public CogServer
-{
-    int tickCount;
-    bool tickBased;
-    int maxCount;
-    public: 
-
-        static BaseServer* createInstance() {
-            return new TestCogServer();
-        }
-
-        TestCogServer() : tickCount(1), tickBased(false), maxCount(1000) {}
-
-        void setTickBased(bool _tickBased) {
-            tickBased = _tickBased;
-        }
-
-        void setMaxCount(int _maxCount) {
-            maxCount = _maxCount;
-        }
-
-        bool customLoopRun() {
-            bool runCycle  = tickBased?(tickCount % 100 == 0):true; 
-            if (++tickCount > maxCount) stop();
-            return runCycle;
-        }
-};
 
 class PythonEvalUTest :  public CxxTest::TestSuite
 {
@@ -60,37 +21,26 @@ private:
 public:
 
     PythonEvalUTest() {
-        logger().setLevel(Logger::DEBUG);
-        logger().setPrintToStdoutFlag(true);
 
         // Load special config file for the test
-        string configFile = PROJECT_BINARY_DIR"/tests/cython/pyeval.conf";
+        string configFile = PROJECT_BINARY_DIR"/tests/cython/pythoneval.conf";
         try {
             config().load(configFile.c_str(), false);
         } catch (RuntimeException &e) {
             std::cerr << e.getMessage() << std::endl;
             exit(1);
         }
+
+        logger().setPrintToStdoutFlag(true);
+
         // setup global logger
         logger().setFilename(config()["LOG_FILE"]);
         logger().setLevel(Logger::getLevelFromString(config()["LOG_LEVEL"]));
         logger().setBackTraceLevel(Logger::getLevelFromString(config()["BACK_TRACE_LOG_LEVEL"]));
         logger().setPrintToStdoutFlag(config().get_bool("LOG_TO_STDOUT"));
-
-        // set cycle duration to a smaller value so that this test do not take too long.
-        config().set("SERVER_CYCLE_DURATION", "10");  // in milliseconds
-        TestCogServer& cogserver = static_cast<TestCogServer&>(server(TestCogServer::createInstance)); 
-
-        config().set("MODULES", "opencog/shell/libpy-shell.so");
-        cogserver.loadModules();
     }
 
     ~PythonEvalUTest() {
-        TestCogServer& cogserver = static_cast<TestCogServer&>(server(TestCogServer::createInstance)); 
-	    // erase the log file if no assertions failed
-	    if (!CxxTest::TestTracker::tracker().suiteFailed())
-            std::remove(logger().getFilename().c_str());
-        cogserver.unloadModule("opencog::py-shell");
     }
 
     void setUp() {
@@ -99,24 +49,179 @@ public:
     void tearDown() {
     }
 
+    void testRawPythonInitialization() {
+
+        logger().debug("[PythonEvalUTest] testRawPythonInitialization()");
+
+        // Start up Python.
+        Py_InitializeEx(NO_SIGNAL_HANDLERS);
+        PyEval_InitThreads();
+
+        // Release the GIL.
+        PyEval_ReleaseLock();
+
+        // Stop Python.
+        Py_Finalize();
+
+
+        // Try it again to make sure the Python library cleans up properly.
+     
+        // Start up Python.
+        Py_InitializeEx(NO_SIGNAL_HANDLERS);
+        PyEval_InitThreads();
+
+        // Release the GIL.
+        PyEval_ReleaseLock();
+
+        // Stop Python.
+        Py_Finalize();
+
+
+        // And again...
+     
+        // Start up Python.
+        Py_InitializeEx(NO_SIGNAL_HANDLERS);
+        PyEval_InitThreads();
+
+        // Release the GIL.
+        PyEval_ReleaseLock();
+
+        // Stop Python.
+        Py_Finalize();
+ 
+         logger().debug("[PythonEvalUTest] testRawPythonInitialization() DONE");
+   }
+
+    void testRawPythonInitializeWithGetSys(){
+
+        logger().debug("[PythonEvalUTest] testRawPythonInitializeWithGetSys()");
+
+        PyObject* pySysPath = NULL;
+
+        // Get the system path object.
+        Py_InitializeEx(NO_SIGNAL_HANDLERS);
+        PyEval_InitThreads();
+
+        PyRun_SimpleString(
+                    "import sys\n"
+                    "import StringIO\n"
+                    );
+        pySysPath = PySys_GetObject((char*)"path");
+
+        Py_ssize_t pathSize = PyList_Size(pySysPath);
+        for (int pathIndex = 0; pathIndex < pathSize; pathIndex++) {
+            PyObject* pySysPathLine = PyList_GetItem(pySysPath, pathIndex);
+            logger().info("        %2d > %s", pathIndex, PyString_AsString(pySysPathLine));
+            // NOTE: PyList_GetItem returns a borrowed reference so don't do this:
+            // Py_DECREF(pySysPathLine);
+        }
+
+        // NOTE: PySys_GetObject returns a borrowed reference so don't do this:
+        // Py_DECREF(pySysPath);
+
+        PyEval_ReleaseLock();
+        Py_Finalize();
+
+        // Get it again
+        Py_InitializeEx(NO_SIGNAL_HANDLERS);
+        PyEval_InitThreads();
+
+        PyRun_SimpleString(
+                    "import sys\n"
+                    "import StringIO\n"
+                    );
+        pySysPath = PySys_GetObject((char*)"path");
+
+        // NOTE: PySys_GetObject returns a borrowed reference so don't do this:
+        // Py_DECREF(pySysPath);
+
+        PyEval_ReleaseLock();
+        Py_Finalize();
+
+        logger().debug("[PythonEvalUTest] testRawPythonInitializeWithGetSys() DONE");
+    }
+
+    void testCogServerPythonInitialization() {
+
+        logger().debug("[PythonEvalUTest] testCogServerPythonInitialization()");
+
+         // Initialize and finalize Python.
+        global_python_initialize();
+        global_python_finalize();
+
+         // Initialize and finalize Python.
+        global_python_initialize();
+        global_python_finalize();
+
+        logger().debug("[PythonEvalUTest] testCogServerPythonInitialization() DONE");
+    }
+
     void testPythonEvalScript() {
-        TestCogServer& cogserver = static_cast<TestCogServer&>(server(TestCogServer::createInstance));
 
-        //  Create the py-eval request.
-        Request* pythonEvalRequest = cogserver.createRequest("py-eval");
-        TS_ASSERT(pythonEvalRequest != NULL);
-        pythonEvalRequest->addParameter("print 'Hello'");
-        StringRequestResult *pythonEvalRequestResult = new StringRequestResult();
-        pythonEvalRequest->setRequestResult(pythonEvalRequestResult);
+        logger().debug("[PythonEvalUTest] testPythonEvalScript()");
 
-        // Add request to queue.
-        cogserver.pushRequest(pythonEvalRequest);
+        AtomSpace* atomSpace = NULL;
 
-        // Process this request.
-        cogserver.runLoopStep();
+        // Initialize Python.
+        global_python_initialize();
 
-        // Make sure we get a "Hello" back.
-        TS_ASSERT_DIFFERS(pythonEvalRequestResult->result.find("Hello"), std::string::npos)
+        // Tell the python evaluator to create its singleton instance.
+        PythonEval::create_singleton_instance(NULL);
+
+        // Delete the singleton instance of the PythonEval.
+        PythonEval::delete_singleton_instance();
+
+        // Cleanup Python.
+        global_python_finalize();
+
+
+        // Now do it again with a non-NULL atomspace object.
+
+        // Initialize Python.
+        global_python_initialize();
+
+        // Create an atomspace.
+        atomSpace = new AtomSpace();
+
+        // Tell the python evaluator to create its singleton instance
+        // with this atomspace.
+        PythonEval::create_singleton_instance(atomSpace);
+
+        // Delete the singleton instance of the PythonEval.
+        PythonEval::delete_singleton_instance();
+
+        // Delete the atomspace.
+        delete atomSpace;
+        atomSpace = NULL;
+
+        // Cleanup Python.
+        global_python_finalize();
+
+
+        // Now do it again to make sure we cleaned up properly.
+
+
+        // Initialize Python.
+        global_python_initialize();
+
+        // Create an atomspace.
+        atomSpace = new AtomSpace();
+
+        // Tell the python evaluator to create its singleton instance
+        // with this atomspace.
+        PythonEval::create_singleton_instance(atomSpace);
+
+        // Delete the singleton instance of the PythonEval.
+        PythonEval::delete_singleton_instance();
+
+        // Delete the atomspace.
+        delete atomSpace;
+        atomSpace = NULL;
+
+        // Cleanup Python.
+        global_python_finalize();
+
+        logger().debug("[PythonEvalUTest] testPythonEvalScript() DONE");
     }
 
 };

--- a/tests/cython/pythoneval.conf
+++ b/tests/cython/pythoneval.conf
@@ -1,0 +1,3 @@
+
+# cmake replaces this variable
+PYTHON_EXTENSION_DIRS = @CMAKE_SOURCE_DIR@/tests/cython,@CMAKE_SOURCE_DIR@/tests/cython/agents

--- a/tests/embodiment/AtomSpaceExtensions/AtomSpaceUtilUTest.cxxtest
+++ b/tests/embodiment/AtomSpaceExtensions/AtomSpaceUtilUTest.cxxtest
@@ -77,7 +77,6 @@ public:
     }
 
     void testAddRewardPredicate() {
-        server(SpaceTimeCogServer::createInstance);
         SpaceTimeCogServer srv;
         AtomSpace& atomSpace = srv.getAtomSpace();
         Handle evalLink = AtomSpaceUtil::addRewardPredicate(atomSpace, "1", 1000);
@@ -101,7 +100,6 @@ public:
     }
 
     void testAddPunishmentPredicate() {
-        server(SpaceTimeCogServer::createInstance);
         SpaceTimeCogServer srv;
         AtomSpace& atomSpace = srv.getAtomSpace();
         Handle evalLink = AtomSpaceUtil::addPunishmentPredicate(atomSpace, "1", 1000);
@@ -125,7 +123,6 @@ public:
     }
 
     void testIsActionPredicatePresent() {
-        server(SpaceTimeCogServer::createInstance);
         SpaceTimeCogServer srv;
         AtomSpace& atomSpace(srv.getAtomSpace());
         TimeServer& timeServer = srv.getTimeServer();

--- a/tests/server/CogServerUTest.cxxtest
+++ b/tests/server/CogServerUTest.cxxtest
@@ -130,7 +130,7 @@ public:
         // set cycle duration to a smaller value so that this test do not take too long.
         config().set("SERVER_CYCLE_DURATION", "10");  // in milliseconds
         Factory<MyAgent, Agent> factory;
-        CustomCogServer& cogserver = static_cast<CustomCogServer&>(server(CustomCogServer::createInstance)); 
+        CustomCogServer cogserver;
         cogserver.setTickBased(false);
         cogserver.setMaxCount(50);
         cogserver.registerAgent(MyAgent::info().id, &factory);
@@ -190,10 +190,16 @@ public:
         TS_ASSERT(aat[a[2]].size() == 13);
         TS_ASSERT(aat[a[3]].size() == 12);
         TS_ASSERT(aat[a[4]].size() == 10);
-    }
 
-    /* test custom server, like required by virtual agents (embodiment) */
-    void testCustomCogServer() {
+        // Destroy all the agents.
+        for (int i = 0; i < 5; ++i) {
+            cogserver.destroyAgent(a[i]);
+        }
+
+    } // testProcessAgents
+
+    /* test tick-based server */
+    void testTickBasedCogServer() {
         // Make it use external tick so that it does not call sleep inside serverLoop
         config().set("EXTERNAL_TICK_MODE", "true");
         CustomCogServer cogserver;


### PR DESCRIPTION
Moved all Python initialization to a single place.
Removed some unnecessary GIL lock calls.
Separated out PythonEvalUTest into two parts:
   one that tests PythonEval separate from the CogServer
   and the other that tests “py-eval” through the server.
Fixed problems with Python C API borrowed references that were causing crashes in more than one Python finalize / initialize cycle.
Fixed some problems with multiple server instances in tests that was causing a crash on CogServer destruction.
Fixed a crash in the NetworkServer threading code on teardown.

These changes fix bug #535.