### PR TITLE
Fixed dependencies for PythonEval and agent_finder

### DIFF
--- a/opencog/cython/CMakeLists.txt
+++ b/opencog/cython/CMakeLists.txt
@@ -32,7 +32,7 @@ file(COPY opencog/__init__.py DESTINATION opencog)
 ADD_LIBRARY(PythonEval SHARED
 	PythonEval.cc
 )
-ADD_DEPENDENCIES(PythonEval atomspace_cython)
+ADD_DEPENDENCIES(PythonEval atomspace_cython agent_finder)
 
 TARGET_LINK_LIBRARIES(PythonEval
 	${PYTHON_LIBRARIES}

--- a/opencog/cython/opencog/CMakeLists.txt
+++ b/opencog/cython/opencog/CMakeLists.txt
@@ -179,7 +179,7 @@ IF (HAVE_SERVER)
 		${Boost_SYSTEM_LIBRARY}
 	)
 
-	ADD_DEPENDENCIES(agent_finder cogserver_cython atomspace_cython)
+	ADD_DEPENDENCIES(agent_finder atomspace_cython)
 
 	SET_TARGET_PROPERTIES(agent_finder PROPERTIES
 		PREFIX ""


### PR DESCRIPTION
PythonEval now depends on agent_finder since it requires agent_finder_api.h which is auto generated by Cython. This caused a problem with the `make all` check on the buildbot. And would show up when you did a:

```
make clean
make all
```

Additionally, agent_finder was depending on cogserver_cython unnecessarily which created a cycle in the dependency graph which I also had to remove.

Tested:

```
make clean
make agent_finder
```

and:

```
make clean
make PythonEval
```

and they now build so the dependencies are good.