### PR TITLE
ExecutionOutptLinks are nestable

### DIFF
--- a/opencog/execution/README.md
+++ b/opencog/execution/README.md
@@ -1,0 +1,42 @@
+
+Execution and Evaluation Support
+================================
+
+The code here implements a very crude form of execution support for
+the AtomSpace. Its crude, because its mostly simple, straight-forward,
+and painfully slow and inefficient.
+
+First, some reasons its slow, and ways to speed that up. Second,
+some more abstract thoughts about language design.
+
+The code is slow because function names are currently stored as strings.
+Thus, each time execution needs to be done, the string needs to be
+decoded.  Next, after being decoded, either the guile, python or combo
+interpreters need to be entered; this takes a fair amount of time.
+
+The string decodes could be solved by decoding the string only once,
+and caching that value (memoizing it).  The cached value would be the
+SCM symbol, or the PyObject that the string name refers to.  Likewise,
+the arguments: currently, just handles, could also be memoized (again,
+as SCM's or PyObjects).
+
+Where should these cached values be stored? Well, obviously, in the
+Atom itself.  Either that, or the Handle, but the Atom makes more sense.
+The memoized function should be stored in the GSN/GPN atom.
+
+At this time, (March 2015) we don't have a good way of caching the
+PyObject or the SCM in an atom.  Note that a partial work-around is to
+store the SCM and PyObject caches in the C++ class ExecutionOutputLink,
+and implement some resolution mechanism so that the AtomSpace stores
+a pointer to the C++ ExecutionOutputLink class, instead of just a plain
+C++ Link class.  However, in the long run, storing the memoized SCM or
+PyObject with the Atom, in general, seems like a better idea.
+
+
+Side effects
+------------
+There is also another theoretical issue: the current design assumes
+that ExecutionOutputLink can have side effects, and thus, it needs
+to be run ever time that it is encountered.  This is a poor choice
+for good performance; we need to define a side-effect-free execution
+link, and we need to define a monad when the side effects are needed.

--- a/opencog/guile/SchemeExec.cc
+++ b/opencog/guile/SchemeExec.cc
@@ -55,6 +55,10 @@ SCM SchemeEval::do_apply_scm(const std::string& func, Handle& varargs )
 	for (int i=sz-1; i>=0; i--)
 	{
 		Handle h = oset[i];
+		if (h->getType() == EXECUTION_OUTPUT_LINK)
+		{
+			h = ExecutionOutputLink::do_execute(atomspace, h);
+		}
 		SCM sh = SchemeSmob::handle_to_scm(h);
 		expr = scm_cons(sh, expr);
 	}

--- a/opencog/guile/SchemeExec.cc
+++ b/opencog/guile/SchemeExec.cc
@@ -51,15 +51,11 @@ SCM SchemeEval::do_apply_scm(const std::string& func, Handle& varargs )
 	// If there were args, pass the args to the function.
 	const std::vector<Handle> &oset = atomspace->getOutgoing(varargs);
 
+	// Iterate in reverse, because cons chains in reverse.
 	size_t sz = oset.size();
 	for (int i=sz-1; i>=0; i--)
 	{
-		Handle h = oset[i];
-		if (h->getType() == EXECUTION_OUTPUT_LINK)
-		{
-			h = ExecutionOutputLink::do_execute(atomspace, h);
-		}
-		SCM sh = SchemeSmob::handle_to_scm(h);
+		SCM sh = SchemeSmob::handle_to_scm(oset[i]);
 		expr = scm_cons(sh, expr);
 	}
 	expr = scm_cons(sfunc, expr);

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -137,7 +137,7 @@ SCM SchemeSmob::ss_dec_vlti (SCM satom)
  */
 SCM SchemeSmob::ss_outgoing_set (SCM satom)
 {
-	Handle h = verify_handle(satom, "cog-outgoping-set");
+	Handle h = verify_handle(satom, "cog-outgoing-set");
 
 	LinkPtr lll(LinkCast(h));
 	if (NULL == lll) return SCM_EOL;

--- a/tests/scm/SCMExecutionOutputUTest.cxxtest
+++ b/tests/scm/SCMExecutionOutputUTest.cxxtest
@@ -77,6 +77,7 @@ class SCMExecutionOutputUTest :  public CxxTest::TestSuite
 	void threadedAdd(int thread_id, int N);
 
 	void test_recursive(void);
+	void test_nested(void);
 };
 
 void SCMExecutionOutputUTest::setUp(void)
@@ -211,6 +212,9 @@ void SCMExecutionOutputUTest::test_multi_threads(void)
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
+// This tests a tail-recursive invocation of nested
+// ExectutionOutputLinks, with an intervening cog-execute! at each step.
+// Thus, this winds up the C++ stack for the recursion.
 void SCMExecutionOutputUTest::test_recursive(void)
 {
 	// Empty out the atomspace
@@ -311,9 +315,64 @@ void SCMExecutionOutputUTest::test_recursive(void)
 	// Now, the atomspace has nine atoms
 	// 3:  (Inheritance julian king)
 	// 3:  (Inheritance anne queen)
-	// 3:  (ExecutionLink (GroundedSchemeNode) (ListLink anne))
+	// 3:  (ExecutionLink (GroundedSchemaNode) (ListLink anne))
 	size = as->getSize();
 	TS_ASSERT_EQUALS(size, 9);
 
 	size = as->getSize();
+}
+
+// Test nested execution links. github issue #1340
+//
+// The following should work:
+//   ExecutionOutputLink
+//       "scm: *"
+//       ListLink
+//            ExecutionOutputLink
+//                 "scm: +"
+//                 ListLink
+//                     NumberNode 1
+//                     NumberNode 2
+//            NumberNode 3
+//
+// is a representation of (1 + 2) * 3
+//
+void SCMExecutionOutputUTest::test_nested(void)
+{
+	// Empty out the atomspace
+	as->clear();
+	size_t size = as->getSize();
+	TS_ASSERT_EQUALS(size, 0);
+
+	// Define various generic utilities
+	eval->eval(
+		"(define (oc-plus x y)"
+		"   (NumberNode (number->string (+ "
+		"      (string->number (cog-name x)) "
+		"      (string->number (cog-name y))))))"
+		"(define (oc-times x y)"
+		"   (NumberNode (number->string (* "
+		"      (string->number (cog-name x)) "
+		"      (string->number (cog-name y))))))"
+	);
+	CHKEV(eval);
+
+	eval->eval(
+		"(define nestor"
+		"   (ExecutionOutputLink "
+		"      (GroundedSchemaNode \"scm: oc-times\")"
+		"      (ListLink "
+		"         (ExecutionOutputLink "
+		"            (GroundedSchemaNode \"scm: oc-plus\")"
+		"            (ListLink "
+		"               (NumberNode \"1\")"
+		"               (NumberNode \"2\")))"
+		"         (NumberNode \"3\"))))"
+	);
+	CHKEV(eval);
+
+	Handle enine = eval->eval_h("(cog-execute! nestor)");
+	Handle nine = eval->eval_h("(NumberNode \"9\")");
+
+	TS_ASSERT_EQUALS(nine, enine);
 }


### PR DESCRIPTION
This is a fix for bug #1340 ... Its simple, its easy, its slow. Turns out that proper, high-speed, high-quality support raises many hard but interesting language-design issues.