### PR TITLE
Update pyshell.py to use newer IPython API

### DIFF
--- a/opencog/cython/PythonModule.cc
+++ b/opencog/cython/PythonModule.cc
@@ -30,7 +30,6 @@
 
 #include "PyMindAgent.h"
 #include "PyRequest.h"
-#include "PythonEval.h"
 #include "PythonModule.h"
 
 #include "opencog/agent_finder_types.h"
@@ -216,7 +215,7 @@ std::string PythonModule::do_load_py(Request *dummy, std::list<std::string> args
             if (!first) { oss << ", "; first = false; }
             oss << s;
         }
-        oss << ".";
+        oss << ".\n";
     } else {
         oss << "No subclasses of opencog.cogserver.Request found.\n";
     }


### PR DESCRIPTION
Also fixed a missing '\n' in PythonModule that resulted in the `cogserver>` prompt not being left-justified after a `loadpy`