### PR TITLE
Refactor user function calls and added test to PythonEvalUTest

### DIFF
--- a/opencog/cython/PythonEval.h
+++ b/opencog/cython/PythonEval.h
@@ -98,6 +98,7 @@ class PythonEval : public GenericEval
         void add_to_sys_path(std::string path);
         PyObject * atomspace_py_object(AtomSpace * atomspace = NULL);
         void print_dictionary(PyObject* obj);
+        void execute_string(const char* command);
 
         static PythonEval* singletonInstance;
         static AtomSpace* singletonAtomSpace;
@@ -156,6 +157,13 @@ class PythonEval : public GenericEval
          * Calls the Python function passed in 'func' returning a TruthValuePtr.
          */
         TruthValuePtr apply_tv(const std::string& func, Handle varargs);
+
+        /**
+         *
+         */
+        void print_root_dictionary()
+            { this->print_dictionary(PyModule_GetDict(this->pyRootModule)); }
+
 };
 
 /**

--- a/opencog/cython/PythonEval.h
+++ b/opencog/cython/PythonEval.h
@@ -100,6 +100,8 @@ class PythonEval : public GenericEval
         void print_dictionary(PyObject* obj);
         void execute_string(const char* command);
         int argument_count(PyObject* pyFunction);
+        PyObject* module_for_function(  const std::string& moduleFunction,
+                                        std::string& functionName);
 
         static PythonEval* singletonInstance;
         static AtomSpace* singletonAtomSpace;

--- a/opencog/cython/PythonEval.h
+++ b/opencog/cython/PythonEval.h
@@ -99,6 +99,7 @@ class PythonEval : public GenericEval
         PyObject * atomspace_py_object(AtomSpace * atomspace = NULL);
         void print_dictionary(PyObject* obj);
         void execute_string(const char* command);
+        int argument_count(PyObject* pyFunction);
 
         static PythonEval* singletonInstance;
         static AtomSpace* singletonAtomSpace;

--- a/opencog/cython/PythonEval.h
+++ b/opencog/cython/PythonEval.h
@@ -83,16 +83,20 @@ class PythonEval : public GenericEval
     private:
         void initialize_python_objects_and_imports(void);
 
+        // Module utility functions
         void import_module( const boost::filesystem::path &file,
                             PyObject* pyFromList);
         void add_module_directory(const boost::filesystem::path &directory);
         void add_module_file(const boost::filesystem::path &file);
         void add_modules_from_path(std::string path);
 
+        // Python utility functions
+        PyObject* call_user_function(   const std::string& func,
+                                        Handle varargs);
+        void build_python_error_message(    const char* function_name,
+                                            std::string& errorMessage);
         void add_to_sys_path(std::string path);
-
         PyObject * atomspace_py_object(AtomSpace * atomspace = NULL);
-
         void print_dictionary(PyObject* obj);
 
         static PythonEval* singletonInstance;

--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -70,6 +70,9 @@ cdef class Atom(object):
         def __get__(self):
             return self.type
 
+    def handle_uuid(self):
+        return self.handle.value()
+
     def is_source(self,Atom a):
         return self.atomspace.is_source(a.h,self.handle)
 

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -82,7 +82,7 @@ cdef extern from "opencog/atomspace/atom_types.h" namespace "opencog":
     cdef Type NOTYPE
 
 # Handle
-ctypedef long UUID
+ctypedef public long UUID
 
 cdef extern from "opencog/atomspace/Handle.h" namespace "opencog":
     cdef cppclass cHandle "opencog::Handle":

--- a/opencog/cython/opencog/atomspace_details.pyx
+++ b/opencog/cython/opencog/atomspace_details.pyx
@@ -411,3 +411,8 @@ cdef api object py_atomspace(cAtomSpace *c_atomspace) with gil:
     cdef AtomSpace atomspace = AtomSpace_factory(c_atomspace)
     return atomspace
 
+cdef api object py_atom(UUID uuid, object atomspace):
+    cdef Handle temphandle = Handle(uuid)
+    cdef Atom atom = Atom(temphandle, atomspace)
+    return atom
+

--- a/opencog/python/preload_functions/test_functions.py
+++ b/opencog/python/preload_functions/test_functions.py
@@ -13,7 +13,7 @@ def print_arguments(argOne, argTwo):
 def add_link(atom_one, atom_two):
     print "atom_one = ", atom_one
     print "atom_two = ", atom_two
-    link_atom = ATOMSPACE.add_link(types.ListLink, [atom_two, atom_two])
+    link_atom = ATOMSPACE.add_link(types.ListLink, [atom_one, atom_two])
     print "link_atom = ", link_atom
     return link_atom
 

--- a/tests/cython/CMakeLists.txt
+++ b/tests/cython/CMakeLists.txt
@@ -39,13 +39,18 @@ IF (HAVE_SERVER)
 ENDIF (HAVE_SERVER)
 
 
-# The PythonEvalUTest tests PythonEval independent of the CogServer.
+# The PythonEvalUTest tests PythonEval independent of the CogServer. It depends
+# on the server being around for the Scheme code but it does not message
+# through a "py-eval" server request.
+#
 ADD_CXXTEST(PythonEvalUTest)
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/cython/pythoneval.conf
 	${PROJECT_BINARY_DIR}/tests/cython/pythoneval.conf)
 
 TARGET_LINK_LIBRARIES(PythonEvalUTest
 	atomspace
+	smob
+	server
 	PythonEval
 	cogutil
 )

--- a/tests/cython/PythonEvalUTest.cxxtest
+++ b/tests/cython/PythonEvalUTest.cxxtest
@@ -4,6 +4,9 @@
 #include <opencog/util/Config.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/cython/PythonEval.h>
+#include <opencog/guile/SchemeEval.h>
+#include <opencog/guile/SchemeSmob.h>
+#include <opencog/server/CogServer.h>
 
 using std::string;
 
@@ -243,9 +246,10 @@ public:
         PythonEval* evaluator = &PythonEval::instance();
 
         // Check that our atom space global is visible and can add a node.
+        evaluator->clear_pending();
         evaluator->eval_expr("from opencog.atomspace import *");
         evaluator->eval_expr("ATOMSPACE.add_node(types.ConceptNode,'test')");
-        evaluator->eval_expr("print 'Total atoms = ', ATOMSPACE.size(), '\n'");
+        evaluator->eval_expr("print 'Total atoms = ', ATOMSPACE.size(), '\\n'");
 
         // Delete the singleton instance and atomspace.
         PythonEval::delete_singleton_instance();
@@ -256,6 +260,66 @@ public:
         global_python_finalize();
 
         logger().debug("[PythonEvalUTest] testPythonEvalEvalExpr() DONE");
+    }
+
+    void testApplyAndApplyTV() {
+
+        CogServer cogServer;
+        bool error;
+
+        config().set("SCM_PRELOAD", "opencog/atomspace/core_types.scm");
+        cogServer.loadSCMModules();
+
+        // Get the python eval instance which the CogServer will have created.
+        PythonEval* python = &PythonEval::instance();
+
+        // Define python functions for use by scheme.
+        python->eval(
+            "from opencog.atomspace import types, Atom, TruthValue\n"
+            "def add_link(atom1, atom2):\n"
+            "    link = ATOMSPACE.add_link(types.ListLink, [atom1, atom2])\n"
+            "    print 'add_linklink(',atom1,',',atom2,') = ', link\n"
+            "    return link\n\n"
+
+            "def return_truth(atom1, atom2):\n"
+            "    print 'return_truth TruthValue(0.75, 100.0)'\n"
+            "    return TruthValue(0.75, 100.0)\n"
+            );
+
+        // Create a scheme evaluator to trigger cog-evaluate and cog-execute.
+        SchemeEval* scheme = new SchemeEval(&cogServer.getAtomSpace());
+       
+        // Test execute -> PythonEval::apply
+        scheme->eval(
+                "(cog-execute! "
+                "   (ExecutionOutputLink"
+                "       (GroundedSchemaNode \"py: add_link\")"
+                "       (ListLink"
+                "           (ConceptNode \"one\")"
+                "           (ConceptNode \"two\")"
+                "       )"
+                "   )"
+                ")"
+                );
+        error = scheme->eval_error();
+        scheme->clear_pending();
+        TSM_ASSERT("Failed cog-execute!", !error);
+
+        // Test cog-evaluate -> PythonEval::apply_tv
+        scheme->eval(
+                "(cog-evaluate! "
+                "   (EvaluationLink"
+                "       (GroundedPredicateNode \"py: return_truth\")"
+                "       (ListLink"
+                "           (ConceptNode \"one\")"
+                "           (ConceptNode \"two\")"
+                "       )"
+                "   )"
+                ")"
+                );
+        error = scheme->eval_error();
+        scheme->clear_pending();
+        TSM_ASSERT("Failed cog-evaluate!", !error);
     }
 
 };

--- a/tests/cython/PythonEvalUTest.cxxtest
+++ b/tests/cython/PythonEvalUTest.cxxtest
@@ -278,7 +278,7 @@ public:
             "from opencog.atomspace import types, Atom, TruthValue\n"
             "def add_link(atom1, atom2):\n"
             "    link = ATOMSPACE.add_link(types.ListLink, [atom1, atom2])\n"
-            "    print 'add_linklink(',atom1,',',atom2,') = ', link\n"
+            "    print 'add_link(',atom1,',',atom2,') = ', link\n"
             "    return link\n\n"
 
             "def return_truth(atom1, atom2):\n"


### PR DESCRIPTION
1. Refactored the way user functions are called so now both `Handle PythonEval::apply` and `TruthValuePtr PythonEval::apply_tv` use the same code.
1. Refactored the Python error message building code so it's now in once place.
1. Added test of cog-execute and cog-evaluate nodes to test `PythonEval::apply` and `PythonEval::apply_tv` to PythonEvalUTest.

(EDIT: This is done ->) There is one more significant refactor left that is not part of this pull request, the change to direct execution of user functions from the current Python function `execute_user_function` calling the user function.