### PR TITLE
ss_delete takes atom or list; returns empty list

### DIFF
--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -1,5 +1,5 @@
 /*
- * SchemeSmobNew.cc
+ * SchemeSmobNew.cc 
  *
  * Scheme small objects (SMOBS) --creating new atoms -- for opencog.
  *

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -13,7 +13,6 @@
 #include <cstddef>
 #include <libguile.h>
 
-#include <iostream>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atomspace/ClassServer.h>
 #include <opencog/guile/SchemeSmob.h>

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -1,5 +1,5 @@
 /*
- * SchemeSmobNew.cc 
+ * SchemeSmobNew.cc
  *
  * Scheme small objects (SMOBS) --creating new atoms -- for opencog.
  *


### PR DESCRIPTION
Hi,

My name is Gavriel Loria (a GSoC 2015 candidate), and I am making my first patch to OpenCog. I believe I have added to ss_delete() extra functionality: it returns an empty list on success, and it can take a list of atoms as an argument. I check that each member of the list is an atom prior to deleting any of them.