### PR TITLE
Experimental number-valued atoms

### DIFF
--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -357,8 +357,7 @@ UnorderedHandleSet AtomTable::getHandlesByNames(const char** names,
                                      bool* subclasses,
                                      Arity arity,
                                      Type type,
-                                     bool subclass)
-    const throw (RuntimeException)
+                                     bool subclass) const
 {
     std::vector<UnorderedHandleSet> sets(arity);
 
@@ -471,7 +470,7 @@ bool AtomTable::inEnviron(AtomPtr atom)
     return false;
 }
 
-Handle AtomTable::add(AtomPtr atom, bool async) throw (RuntimeException)
+Handle AtomTable::add(AtomPtr atom, bool async)
 {
     // Is the atom already in this table, or one of its environments?
     if (inEnviron(atom))

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -38,6 +38,7 @@
 #include <opencog/atomspace/Link.h>
 #include <opencog/atomspace/Node.h>
 #include <opencog/atomspace/TLB.h>
+#include <opencog/execution/NumberNode.h>
 #include <opencog/util/exceptions.h>
 #include <opencog/util/functional.h>
 #include <opencog/util/Logger.h>
@@ -510,7 +511,11 @@ Handle AtomTable::add(AtomPtr atom, bool async) throw (RuntimeException)
     if (at != NULL) {
         NodePtr nnn(NodeCast(atom));
         if (nnn) {
-            atom = createNode(*nnn);
+            // Experimental support for NumberNodes
+            if (NUMBER_NODE == nnn->getType())
+                atom = createNumberNode(*nnn);
+            else
+                atom = createNode(*nnn);
         } else {
             LinkPtr lll(LinkCast(atom));
             atom = createLink(*lll);

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -644,10 +644,20 @@ Handle AtomTable::add(AtomPtr atom, bool async) throw (RuntimeException)
         }
     }
 
+    // Experimental NumberNode support code
+    if (atom->getType() == NUMBER_NODE) {
+        NumberNodePtr nnp(NumberNodeCast(atom));
+        if (NULL == nnp) {
+           nnp = createNumberNode(*NodeCast(atom));
+           nnp->_uuid = atom->_uuid;
+           atom = nnp;
+        }
+    }
+
     // Its possible that the atom already has a UUID assigned,
     // e.g. if it was fetched from persistent storage; this
     // was done to preserve handle consistency. SavingLoading does
-    // this too.  XXX Review SavingLoading for corrrectness...
+    // this too.  XXX Review SavingLoading for correctness...
     if (atom->_uuid == Handle::UNDEFINED.value()) {
        // Atom doesn't yet have a valid uuid assigned to it. Ask the TLB
        // to issue a valid uuid.  And then memorize it.

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -366,8 +366,7 @@ public:
      * criteria in their outgoing set.
      */
     UnorderedHandleSet getHandlesByNames(const char**, Type*, bool*, Arity,
-                              Type type = ATOM, bool subclass = true) const
-    throw (RuntimeException);
+                              Type type = ATOM, bool subclass = true) const;
 
     /**
      * Returns the set of atoms with the given target names and/or types
@@ -440,7 +439,7 @@ public:
      * @param The new atom to be added.
      * @return The handle of the newly added atom.
      */
-    Handle add(AtomPtr, bool async) throw (RuntimeException);
+    Handle add(AtomPtr, bool async);
 
     /**
      * Read-write synchronization barrier fence.  When called, this

--- a/opencog/atomspace/ClassServer.cc
+++ b/opencog/atomspace/ClassServer.cc
@@ -57,7 +57,7 @@ ClassServer* ClassServer::createInstance(void)
     return new ClassServer();
 }
 
-Type ClassServer::addType(Type parent, const std::string& name)
+Type ClassServer::addType(const Type parent, const std::string& name)
 {
     // Check if a type with this name already exists. If it does, then
     // the second and subsequent calls are to be interpreted as defining

--- a/opencog/atomspace/ClassServer.h
+++ b/opencog/atomspace/ClassServer.h
@@ -75,7 +75,7 @@ public:
     static ClassServer* createInstance(void);
 
     /** Adds a new atom type with the given name and parent type */
-    Type addType(Type parent, const std::string& name);
+    Type addType(const Type parent, const std::string& name);
 
     /** Provides ability to get type-added signals.
      * @warning methods connected to this signal must not call ClassServer::addType or

--- a/opencog/atomspace/Node.h
+++ b/opencog/atomspace/Node.h
@@ -41,7 +41,7 @@ namespace opencog
  */
 class Node : public Atom
 {
-private:
+protected:
     // properties
     std::string name;
     void init(const std::string&) throw (InvalidParamException, AssertionException);
@@ -61,7 +61,8 @@ public:
     Node(Type t, const std::string& s,
          TruthValuePtr tv = TruthValue::DEFAULT_TV(),
          AttentionValuePtr av = AttentionValue::DEFAULT_AV())
-        : Atom(t,tv,av) {
+        : Atom(t,tv,av)
+    {
         init(s);
     }
 
@@ -71,7 +72,8 @@ public:
      * because thread-safe locking required in the gets.
      */
     Node(Node &n)
-        : Atom(n.getType(), n.getTruthValue(), n.getAttentionValue()) {
+        : Atom(n.getType(), n.getTruthValue(), n.getAttentionValue())
+    {
         init(n.name);
     }
 
@@ -108,7 +110,8 @@ public:
 typedef std::shared_ptr<Node> NodePtr;
 static inline NodePtr NodeCast(const Handle& h)
     { AtomPtr a(h); return std::dynamic_pointer_cast<Node>(a); }
-static inline NodePtr NodeCast(AtomPtr a) { return std::dynamic_pointer_cast<Node>(a); }
+static inline NodePtr NodeCast(AtomPtr a)
+    { return std::dynamic_pointer_cast<Node>(a); }
 
 // XXX temporary hack ...
 #define createNode std::make_shared<Node>

--- a/opencog/atomspace/TruthValue.h
+++ b/opencog/atomspace/TruthValue.h
@@ -162,9 +162,10 @@ public:
      * Merge this TV object with the given TV object argument.
      * It always returns a new TV object with the result of the merge,
      * even if it is equal to one of the merged TV objects.
-     * @param ms the merge style as described in https://github.com/opencog/opencog/issues/1295
+     * @param ms the merge style as described in
+     *        https://github.com/opencog/opencog/issues/1295
      */
-    virtual TruthValuePtr merge(TruthValuePtr,TVMergeStyle ms=DEFAULT) const = 0;
+    virtual TruthValuePtr merge(TruthValuePtr, TVMergeStyle ms=DEFAULT) const = 0;
 
     /**
      * Check if this TV is a null TV.
@@ -182,7 +183,8 @@ public:
 // overload of operator<< to print TruthValue
 namespace std {
     template<typename Out>
-    Out& operator<<(Out& out, const opencog::TruthValue& tv) {
+    Out& operator<<(Out& out, const opencog::TruthValue& tv)
+    {
         out << tv.toString();
         return out;
     }

--- a/opencog/atomspace/atom_types.script
+++ b/opencog/atomspace/atom_types.script
@@ -90,9 +90,6 @@ EQUIVALENCE_LINK <- AVERAGE_LINK
 // To be used with PredicateNode
 EVALUATION_LINK <- ORDERED_LINK
 
-// ??? symbol link not used anywhere. What is it's semantics?
-// SYMBOL_LINK <- ORDERED_LINK
-
 // Generic association
 ASSOCIATIVE_LINK <- ORDERED_LINK
 
@@ -128,5 +125,11 @@ EXECUTION_OUTPUT_LINK <- ORDERED_LINK
 // processing.
 ANCHOR_NODE <- NODE
 
-// Link for mathematics. (???)
+// ====================================================================
+// Link for mathematics. (???) Huh? What is this? What does it do?
 QUANTITY_LINK <- ORDERED_LINK
+
+// Basic arithmetic operators
+PLUS_LINK <- UNORDERED_LINK
+TIMES_LINK <- UNORDERED_LINK
+GREATER_THAN_LINK <- ORDERED_LINK

--- a/opencog/execution/EvaluationLink.cc
+++ b/opencog/execution/EvaluationLink.cc
@@ -29,27 +29,27 @@
 using namespace opencog;
 
 EvaluationLink::EvaluationLink(const HandleSeq& oset,
-                             TruthValuePtr tv,
-                             AttentionValuePtr av)
+                               TruthValuePtr tv,
+                               AttentionValuePtr av)
     : Link(EVALUATION_LINK, oset, tv, av)
 {
-    if ((2 != oset.size()) or
-       (LIST_LINK != oset[1]->getType()))
-    {
-        throw RuntimeException(TRACE_INFO,
-            "EvaluationLink must have predicate and args!");
-    }
+	if ((2 != oset.size()) or
+	   (LIST_LINK != oset[1]->getType()))
+	{
+		throw RuntimeException(TRACE_INFO,
+		    "EvaluationLink must have predicate and args!");
+	}
 }
 
 EvaluationLink::EvaluationLink(Handle schema, Handle args,
-                             TruthValuePtr tv,
-                             AttentionValuePtr av)
+                               TruthValuePtr tv,
+                               AttentionValuePtr av)
     : Link(EVALUATION_LINK, schema, args, tv, av)
 {
-    if (LIST_LINK != args->getType()) {
-        throw RuntimeException(TRACE_INFO,
-            "EvaluationLink must have args in a ListLink!");
-    }
+	if (LIST_LINK != args->getType()) {
+		throw RuntimeException(TRACE_INFO,
+		    "EvaluationLink must have args in a ListLink!");
+	}
 }
 
 /// do_evaluate -- evaluate the GroundedPredicateNode of the EvaluationLink
@@ -69,11 +69,11 @@ EvaluationLink::EvaluationLink(Handle schema, Handle args,
 ///
 TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as, Handle execlnk)
 {
-    if (EVALUATION_LINK != execlnk->getType()) {
-        throw RuntimeException(TRACE_INFO, "Expecting to get an EvaluationLink!");
-    }
-    LinkPtr l(LinkCast(execlnk));
-    return do_evaluate(as, l->getOutgoingSet());
+	if (EVALUATION_LINK != execlnk->getType()) {
+		throw RuntimeException(TRACE_INFO, "Expecting to get an EvaluationLink!");
+	}
+	LinkPtr l(LinkCast(execlnk));
+	return do_evaluate(as, l->getOutgoingSet());
 }
 
 /// do_evaluate -- evaluate the GroundedPredicateNode of the EvaluationLink
@@ -85,11 +85,11 @@ TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as, Handle execlnk)
 ///
 TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as, const HandleSeq& sna)
 {
-    if (2 != sna.size())
-    {
-        throw RuntimeException(TRACE_INFO, "Incorrect arity for an EvaluationLink!");
-    }
-    return do_evaluate(as, sna[0], sna[1]);
+	if (2 != sna.size())
+	{
+		throw RuntimeException(TRACE_INFO, "Incorrect arity for an EvaluationLink!");
+	}
+	return do_evaluate(as, sna[0], sna[1]);
 }
 
 /// do_evaluate -- evaluate the GroundedPredicateNode of the EvaluationLink
@@ -100,91 +100,91 @@ TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as, const HandleSeq& sna)
 ///
 TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as, Handle gsn, Handle args)
 {
-    if (GROUNDED_PREDICATE_NODE != gsn->getType())
-    {
-        throw RuntimeException(TRACE_INFO, "Expecting GroundedPredicateNode!");
-    }
-    if (LIST_LINK != args->getType())
-    {
-        throw RuntimeException(TRACE_INFO, "Expecting arguments to EvaluationLink!");
-    }
+	if (GROUNDED_PREDICATE_NODE != gsn->getType())
+	{
+		throw RuntimeException(TRACE_INFO, "Expecting GroundedPredicateNode!");
+	}
+	if (LIST_LINK != args->getType())
+	{
+		throw RuntimeException(TRACE_INFO, "Expecting arguments to EvaluationLink!");
+	}
 
-    // Get the schema name.
-    const std::string& schema = NodeCast(gsn)->getName();
-    // printf ("Grounded schema name: %s\n", schema.c_str());
+	// Get the schema name.
+	const std::string& schema = NodeCast(gsn)->getName();
+	// printf ("Grounded schema name: %s\n", schema.c_str());
 
-    // A very special-case C++ comparison.
-    // This compares two NumberNodes, by their numeric value.
-    // Hard-coded in C++ for speed. (well, and for convenience ...)
-    if (0 == schema.compare("c++:greater"))
-    {
-        LinkPtr ll(LinkCast(args));
-        Handle h1(ll->getOutgoingAtom(0));
-        Handle h2(ll->getOutgoingAtom(1));
-        if (NUMBER_NODE != h1->getType() or NUMBER_NODE != h2->getType())
-            throw RuntimeException(TRACE_INFO,
-                "Expecting c++:greater arguments to be NumberNode's!");
-        const std::string& s1 = NodeCast(h1)->getName();
-        const std::string& s2 = NodeCast(h2)->getName();
-        double v1 = atof(s1.c_str());
-        double v2 = atof(s2.c_str());
-        if (v1 > v2)
-            return TruthValue::TRUE_TV();
-        else
-            return TruthValue::FALSE_TV();
-    }
+	// A very special-case C++ comparison.
+	// This compares two NumberNodes, by their numeric value.
+	// Hard-coded in C++ for speed. (well, and for convenience ...)
+	if (0 == schema.compare("c++:greater"))
+	{
+		LinkPtr ll(LinkCast(args));
+		Handle h1(ll->getOutgoingAtom(0));
+		Handle h2(ll->getOutgoingAtom(1));
+		if (NUMBER_NODE != h1->getType() or NUMBER_NODE != h2->getType())
+			throw RuntimeException(TRACE_INFO,
+			     "Expecting c++:greater arguments to be NumberNode's!");
+		const std::string& s1 = NodeCast(h1)->getName();
+		const std::string& s2 = NodeCast(h2)->getName();
+		double v1 = atof(s1.c_str());
+		double v2 = atof(s2.c_str());
+		if (v1 > v2)
+			return TruthValue::TRUE_TV();
+		else
+			return TruthValue::FALSE_TV();
+	}
 
-    // A very special-case C++ comparison.
-    // This compares a set of atoms, verifying that they are all different.
-    // Hard-coded in C++ for speed. (well, and for convenience ...)
-    if (0 == schema.compare("c++:exclusive"))
-    {
-        LinkPtr ll(LinkCast(args));
-        Arity sz = ll->getArity();
-        for (Arity i=0; i<sz-1; i++) {
-            Handle h1(ll->getOutgoingAtom(i));
-            for (Arity j=i+1; j<sz; j++) {
-                Handle h2(ll->getOutgoingAtom(j));
-                if (h1 == h2) return TruthValue::FALSE_TV();
-            }
-        }
-        return TruthValue::TRUE_TV();
-    }
+	// A very special-case C++ comparison.
+	// This compares a set of atoms, verifying that they are all different.
+	// Hard-coded in C++ for speed. (well, and for convenience ...)
+	if (0 == schema.compare("c++:exclusive"))
+	{
+		LinkPtr ll(LinkCast(args));
+		Arity sz = ll->getArity();
+		for (Arity i=0; i<sz-1; i++) {
+			Handle h1(ll->getOutgoingAtom(i));
+			for (Arity j=i+1; j<sz; j++) {
+				Handle h2(ll->getOutgoingAtom(j));
+				if (h1 == h2) return TruthValue::FALSE_TV();
+			}
+		}
+		return TruthValue::TRUE_TV();
+	}
 
-    // At this point, we only run scheme and python schemas.
-    if (0 == schema.compare(0,4,"scm:", 4))
-    {
+	// At this point, we only run scheme and python schemas.
+	if (0 == schema.compare(0,4,"scm:", 4))
+	{
 #ifdef HAVE_GUILE
-        // Be friendly, and strip leading white-space, if any.
-        size_t pos = 4;
-        while (' ' == schema[pos]) pos++;
+		// Be friendly, and strip leading white-space, if any.
+		size_t pos = 4;
+		while (' ' == schema[pos]) pos++;
 
-        SchemeEval* applier = get_evaluator(as);
-        return applier->apply_tv(schema.substr(pos), args);
+		SchemeEval* applier = get_evaluator(as);
+		return applier->apply_tv(schema.substr(pos), args);
 #else
-        throw RuntimeException(TRACE_INFO,
-             "Cannot evaluate scheme GroundedPredicateNode!");
+		throw RuntimeException(TRACE_INFO,
+			 "Cannot evaluate scheme GroundedPredicateNode!");
 #endif /* HAVE_GUILE */
-    }
+	}
 
-    if (0 == schema.compare(0, 3,"py:", 3))
-    {
+	if (0 == schema.compare(0, 3,"py:", 3))
+	{
 #ifdef HAVE_CYTHON
-        // Be friendly, and strip leading white-space, if any.
-        size_t pos = 3;
-        while (' ' == schema[pos]) pos++;
+		// Be friendly, and strip leading white-space, if any.
+		size_t pos = 3;
+		while (' ' == schema[pos]) pos++;
 
-        PythonEval &applier = PythonEval::instance();
-        // std::string rc = applier.apply(schema.substr(pos), args);
-        // if (rc.compare("None") or rc.compare("False")) return false;
-        return applier.apply_tv(schema.substr(pos), args);
+		PythonEval &applier = PythonEval::instance();
+		// std::string rc = applier.apply(schema.substr(pos), args);
+		// if (rc.compare("None") or rc.compare("False")) return false;
+		return applier.apply_tv(schema.substr(pos), args);
 #else
-        throw RuntimeException(TRACE_INFO,
-             "Cannot evaluate python GroundedPredicateNode!");
+		throw RuntimeException(TRACE_INFO,
+			 "Cannot evaluate python GroundedPredicateNode!");
 #endif /* HAVE_CYTHON */
-    }
+	}
 
-    // Unkown proceedure type.
-    throw RuntimeException(TRACE_INFO,
-        "Cannot evaluate unknown GroundedPredicateNode!");
+	// Unkown proceedure type.
+	throw RuntimeException(TRACE_INFO,
+	     "Cannot evaluate unknown GroundedPredicateNode!");
 }

--- a/opencog/execution/EvaluationLink.cc
+++ b/opencog/execution/EvaluationLink.cc
@@ -22,6 +22,7 @@
 
 #include <opencog/atomspace/atom_types.h>
 #include <opencog/atomspace/AtomSpace.h>
+#include <opencog/atomspace/SimpleTruthValue.h>
 #include <opencog/cython/PythonEval.h>
 #include <opencog/guile/SchemeEval.h>
 #include "EvaluationLink.h"
@@ -104,6 +105,13 @@ TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as, Handle execlnk)
 	else if (GREATER_THAN_LINK == t)
 	{
 		return greater(as, LinkCast(execlnk));
+	}
+	else if (NOT_LINK == t)
+	{
+		LinkPtr l(LinkCast(execlnk));
+		TruthValuePtr tv(do_evaluate(as, l->getOutgoingAtom(0)));
+		return SimpleTruthValue::createTV(
+		              1.0 - tv->getMean(), tv->getCount());
 	}
 	throw RuntimeException(TRACE_INFO, "Expecting to get an EvaluationLink!");
 }

