### PR TITLE
Fixed intermittent bug in multi-server unit tests

### DIFF
--- a/opencog/server/BaseServer.cc
+++ b/opencog/server/BaseServer.cc
@@ -87,7 +87,9 @@ void opencog::set_current_server(BaseServer* currentServer)
         return;
 
     // Should not call this on more than one server at a time.
-    if (serverInstance && currentServer != serverInstance) {
+    if (serverInstance &&
+        currentServer != serverInstance &&
+        currentServer != NULL ) {
         throw (RuntimeException(TRACE_INFO,
                 "Can't create more than one server singleton instance!"));
     }


### PR DESCRIPTION
Surprised this worked at all before. The tests were passing on my machine and the buildbot yesterday, and then they both stopped working with a RuntimeException in the safety check for singleton server instances today. I found a clear error in the comparison in that safety check. I'm not sure how it ever worked in looking at it.