### PR TITLE
Add .DS_Store to .gitignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 opencog.log
 opencog-python.log
 .vagrant
+.DS_Store
 
 # misc binaries
 bin


### PR DESCRIPTION
Prevent accidental adds of Mac OS X .DS_Store files