--- a/opencog/execution/ExecutionOutputLink.cc
+++ b/opencog/execution/ExecutionOutputLink.cc
@@ -26,7 +26,9 @@
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/cython/PythonEval.h>
 #include <opencog/guile/SchemeEval.h>
+
 #include "ExecutionOutputLink.h"
+#include "NumberNode.h"
 
 using namespace opencog;
 
@@ -151,7 +153,7 @@ Handle ExecutionOutputLink::do_execute(AtomSpace* as, Type t,
 		{
 			prod *= get_double(h);
 		}
-		return as->addNode(NUMBER_NODE, std::to_string(prod));
+		return as->addAtom(createNumberNode(prod));
 	}
 	else if (PLUS_LINK)
 	{
@@ -160,7 +162,7 @@ Handle ExecutionOutputLink::do_execute(AtomSpace* as, Type t,
 		{
 			sum += get_double(h);
 		}
-		return as->addNode(NUMBER_NODE, std::to_string(sum));
+		return as->addAtom(createNumberNode(sum));
 	}
 
 	throw RuntimeException(TRACE_INFO,

--- a/opencog/execution/ExecutionOutputLink.cc
+++ b/opencog/execution/ExecutionOutputLink.cc
@@ -140,7 +140,7 @@ static inline double get_double(Handle& h)
 Handle ExecutionOutputLink::do_execute(AtomSpace* as, Type t,
                                        const HandleSeq& sna)
 {
-	if (EXECUTION_OUTPUT_LINK)
+	if (EXECUTION_OUTPUT_LINK == t)
 	{
 		if (2 != sna.size())
 		{
@@ -149,7 +149,7 @@ Handle ExecutionOutputLink::do_execute(AtomSpace* as, Type t,
 		}
 		return do_execute(as, sna[0], sna[1]);
 	}
-	else if (TIMES_LINK)
+	else if (TIMES_LINK == t)
 	{
 		double prod = 1.0;
 		for (Handle h: sna)
@@ -158,7 +158,7 @@ Handle ExecutionOutputLink::do_execute(AtomSpace* as, Type t,
 		}
 		return as->addAtom(createNumberNode(prod));
 	}
-	else if (PLUS_LINK)
+	else if (PLUS_LINK == t)
 	{
 		double sum = 0.0;
 		for (Handle h: sna)

--- a/opencog/execution/ExecutionOutputLink.cc
+++ b/opencog/execution/ExecutionOutputLink.cc
@@ -117,14 +117,17 @@ Handle ExecutionOutputLink::recurse(AtomSpace* as, Handle h)
 }
 
 // handle->double conversion
-static double get_double(Handle& h)
+static inline double get_double(Handle& h)
 {
 	if (NUMBER_NODE != h->getType())
 		throw RuntimeException(TRACE_INFO,
 		     "Not a number!");
 
-	NodePtr nnn(NodeCast(h));
-	return atof(nnn->getName().c_str());
+	NumberNodePtr nnn(NumberNodeCast(h));
+	OC_ASSERT (nnn != NULL,
+		"This should never happen; there's a bug in the code!");
+
+	return nnn->getValue();
 }
 
 /// do_execute -- execute the GroundedSchemaNode of the ExecutionOutputLink

--- a/opencog/execution/ExecutionOutputLink.cc
+++ b/opencog/execution/ExecutionOutputLink.cc
@@ -31,26 +31,26 @@ using namespace opencog;
 ExecutionOutputLink::ExecutionOutputLink(const HandleSeq& oset,
                                          TruthValuePtr tv,
                                          AttentionValuePtr av)
-    : Link(EXECUTION_OUTPUT_LINK, oset, tv, av)
+	: Link(EXECUTION_OUTPUT_LINK, oset, tv, av)
 {
-    if ((2 != oset.size()) or
-       (LIST_LINK != oset[1]->getType()))
-    {
-        throw RuntimeException(TRACE_INFO,
-            "ExecutionOutputLink must have schema and args!");
-    }
+	if ((2 != oset.size()) or
+	   (LIST_LINK != oset[1]->getType()))
+	{
+		throw RuntimeException(TRACE_INFO,
+			"ExecutionOutputLink must have schema and args!");
+	}
 }
 
 ExecutionOutputLink::ExecutionOutputLink(Handle schema, Handle args,
                                          TruthValuePtr tv,
                                          AttentionValuePtr av)
-    : Link(EXECUTION_OUTPUT_LINK, schema, args, tv, av)
+	: Link(EXECUTION_OUTPUT_LINK, schema, args, tv, av)
 {
-    if (LIST_LINK != args->getType())
-    {
-        throw RuntimeException(TRACE_INFO,
-            "ExecutionOutputLink must have schema and args!");
-    }
+	if (LIST_LINK != args->getType())
+	{
+		throw RuntimeException(TRACE_INFO,
+			"ExecutionOutputLink must have schema and args!");
+	}
 }
 
 /// do_execute -- execute the GroundedSchemaNode of the ExecutionOutputLink
@@ -70,39 +70,39 @@ ExecutionOutputLink::ExecutionOutputLink(Handle schema, Handle args,
 ///
 Handle ExecutionOutputLink::do_execute(AtomSpace* as, Handle execlnk)
 {
-    if (EXECUTION_OUTPUT_LINK != execlnk->getType())
-    {
-        throw RuntimeException(TRACE_INFO,
-            "Expecting to get an ExecutionOutputLink!");
-    }
-    LinkPtr l(LinkCast(execlnk));
-    return do_execute(as, l->getOutgoingSet());
+	if (EXECUTION_OUTPUT_LINK != execlnk->getType())
+	{
+		throw RuntimeException(TRACE_INFO,
+		      "Expecting to get an ExecutionOutputLink!");
+	}
+	LinkPtr l(LinkCast(execlnk));
+	return do_execute(as, l->getOutgoingSet());
 }
 
 /// Non-throwing, recursive version.
 Handle ExecutionOutputLink::recurse(AtomSpace* as, Handle h)
 {
-    LinkPtr lll(LinkCast(h));
-    if (NULL == lll) return h;
+	LinkPtr lll(LinkCast(h));
+	if (NULL == lll) return h;
 
-    // If its an execution link, execute it.
-    Type t = lll->getType();
-    if (EXECUTION_OUTPUT_LINK == t)
-        return do_execute(as, lll->getOutgoingSet());
+	// If its an execution link, execute it.
+	Type t = lll->getType();
+	if (EXECUTION_OUTPUT_LINK == t)
+		return do_execute(as, lll->getOutgoingSet());
 
-    // Search for additional execution links, and execute them too.
-    // We will know that happend if the returned handle differs from
-    // the input handle.
-    std::vector<Handle> new_oset;
-    bool changed = false;
-    for (Handle ho : lll->getOutgoingSet())
-    {
-        Handle nh(recurse(as, ho));
-        new_oset.push_back(nh);
-        if (nh != ho) changed = true;
-    }
-    if (not changed) return h;
-    return as->addLink(t, new_oset);
+	// Search for additional execution links, and execute them too.
+	// We will know that happend if the returned handle differs from
+	// the input handle.
+	std::vector<Handle> new_oset;
+	bool changed = false;
+	for (Handle ho : lll->getOutgoingSet())
+	{
+		Handle nh(recurse(as, ho));
+		new_oset.push_back(nh);
+		if (nh != ho) changed = true;
+	}
+	if (not changed) return h;
+	return as->addLink(t, new_oset);
 }
 
 /// do_execute -- execute the GroundedSchemaNode of the ExecutionOutputLink
@@ -114,12 +114,12 @@ Handle ExecutionOutputLink::recurse(AtomSpace* as, Handle h)
 ///
 Handle ExecutionOutputLink::do_execute(AtomSpace* as, const HandleSeq& sna)
 {
-    if (2 != sna.size())
-    {
-        throw RuntimeException(TRACE_INFO,
-           "Incorrect arity for an ExecutionOutputLink!");
-    }
-    return do_execute(as, sna[0], sna[1]);
+	if (2 != sna.size())
+	{
+		throw RuntimeException(TRACE_INFO,
+		     "Incorrect arity for an ExecutionOutputLink!");
+	}
+	return do_execute(as, sna[0], sna[1]);
 }
 
 /// do_execute -- execute the GroundedSchemaNode of the ExecutionOutputLink
@@ -130,87 +130,86 @@ Handle ExecutionOutputLink::do_execute(AtomSpace* as, const HandleSeq& sna)
 ///
 Handle ExecutionOutputLink::do_execute(AtomSpace* as, Handle gsn, Handle args)
 {
-    if (GROUNDED_SCHEMA_NODE != gsn->getType())
-    {
-        throw RuntimeException(TRACE_INFO, "Expecting GroundedSchemaNode!");
-    }
+	if (GROUNDED_SCHEMA_NODE != gsn->getType())
+	{
+		throw RuntimeException(TRACE_INFO, "Expecting GroundedSchemaNode!");
+	}
 
-    if (LIST_LINK != args->getType())
-    {
-        throw RuntimeException(TRACE_INFO,
-            "Expecting arguments to ExecutionOutputLink!");
-    }
+	if (LIST_LINK != args->getType())
+	{
+		throw RuntimeException(TRACE_INFO,
+		     "Expecting arguments to ExecutionOutputLink!");
+	}
 
-    // Search for additional execution links, and execute them too.
-    // We will know that happend if the returned handle differs from
-    // the input handle.
-    LinkPtr largs(LinkCast(args));
-    if (largs)
-    {
-        std::vector<Handle> new_oset;
-        bool changed = false;
-        for (Handle ho : largs->getOutgoingSet())
-        {
-            Handle nh(recurse(as, ho));
-            new_oset.push_back(nh);
-            if (nh != ho) changed = true;
-        }
-        if (changed)
-            args = as->addLink(LIST_LINK, new_oset);
-    }
+	// Search for additional execution links, and execute them too.
+	// We will know that happend if the returned handle differs from
+	// the input handle.
+	LinkPtr largs(LinkCast(args));
+	if (largs)
+	{
+		std::vector<Handle> new_oset;
+		bool changed = false;
+		for (Handle ho : largs->getOutgoingSet())
+		{
+			Handle nh(recurse(as, ho));
+			new_oset.push_back(nh);
+			if (nh != ho) changed = true;
+		}
+		if (changed)
+			args = as->addLink(LIST_LINK, new_oset);
+	}
 
-    // Get the schema name.
-    const std::string& schema = NodeCast(gsn)->getName();
-    // printf ("Grounded schema name: %s\n", schema.c_str());
+	// Get the schema name.
+	const std::string& schema = NodeCast(gsn)->getName();
+	// printf ("Grounded schema name: %s\n", schema.c_str());
 
-    // At this point, we only run scheme and python schemas.
-    if (0 == schema.compare(0,4,"scm:", 4))
-    {
+	// At this point, we only run scheme and python schemas.
+	if (0 == schema.compare(0,4,"scm:", 4))
+	{
 #ifdef HAVE_GUILE
-        // Be friendly, and strip leading white-space, if any.
-        size_t pos = 4;
-        while (' ' == schema[pos]) pos++;
+		// Be friendly, and strip leading white-space, if any.
+		size_t pos = 4;
+		while (' ' == schema[pos]) pos++;
 
-        SchemeEval* applier = get_evaluator(as);
-        Handle h(applier->apply(schema.substr(pos), args));
+		SchemeEval* applier = get_evaluator(as);
+		Handle h(applier->apply(schema.substr(pos), args));
 
-        // Exceptions were already caught, before leaving guile mode,
-        // so we can't rethrow.  Just throw a new exception.
-        if (applier->eval_error())
-            throw RuntimeException(TRACE_INFO,
-                "Failed evaluation; see logfile for stack trace.");
-        return h;
+		// Exceptions were already caught, before leaving guile mode,
+		// so we can't rethrow.  Just throw a new exception.
+		if (applier->eval_error())
+			throw RuntimeException(TRACE_INFO,
+			    "Failed evaluation; see logfile for stack trace.");
+		return h;
 #else
-        throw RuntimeException(TRACE_INFO,
-            "Cannot evaluate scheme GroundedSchemaNode!");
+		throw RuntimeException(TRACE_INFO,
+		    "Cannot evaluate scheme GroundedSchemaNode!");
 #endif /* HAVE_GUILE */
-    }
+	}
 
-    if (0 == schema.compare(0, 3,"py:", 3))
-    {
+	if (0 == schema.compare(0, 3,"py:", 3))
+	{
 #ifdef HAVE_CYTHON
-        // Be friendly, and strip leading white-space, if any.
-        size_t pos = 3;
-        while (' ' == schema[pos]) pos++;
+		// Be friendly, and strip leading white-space, if any.
+		size_t pos = 3;
+		while (' ' == schema[pos]) pos++;
 
-        // Get a reference to the python evaluator. NOTE: We are
-        // passing in a reference to our atom space to invoke
-        // the safety checking to make sure the singleton instance
-        // is using the same atom space.
-        PythonEval &applier = PythonEval::instance(as);
+		// Get a reference to the python evaluator. NOTE: We are
+		// passing in a reference to our atom space to invoke
+		// the safety checking to make sure the singleton instance
+		// is using the same atom space.
+		PythonEval &applier = PythonEval::instance(as);
 
-        Handle h = applier.apply(schema.substr(pos), args);
+		Handle h = applier.apply(schema.substr(pos), args);
 
-        // Return the handle
-        return h;
+		// Return the handle
+		return h;
 #else
-        throw RuntimeException(TRACE_INFO,
-            "Cannot evaluate python GroundedSchemaNode!");
+		throw RuntimeException(TRACE_INFO,
+		    "Cannot evaluate python GroundedSchemaNode!");
 #endif /* HAVE_CYTHON */
-    }
+	}
 
-    // Unkown proceedure type.
-    throw RuntimeException(TRACE_INFO,
-        "Cannot evaluate unknown GroundedSchemaNode!");
+	// Unkown proceedure type.
+	throw RuntimeException(TRACE_INFO,
+	    "Cannot evaluate unknown GroundedSchemaNode!");
 }
-

--- a/opencog/execution/ExecutionOutputLink.h
+++ b/opencog/execution/ExecutionOutputLink.h
@@ -48,7 +48,7 @@ public:
     }
 
     static Handle do_execute(AtomSpace*, Handle);
-    static Handle do_execute(AtomSpace*, const HandleSeq& schema_and_args);
+    static Handle do_execute(AtomSpace*, Type, const HandleSeq& schema_and_args);
     static Handle do_execute(AtomSpace*, Handle schema, Handle args);
 
 private:

--- a/opencog/execution/NumberNode.h
+++ b/opencog/execution/NumberNode.h
@@ -1,0 +1,74 @@
+/*
+ * opencog/execution/NumberNode.h
+ *
+ * Copyright (C) 2015 Linas Vepstas
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OPENCOG_NUMBER_NODE_H
+#define _OPENCOG_NUMBER_NODE_H
+
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/atomspace/Node.h>
+
+namespace opencog
+{
+/** \addtogroup grp_atomspace
+ *  @{
+ *
+ * Experimental NumberNode class. This is a rough sketch for how things
+ * like this might be done. It is not necessarily a god idea, and might
+ * be replaced by something completely different, someday ...
+ */
+
+class NumberNode : public Node
+{
+protected:
+	double value;
+
+public:
+	NumberNode(const std::string& s,
+	           TruthValuePtr tv = TruthValue::DEFAULT_TV(),
+	           AttentionValuePtr av = AttentionValue::DEFAULT_AV())
+		: Node(NUMBER_NODE, s, tv, av),
+		  value(std::stod(s))
+	{}
+
+	NumberNode(double vvv,
+	           TruthValuePtr tv = TruthValue::DEFAULT_TV(),
+	           AttentionValuePtr av = AttentionValue::DEFAULT_AV())
+		: Node(NUMBER_NODE, std::to_string(vvv), tv, av),
+		  value(vvv)
+	{}
+
+	double getValue(void) { return value; }
+};
+
+typedef std::shared_ptr<NumberNode> NumberNodePtr;
+static inline NumberNodePtr NumberNodeCast(const Handle& h)
+	{ AtomPtr a(h); return std::dynamic_pointer_cast<NumberNode>(a); }
+static inline NumberNodePtr NumberNodeCast(AtomPtr a)
+	{ return std::dynamic_pointer_cast<NumberNode>(a); }
+
+// XXX temporary hack ...
+#define createNumberNode std::make_shared<NumberNode>
+
+/** @}*/
+}
+
+#endif // _OPENCOG_NUMBER_NODE_H

--- a/opencog/execution/NumberNode.h
+++ b/opencog/execution/NumberNode.h
@@ -45,7 +45,8 @@ public:
 	NumberNode(const std::string& s,
 	           TruthValuePtr tv = TruthValue::DEFAULT_TV(),
 	           AttentionValuePtr av = AttentionValue::DEFAULT_AV())
-		: Node(NUMBER_NODE, s, tv, av),
+		// Convert to number and back to string to avoid miscompares.
+		: Node(NUMBER_NODE, std::to_string(std::stod(s)), tv, av),
 		  value(std::stod(s))
 	{}
 
@@ -57,7 +58,8 @@ public:
 	{}
 
 	NumberNode(Node &n)
-		: Node(NUMBER_NODE, n.getName(), n.getTruthValue(), n.getAttentionValue()),
+		: Node(NUMBER_NODE, std::to_string(std::stod(n.getName())),
+		       n.getTruthValue(), n.getAttentionValue()),
 		  value(std::stod(n.getName()))
 	{
 		OC_ASSERT(NUMBER_NODE == n.getType(), "Bad NumberNode consructor!");

--- a/opencog/execution/NumberNode.h
+++ b/opencog/execution/NumberNode.h
@@ -56,6 +56,13 @@ public:
 		  value(vvv)
 	{}
 
+	NumberNode(Node &n)
+		: Node(NUMBER_NODE, n.getName(), n.getTruthValue(), n.getAttentionValue()),
+		  value(std::stod(n.getName()))
+	{
+		OC_ASSERT(NUMBER_NODE == n.getType(), "Bad NumberNode consructor!");
+	}
+
 	double getValue(void) { return value; }
 };
 

--- a/opencog/execution/README.md
+++ b/opencog/execution/README.md
@@ -88,3 +88,9 @@ Example:
   (define plu (PlusLink two two))
   (cog-execute! plu)
 ```
+Some other expressions:
+```
+  (cog-execute! (PlusLink (NumberNode 3) (NumberNode 2)))
+  (cog-execute! (TimesLink (NumberNode 3) (NumberNode 2)))
+  (cog-execute! (TimesLink (NumberNode 4) (PlusLink (NumberNode 5) (NumberNode 1))))
+```

--- a/opencog/execution/README.md
+++ b/opencog/execution/README.md
@@ -20,18 +20,21 @@ SCM symbol, or the PyObject that the string name refers to.  Likewise,
 the arguments: currently, just handles, could also be memoized (again,
 as SCM's or PyObjects).
 
-Where should these cached values be stored? Well, obviously, in the
-Atom itself.  Either that, or the Handle, but the Atom makes more sense.
-The memoized function should be stored in the GSN/GPN atom.
+Where should these cached values be stored? Well, obviously, the best
+place seems to be the Atom itself.  The memoized function should be
+stored in the GSN/GPN atom.
 
-At this time, (March 2015) we don't have a good way of caching the
-PyObject or the SCM in an atom.  Note that a partial work-around is to
-store the SCM and PyObject caches in the C++ class ExecutionOutputLink,
-and implement some resolution mechanism so that the AtomSpace stores
-a pointer to the C++ ExecutionOutputLink class, instead of just a plain
-C++ Link class.  However, in the long run, storing the memoized SCM or
-PyObject with the Atom, in general, seems like a better idea.
+The problem is that this makes the Atom fatter still (every Atom would
+need to have an SCM in it, a PyObject in it, an hl for Haskell...)
+The alternative would be to use a map to store only the afftecte atoms.
+The map should live in the atomspace, because deleted atoms would have
+to be removed from the map, as well.  Thus, there would need to be a
+calls
 
+```
+SCM AtomSpace::getSCM(Handle);
+PyObject* AtomSpace::getPy(Handle);
+```
 
 Side effects
 ------------

--- a/opencog/execution/README.md
+++ b/opencog/execution/README.md
@@ -92,11 +92,16 @@ Some other expressions:
 ```
   (cog-execute! (PlusLink (NumberNode 3) (NumberNode 2)))
   (cog-execute! (TimesLink (NumberNode 3) (NumberNode 2)))
-  (cog-execute! (TimesLink (NumberNode 4) (PlusLink (NumberNode 5) (NumberNode 1))))
+  (cog-execute! (TimesLink (NumberNode 4)
+     (PlusLink (NumberNode 5) (NumberNode 1))))
 ```
 Inequalities:
 ```
   (define g (GreaterThanLink (NumberNode 3) (NumberNode 2)))
   (cog-evaluate! g)
+
   (cog-evaluate! (GreaterThanLink (NumberNode 3) (NumberNode 42)))
+
+  (cog-evaluate! (GreaterThanLink (NumberNode 3)
+     (PlusLink (NumberNode 6) (NumberNode 7))))
 ```

--- a/opencog/execution/README.md
+++ b/opencog/execution/README.md
@@ -36,6 +36,42 @@ SCM AtomSpace::getSCM(Handle);
 PyObject* AtomSpace::getPy(Handle);
 ```
 
+Non-string values
+-----------------
+Some node types need to store one or more non-string values.  The
+NumberNode here is a rough prototype for how that could be done. By
+storing a double-precision floating point number (i.e. "caching" it)
+it can potentially avoid string->double and double->string conversions
+every time that it is accessed.  There are several caveats:
+
+ * This works only if all possible Handles and AtomPtr's actually
+   point to an instance of the NumberNode class, instead of an
+   instance of a Node class, with the type set to NUMBER_NODE.
+
+ * The above can happen only if the AtomSpace itself is careful to
+   always work with instances of NumberNode, as it is the final
+   arbiter of what a Handle points to.
+
+ * The creation of a NumberNode is still "heavyweight": one must
+   crate and initialize the Atom class (which takes time); one
+   must also initialize the Node class, and to do that, one must
+   convert the float pt. number to a string. The string is needed
+   to allow the atom to be held in AtomSpace indexes.
+
+ * The NumberNode must be inserted into the AtomSpace. This is a
+   particularly time-consuming process, require multiple lookups and
+   checks and validations, insertion into multiple indexes of various
+   sorts. This far exceeds the cost of initializing the atom itself.
+
+After the above is all done, the actual float pt. value in the
+NumberNode can be accessed quickly enough ... but how often is that
+really needed?  Was it really worth the additional complexity? Given
+the other high costs shown above, does it result in any actual speedup?
+
+For the above reasons, it is not at all clear that having a NumberNode
+class is actually a good idea.  There could be a better way...
+
+
 Side effects
 ------------
 There is also another theoretical issue: the current design assumes

--- a/opencog/execution/README.md
+++ b/opencog/execution/README.md
@@ -104,4 +104,7 @@ Inequalities:
 
   (cog-evaluate! (GreaterThanLink (NumberNode 3)
      (PlusLink (NumberNode 6) (NumberNode 7))))
+
+  (cog-evaluate! (NotLink (GreaterThanLink (NumberNode 3)
+     (PlusLink (NumberNode 6) (NumberNode 7)))))
 ```

--- a/opencog/execution/README.md
+++ b/opencog/execution/README.md
@@ -94,3 +94,9 @@ Some other expressions:
   (cog-execute! (TimesLink (NumberNode 3) (NumberNode 2)))
   (cog-execute! (TimesLink (NumberNode 4) (PlusLink (NumberNode 5) (NumberNode 1))))
 ```
+Inequalities:
+```
+  (define g (GreaterThanLink (NumberNode 3) (NumberNode 2)))
+  (cog-evaluate! g)
+  (cog-evaluate! (GreaterThanLink (NumberNode 3) (NumberNode 42)))
+```

--- a/opencog/execution/README.md
+++ b/opencog/execution/README.md
@@ -79,3 +79,12 @@ that ExecutionOutputLink can have side effects, and thus, it needs
 to be run ever time that it is encountered.  This is a poor choice
 for good performance; we need to define a side-effect-free execution
 link, and we need to define a monad when the side effects are needed.
+
+Demo
+----
+Example:
+```
+  (define two (NumberNode 2))
+  (define plu (PlusLink two two))
+  (cog-execute! plu)
+```

--- a/opencog/guile/SchemeEval.h
+++ b/opencog/guile/SchemeEval.h
@@ -93,6 +93,7 @@ class SchemeEval : public GenericEval
 		// Straight-up evaluation
 		SCM do_scm_eval(SCM, SCM (*)(void *));
 		static void * c_wrap_eval_h(void *);
+		static void * c_wrap_eval_tv(void *);
 
 		// Apply function to arguments, returning Handle or TV
 		Handle do_apply(const std::string& func, Handle& varargs);
@@ -144,6 +145,10 @@ class SchemeEval : public GenericEval
 		// Evaluate expression, returning handle.
 		Handle eval_h(const std::string&);
 		Handle eval_h(const std::stringstream& ss) { return eval_h(ss.str()); }
+
+		// Evaluate expression, returning TV.
+		TruthValuePtr eval_tv(const std::string&);
+		TruthValuePtr eval_tv(const std::stringstream& ss) { return eval_tv(ss.str()); }
 
 		// Apply expression to args, returning Handle or TV
 		Handle apply(const std::string& func, Handle varargs);

--- a/opencog/guile/SchemeExec.cc
+++ b/opencog/guile/SchemeExec.cc
@@ -69,11 +69,13 @@ SCM SchemeEval::do_apply_scm(const std::string& func, Handle& varargs )
 SCM SchemeSmob::ss_execute (SCM satom)
 {
 	Handle h = verify_handle(satom, "cog-execute!");
-
-	if (h->getType() != EXECUTION_OUTPUT_LINK)
+	Type t = h->getType();
+	if ((EXECUTION_OUTPUT_LINK != t)
+	    and (PLUS_LINK != t)
+	    and (TIMES_LINK != t))
 	{
 		scm_wrong_type_arg_msg("cog-execute!", 1, satom,
-			"ExecutionOutputLink opencog cog-execute!!");
+			"ExecutionOutputLink, PlusLink or TimesLink");
 	}
 
 	AtomSpace* atomspace = ss_get_env_as("cog-execute!");

--- a/opencog/guile/SchemeExec.cc
+++ b/opencog/guile/SchemeExec.cc
@@ -105,10 +105,12 @@ SCM SchemeSmob::ss_evaluate (SCM satom)
 {
 	Handle h = verify_handle(satom, "cog-evaluate!");
 
-	if (h->getType() != EVALUATION_LINK)
+	Type t = h->getType();
+	if ((EVALUATION_LINK != t)
+	    and (GREATER_THAN_LINK != t))
 	{
 		scm_wrong_type_arg_msg("cog-evaluate!", 1, satom,
-			"EvaluationLink opencog cog-evaluate!");
+			"EvaluationLink or GreaterThanLink");
 	}
 
 	AtomSpace* atomspace = ss_get_env_as("cog-evaluate!");

--- a/opencog/guile/SchemeExec.cc
+++ b/opencog/guile/SchemeExec.cc
@@ -107,10 +107,11 @@ SCM SchemeSmob::ss_evaluate (SCM satom)
 
 	Type t = h->getType();
 	if ((EVALUATION_LINK != t)
-	    and (GREATER_THAN_LINK != t))
+	    and (GREATER_THAN_LINK != t)
+	    and (NOT_LINK != t))
 	{
 		scm_wrong_type_arg_msg("cog-evaluate!", 1, satom,
-			"EvaluationLink or GreaterThanLink");
+			"EvaluationLink or GreaterThanLink or NotLink");
 	}
 
 	AtomSpace* atomspace = ss_get_env_as("cog-evaluate!");

--- a/opencog/query/Instantiator.cc
+++ b/opencog/query/Instantiator.cc
@@ -51,7 +51,9 @@ Handle Instantiator::walk_tree(Handle expr)
 		oset_results.push_back(walk_tree(h));
 
 	// Fire execution links, if found.
-	if (t == EXECUTION_OUTPUT_LINK)
+	if ((EXECUTION_OUTPUT_LINK == t)
+	   or (PLUS_LINK == t)
+	   or (TIMES_LINK == t))
 	{
 		// The atoms being created above might not all be in the
 		// atomspace, just yet. Because we have no clue what the
@@ -65,7 +67,7 @@ Handle Instantiator::walk_tree(Handle expr)
 
 		// This throws if it can't figure out the schema ...
 		// Let the throw pass right on up the stack.
-		return ExecutionOutputLink::do_execute(_as, oset_results);
+		return ExecutionOutputLink::do_execute(_as, t, oset_results);
 	}
 
 	// Now create a duplicate link, but with an outgoing set where

--- a/tests/atomspace/AtomSpaceAsyncUTest.cxxtest
+++ b/tests/atomspace/AtomSpaceAsyncUTest.cxxtest
@@ -160,14 +160,14 @@ public:
         /* Add and remove a simple node */
         __testSignalsCounter = 0;
         logger().debug("before first atom add");
-        Handle wnHandle = atomSpace->addNode(NUMBER_NODE, "1");
+        Handle wnHandle = atomSpace->addNode(NUMBER_NODE, "1.41421356");
         TS_ASSERT(__testSignalsCounter == 11);
         TS_ASSERT(atomSpace->getSize() == 1);
 
         /* Since we're adding *exactly* the same atom, we should get a tv-merged signal */
         logger().debug("before second atom add");
         TruthValuePtr tv(SimpleTruthValue::createTV(0.5, 1.0));
-        atomSpace->addNode(NUMBER_NODE, "1")->setTruthValue(tv);
+        atomSpace->addNode(NUMBER_NODE, "1.41421356")->setTruthValue(tv);
         TS_ASSERT(__testSignalsCounter == 1111);
         TS_ASSERT(atomSpace->getSize() == 1);
 
@@ -181,8 +181,8 @@ public:
         add1.disconnect();
         merge1.disconnect();
         remove1.disconnect();
-        wnHandle = atomSpace->addNode(NUMBER_NODE, "1");
-        atomSpace->addNode(NUMBER_NODE, "1");
+        wnHandle = atomSpace->addNode(NUMBER_NODE, "1.41421356");
+        atomSpace->addNode(NUMBER_NODE, "1.41421356");
         TS_ASSERT(__testSignalsCounter == 10);
         atomSpace->purgeAtom(wnHandle, true);
         TS_ASSERT(__testSignalsCounter == 100010);
@@ -191,8 +191,8 @@ public:
         add2.disconnect();
         merge2.disconnect();
         remove2.disconnect();
-        wnHandle = atomSpace->addNode(NUMBER_NODE, "1");
-        atomSpace->addNode(NUMBER_NODE, "1");
+        wnHandle = atomSpace->addNode(NUMBER_NODE, "1.41421356");
+        atomSpace->addNode(NUMBER_NODE, "1.41421356");
         TS_ASSERT(__testSignalsCounter == 0);
         atomSpace->purgeAtom(wnHandle, true);
         TS_ASSERT(__testSignalsCounter == 0);
@@ -206,7 +206,8 @@ public:
         Type numberOfTypes = classserver().getNumberOfClasses();
         OC_ASSERT(t < numberOfTypes);
         Type randomType = NOTYPE;
-        while (!classserver().isA(randomType, t))
+        while (!classserver().isA(randomType, t)
+               or NUMBER_NODE == randomType)
             randomType = ATOM + rng->randint(numberOfTypes-1);
         return randomType;
     }

