### PR TITLE
Temporary disable one of the parallel call for testing

### DIFF
--- a/opencog/nlp/microplanning/main.scm
+++ b/opencog/nlp/microplanning/main.scm
@@ -154,7 +154,7 @@
 
 		(cond ; use the sub-helper to keep calling make sentence until all atoms are used, branching on all allowed utterance type
 		      ((not (null? atomW-unused))
-			(par-for-each sub-helper ut)
+			(for-each sub-helper ut)
 		      )
 		      ; finished all atoms, store the created chunks & their corresponding utterance-type
 		      (else


### PR DESCRIPTION
Trying to see if this is causing buildbot hangup.  Will try to disable the other one in anaphora.scm later if this is not fixing it.

I couldn't reproduce it on my local machine.