--- a/tests/atomspace/MultiSpaceUTest.cxxtest
+++ b/tests/atomspace/MultiSpaceUTest.cxxtest
@@ -125,7 +125,7 @@ public:
 		// Create three nodes
 		NodePtr n1(createNode(CONCEPT_NODE, "uni-1"));
 		n1->setTruthValue(tv1);
-		NodePtr n2(createNode(NUMBER_NODE, "uni-2"));
+		NodePtr n2(createNode(NUMBER_NODE, "2.2222"));
 		n2->setTruthValue(tv2);
 		NodePtr n3(createNode(VARIABLE_NODE, "uni-3"));
 		n3->setTruthValue(tv3);
@@ -174,15 +174,15 @@ public:
 
 		// Fetch three atoms in three different atomspaces
 		Handle h1n1 = as1.addNode(CONCEPT_NODE, "uni-1");
-		Handle h1n2 = as1.addNode(NUMBER_NODE, "uni-2");
+		Handle h1n2 = as1.addNode(NUMBER_NODE, "2.2222");
 		Handle h1n3 = as1.addNode(VARIABLE_NODE, "uni-3");
 
 		Handle h2n1 = as2.addNode(CONCEPT_NODE, "uni-1");
-		Handle h2n2 = as2.addNode(NUMBER_NODE, "uni-2");
+		Handle h2n2 = as2.addNode(NUMBER_NODE, "2.2222");
 		Handle h2n3 = as2.addNode(VARIABLE_NODE, "uni-3");
 
 		Handle h3n1 = as3.addNode(CONCEPT_NODE, "uni-1");
-		Handle h3n2 = as3.addNode(NUMBER_NODE, "uni-2");
+		Handle h3n2 = as3.addNode(NUMBER_NODE, "2.2222");
 		Handle h3n3 = as3.addNode(VARIABLE_NODE, "uni-3");
 
 		// They should NOT match one-another
@@ -235,7 +235,7 @@ public:
 		// Create three nodes in the base atomspace
 		Handle hnd1 = nas1.addNode(CONCEPT_NODE, "nest-1");
 		hnd1->setTruthValue(tv1);
-		Handle hnd2 = nas1.addNode(NUMBER_NODE, "nest-2");
+		Handle hnd2 = nas1.addNode(NUMBER_NODE, "2.34");
 		hnd2->setTruthValue(tv2);
 		Handle hnd3 = nas1.addNode(VARIABLE_NODE, "nest-3");
 		hnd3->setTruthValue(tv3);
@@ -274,15 +274,15 @@ public:
 
 		// Fetch three atoms in three different atomspaces
 		Handle h1n1 = nas1.addNode(CONCEPT_NODE, "nest-1");
-		Handle h1n2 = nas1.addNode(NUMBER_NODE, "nest-2");
+		Handle h1n2 = nas1.addNode(NUMBER_NODE, "2.34");
 		Handle h1n3 = nas1.addNode(VARIABLE_NODE, "nest-3");
 
 		Handle h2n1 = nas2.addNode(CONCEPT_NODE, "nest-1");
-		Handle h2n2 = nas2.addNode(NUMBER_NODE, "nest-2");
+		Handle h2n2 = nas2.addNode(NUMBER_NODE, "2.34");
 		Handle h2n3 = nas2.addNode(VARIABLE_NODE, "nest-3");
 
 		Handle h3n1 = nas3.addNode(CONCEPT_NODE, "nest-1");
-		Handle h3n2 = nas3.addNode(NUMBER_NODE, "nest-2");
+		Handle h3n2 = nas3.addNode(NUMBER_NODE, "2.34");
 		Handle h3n3 = nas3.addNode(VARIABLE_NODE, "nest-3");
 
 		// They should be identical

--- a/tests/scm/SCMExecutionOutputUTest.cxxtest
+++ b/tests/scm/SCMExecutionOutputUTest.cxxtest
@@ -32,6 +32,7 @@
 #include <opencog/util/Config.h>
 #include <opencog/execution/ExecutionOutputLink.h>
 #include <opencog/execution/EvaluationLink.h>
+#include <opencog/execution/NumberNode.h>
 
 using namespace opencog;
 
@@ -81,6 +82,7 @@ class SCMExecutionOutputUTest :  public CxxTest::TestSuite
 	void test_recursive(void);
 	void test_nested(void);
 
+	void test_boolean(void);
 	void test_numeric(void);
 };
 
@@ -377,8 +379,14 @@ void SCMExecutionOutputUTest::test_nested(void)
 
 	Handle enine = eval->eval_h("(cog-execute! nestor)");
 	Handle nine = eval->eval_h("(NumberNode \"9\")");
+	// TS_ASSERT_EQUALS(nine, enine);
 
-	TS_ASSERT_EQUALS(nine, enine);
+	NumberNodePtr ne(NumberNodeCast(enine));
+	NumberNodePtr ni(NumberNodeCast(nine));
+	double dne = ne->getValue();
+	double dni = ni->getValue();
+	TS_ASSERT_LESS_THAN(fabs(dne - dni), 0.000001);
+	TS_ASSERT_LESS_THAN(fabs(9.0 - dne), 0.000001);
 }
 
 void SCMExecutionOutputUTest::test_evaluate(void)
@@ -413,6 +421,32 @@ void SCMExecutionOutputUTest::test_evaluate(void)
 }
 
 void SCMExecutionOutputUTest::test_numeric(void)
+{
+	// A Numeric expression
+	eval->eval(
+		"(define expr "
+		"   (TimesLink (NumberNode 6) "
+		"      (PlusLink (NumberNode 2) (NumberNode 2))))"
+	);
+	CHKEV(eval);
+
+	// Evaluate the numeric expreson; it should be 24
+	Handle nexp = eval->eval_h("(cog-execute! expr)");
+	CHKEV(eval);
+	Handle twntyfour = eval->eval_h("(NumberNode 24)");
+	std::cout << "Expression is " << nexp->toString() << std::endl;
+	std::cout << "Number is " << twntyfour->toString() << std::endl;
+	// TS_ASSERT_EQUALS(nexp, twntyfour);
+
+	NumberNodePtr ne(NumberNodeCast(nexp));
+	NumberNodePtr nt(NumberNodeCast(twntyfour));
+	double dne = ne->getValue();
+	double dnt = nt->getValue();
+	TS_ASSERT_LESS_THAN(fabs(dne - dnt), 0.000001);
+	TS_ASSERT_LESS_THAN(fabs(24.0 - dne), 0.000001);
+}
+
+void SCMExecutionOutputUTest::test_boolean(void)
 {
 	// A boolean-valued expression
 	eval->eval(

--- a/tests/scm/SCMExecutionOutputUTest.cxxtest
+++ b/tests/scm/SCMExecutionOutputUTest.cxxtest
@@ -31,6 +31,7 @@
 #include <opencog/util/Logger.h>
 #include <opencog/util/Config.h>
 #include <opencog/execution/ExecutionOutputLink.h>
+#include <opencog/execution/EvaluationLink.h>
 
 using namespace opencog;
 
@@ -80,6 +81,7 @@ class SCMExecutionOutputUTest :  public CxxTest::TestSuite
 	void test_recursive(void);
 	void test_nested(void);
 
+	void test_numeric(void);
 };
 
 void SCMExecutionOutputUTest::setUp(void)
@@ -408,4 +410,33 @@ void SCMExecutionOutputUTest::test_evaluate(void)
 	CHKEV(eval);
 	eval->eval("(chk-tv (ConceptNode \"glurg\" (cog-new-ctv 0.123 0.456 789)))");
 	CHKEV(eval);
+}
+
+void SCMExecutionOutputUTest::test_numeric(void)
+{
+	// A boolean-valued expression
+	eval->eval(
+		"(define expr "
+		"   (NotLink (GreaterThanLink (NumberNode 3) "
+		"      (PlusLink (NumberNode 6) "
+		"         (TimesLink (NumberNode 7.34) (NumberNode 2.36))))))"
+	);
+	CHKEV(eval);
+
+	// Evaluate the boolean expreson; it should be true.
+	TruthValuePtr tv = eval->eval_tv("(cog-evaluate! expr)");
+	CHKEV(eval);
+	TS_ASSERT_LESS_THAN_EQUALS(0.999, tv->getMean());
+
+	// Another boolean expression
+	Handle boolex = eval->eval_h(
+		"(GreaterThanLink (NumberNode 3.654) "
+		"   (PlusLink (NumberNode 5.6) "
+		"      (TimesLink (NumberNode 1.34) (NumberNode 1.36))))"
+	);
+	CHKEV(eval);
+
+	// When evaluated, this one should be false.
+	tv = EvaluationLink::do_evaluate(as, boolex);
+	TS_ASSERT_LESS_THAN_EQUALS(tv->getMean(), 0.001);
 }


### PR DESCRIPTION
This is an demo prototype showing one way in which number-valued NumberNodes could be accomodated in the AtomSpace.  The demo "works" in the sense that you can now say
```
  (cog-evaluate! (NotLink (GreaterThanLink (NumberNode 3)
     (PlusLink (NumberNode 6) (TimesLink (NumberNode 7) (NumberNode 11))))))
```
and get back TRUE_TV.  However, the code is very inefficient, were you to compare it to the equivalent combo code.   There are many reasons for this, and the README lists some of them.  Thus, this really should be considered to be "experimental" code, rather than the 'one true way'.