### PR TITLE
Benchmark updates and change of AtomTable _atom_set to use std::unordered_set

### DIFF
--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -93,7 +93,7 @@ private:
     // handle uuid and the actual atom pointer (since they are stored
     // together).  To some degree, this info is duplicated in the Node
     // and LinkIndex below; we have this here for convenience.
-    std::set<Handle, handle_less> _atom_set;
+    std::unordered_set<Handle, handle_hash> _atom_set;
 
     //!@{
     //! Index for quick retreival of certain kinds of atoms.

--- a/opencog/benchmark/README
+++ b/opencog/benchmark/README
@@ -93,7 +93,31 @@ and then run:
 
  $ python ./opencog/benchmark/benchmark.py
 
-The test will run and produce its output automatically. There are 
-no command line options at the moment as running all the tests with significant
-iterations takes less than a minute on most hardware.
+or execute directly with:
+
+ $ ./opencog/benchmark/benchmark.py
+
+The test will run and produce its output automatically if no options are
+specified. The options are available with -h or --help.
+
+$ python benchmark.py -h
+usage: benchmark.py [-h] [-v | -c]
+                    [-a | -t {spread,node,bindlink,traverse,scheme}] [-i N]
+
+OpenCog Python Benchmark
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -v, --verbose         verbose output
+  -c, --columns         columnar output (default)
+  -a, --all             run all tests
+  -t {spread,node,bindlink,traverse,scheme}, --test {spread,node,bindlink,traverse,scheme}
+                        Test to benchmark, where:
+                          spread    - a spread of tests across areas (default)
+                          node      - atomspace node operations 
+                          bindlink  - all the bindlink forms
+                          traverse  - traversal of atomspace lists
+                          scheme    - scheme evaluation functions
+  -i N, --iterations N  iterations to average (default=10)
+
 

--- a/opencog/benchmark/benchmark.py
+++ b/opencog/benchmark/benchmark.py
@@ -354,20 +354,20 @@ tests = [
 
 (['all'],                   None,               None,                   "-- Testing Atom Traversal --"),
 (['traverse'],              prep_traverse_100K, test_bare_traversal,    "Bare atom traversal 100K - by type"),
-(['traverse'],              prep_traverse_10K,  test_resolve_traversal, "Resolve handle 10K - by type"),
-(['traverse','spread'],     prep_traverse_100K, test_resolve_traversal, "Resolve handle 100K - by type"),
-(['traverse'],              prep_traverse_1M,   test_resolve_traversal, "Resolve handle 1M - by type"),
+(['traverse'],              prep_traverse_10K,  test_resolve_traversal, "Resolve Handle 10K - by type"),
+(['traverse','spread'],     prep_traverse_100K, test_resolve_traversal, "Resolve Handle 100K - by type"),
+(['traverse'],              prep_traverse_1M,   test_resolve_traversal, "Resolve Handle 1M - by type"),
 
 (['all'],                   None,               None,                   "-- Testing Bind --"),
-(['bindlink'],              prep_none,          test_stub_bindlink,     "Bind stub_bindlink - Cython"),
-(['bindlink','spread'],     prep_bind_python,   test_bind,              "Bind bindlink - Cython"),
-(['bindlink'],              prep_bind_python,   test_validate_bindlink, "Bind validate_bindlink - Cython"),
+(['bindlink'],              prep_none,          test_stub_bindlink,     "Bind - stub_bindlink - Cython"),
+(['bindlink','spread'],     prep_bind_python,   test_bind,              "Bind - bindlink - Cython"),
+(['bindlink'],              prep_bind_python,   test_validate_bindlink, "Bind - validate_bindlink - Cython"),
 
 (['all'],                   None,               None,                   "-- Testing Scheme Eval --"),
 (['scheme','spread'],       prep_scheme,        test_scheme_eval,       "Test scheme_eval_h(+ 2 2)"),
-(['scheme'],                prep_bind_scheme,   test_bind_scheme,       "Bind - cog-bind"),
-(['scheme'],                prep_scheme,        test_add_nodes_scheme,  "Add nodes - Scheme cog-new-node"),
-(['scheme'],                prep_scheme,        test_add_nodes_sugar,   "Add nodes - Scheme ConceptNode sugar"),
+(['scheme'],                prep_bind_scheme,   test_bind_scheme,       "Bind - cog-bind - Scheme"),
+(['scheme'],                prep_scheme,        test_add_nodes_scheme,  "Add nodes - cog-new-node - Scheme"),
+(['scheme'],                prep_scheme,        test_add_nodes_sugar,   "Add nodes - ConceptNode sugar - Scheme"),
 ]
 
 
@@ -382,8 +382,7 @@ if args.verbose or args.iterations != 10:
         print "Test times averaged over {0:d} iterations.".format(test_iterations)
     else:
         print "Test times averaged over 1 iteration."
-
-if not args.verbose:
+if not args.verbose and args.iterations != 10:
     print
 
 if args.verbose:

--- a/opencog/benchmark/benchmark.py
+++ b/opencog/benchmark/benchmark.py
@@ -39,6 +39,7 @@ Add fully connected nodes
 
 """
 
+import argparse
 import time, datetime
 from opencog.atomspace import AtomSpace, TruthValue, Handle, types
 import opencog.scheme_wrapper as scheme
@@ -46,6 +47,40 @@ from opencog.scheme_wrapper import load_scm, scheme_eval, scheme_eval_h
 from opencog.bindlink import stub_bindlink, bindlink, validate_bindlink
 
 __authors__ = 'Cosmo Harrigan, Curtis Faith'
+
+class SmartFormatter(argparse.HelpFormatter):
+
+    def _split_lines(self, text, width):
+        # this is the RawTextHelpFormatter._split_lines
+        if text.startswith('R|'):
+            return text[2:].splitlines()  
+        return argparse.HelpFormatter._split_lines(self, text, width)
+
+# Setup the argument parser.
+parser = argparse.ArgumentParser(description="OpenCog Python Benchmark",
+        formatter_class=SmartFormatter)
+verbosity_group = parser.add_mutually_exclusive_group()
+verbosity_group.add_argument("-v", "--verbose", action="store_true", help="verbose output")
+verbosity_group.add_argument("-c", "--columns", action="store_true", default=True, help="columnar output (default)")
+#verbosity_group.add_argument("-q", "--quiet", action="store_true", help="minimal output")
+test_group = parser.add_mutually_exclusive_group()
+test_group.add_argument("-a", "--all",  default=False, action="store_true", help="run all tests")
+test_group.add_argument("-t", "--test", type=str, default='spread',
+                        choices=['spread','node', 'bindlink', 'traverse', 'scheme'],
+                        help="R|Test to benchmark, where:\n"
+                             "  spread    - a spread of tests across areas (default)\n"
+                             "  node      - atomspace node operations \n"
+                             "  bindlink  - all the bindlink forms\n"
+                             "  traverse  - traversal of atomspace lists\n"
+                             "  scheme    - scheme evaluation functions")
+parser.add_argument("-i", "--iterations", metavar='N', type=int, default=10, help="iterations to average (default=10)")
+args = parser.parse_args()
+
+if args.verbose:
+    args.columns = False
+
+# Number of test iterations to average for timing.
+test_iterations = args.iterations
 
 scheme_preload = [  
                     "opencog/atomspace/core_types.scm",
@@ -65,6 +100,27 @@ def loop_time_per_op():
 
 def prep_none(atomspace):
     pass
+
+def prep_traverse_10K(atomspace):
+    """Add n nodes in atomspace with python bindings"""
+    n = 10000
+    for i in xrange(n):
+        atomspace.add_node(types.ConceptNode, str(i), TruthValue(.5, .5))
+    return n, atomspace.get_atoms_by_type(types.ConceptNode)
+
+def prep_traverse_100K(atomspace):
+    """Add n nodes in atomspace with python bindings"""
+    n = 100000
+    for i in xrange(n):
+        atomspace.add_node(types.ConceptNode, str(i), TruthValue(.5, .5))
+    return n, atomspace.get_atoms_by_type(types.ConceptNode)
+
+def prep_traverse_1M(atomspace):
+    """Add n nodes in atomspace with python bindings"""
+    n = 1000000
+    for i in xrange(n):
+        atomspace.add_node(types.ConceptNode, str(i), TruthValue(.5, .5))
+    return n, atomspace.get_atoms_by_type(types.ConceptNode)
 
 def prep_scheme(atomspace):
     scheme.__init__(atomspace)
@@ -134,24 +190,6 @@ def prep_bind_scheme(atomspace):
 
 # Tests
 
-def test_stub_bindlink(atomspace, prep_handle):
-    n = 100000
-    for i in xrange(n):
-        result = stub_bindlink(atomspace, prep_handle)
-    return n
-
-def test_bind(atomspace, prep_handle):
-    n = 100000
-    for i in xrange(n):
-        result = bindlink(atomspace, prep_handle)
-    return n
-
-def test_validate_bindlink(atomspace, prep_handle):
-    n = 100000
-    for i in xrange(n):
-        result = validate_bindlink(atomspace, prep_handle)
-    return n
-
 def test_add_nodes(atomspace, prep_handle):
     """Add n nodes in atomspace with python bindings"""
     n = 100000
@@ -184,21 +222,66 @@ def test_add_connected(atomspace, prep_handle):
     # Number of vertices plus number of edges in a fully connected graph
     return n + (n**2 - n) / 2
 
-def test_scheme_eval(atomspace, prep_handle):
+
+# Traversal tests
+def test_bare_traversal(atomspace, prep_traverse_result):
+    atom_count, atom_list = prep_traverse_result
+    counter = 0;
+    for atom in atom_list:
+        counter += 1
+
+    # Prep for traversal returned the node count. The above iterates all.
+    return atom_count
+
+def test_resolve_traversal(atomspace, prep_traverse_result):
+    atom_count, atom_list = prep_traverse_result
+    for atom in atom_list:
+        if not atom:
+            print "test_resolve_traversal - atom didn't resolve"
+            break
+
+    # Prep for traversal returned the node count. The above iterates all.
+    return atom_count
+
+
+# Bindlink tests
+
+def test_stub_bindlink(atomspace, prep_handle):
     n = 100000
+    for i in xrange(n):
+        result = stub_bindlink(atomspace, prep_handle)
+    return n
+
+def test_bind(atomspace, prep_handle):
+    n = 10000
+    for i in xrange(n):
+        result = bindlink(atomspace, prep_handle)
+    return n
+
+def test_validate_bindlink(atomspace, prep_handle):
+    n = 10000
+    for i in xrange(n):
+        result = validate_bindlink(atomspace, prep_handle)
+    return n
+
+
+# Scheme tests
+
+def test_scheme_eval(atomspace, prep_handle):
+    n = 10000
     for i in xrange(n):
         result = scheme_eval_h(atomspace, '(+ 2 2)')
     return n
 
 def test_bind_scheme(atomspace, prep_handle):
-    n = 100000
+    n = 10000
     for i in xrange(n):
         result = scheme_eval_h(atomspace, '(cog-bind find-animals)')
     return n
 
 def test_add_nodes_scheme(atomspace, prep_handle):
     """Add n nodes in atomspace using scheme"""
-    n = 100000
+    n = 10000
     for i in xrange(n):
         scheme = 'cog-new-node \'ConceptNode "' + str(i) + \
                 '" (cog-new-stv 0.5 0.5)'
@@ -207,7 +290,7 @@ def test_add_nodes_scheme(atomspace, prep_handle):
 
 def test_add_nodes_sugar(atomspace, prep_handle):
     """Add n nodes in atomspace using scheme with syntactic sugar"""
-    n = 100000
+    n = 10000
     for i in xrange(n):
         scheme = '\'ConceptNode "' + str(i) + '" (cog-new-stv 0.5 0.5)'
         scheme_eval_h(atomspace, scheme)
@@ -218,53 +301,75 @@ def test_add_nodes_sugar(atomspace, prep_handle):
 # atomspace goes out of scope. So each test begins with a new AtomSpace.
 def do_test(prep, test, description, op_time_adjustment):
     """Runs tests and prints the test name and performance"""
-    print description
+    if not args.columns: 
+        print description
     if (test != None):
-        # Prep the test
-        atomspace = AtomSpace()
-        prep_handle = prep(atomspace)
+        total_time = 0
+        total_ops = 0
+        for i in xrange(test_iterations):
+            # Prep the test
+            atomspace = AtomSpace()
+            prep_result = prep(atomspace)
 
-        # Time the test
-        start = time.time()
-        ops = test(atomspace, prep_handle)
-        finish = time.time()
-        adjusted_time = (finish - start) - (ops * op_time_adjustment)
+            # Time the test
+            start = time.time()
+            ops = test(atomspace, prep_result)
+            finish = time.time()
+
+            # Add the time and ops for this iteration
+            total_time += finish - start
+            total_ops += ops
+
+        average_time = total_time / test_iterations
+        average_ops = total_ops / test_iterations
+        adjusted_time = average_time - (ops * op_time_adjustment)
 
         # Print timing results
-        time_string = "{0:.03f}".format(adjusted_time)
-        print "  Total:   {0: >12}s".format(time_string)
+        if args.verbose:
+            time_string = "{0:.03f}".format(adjusted_time)
+            print "  Total:   {0: >12}s".format(time_string)
 
-        time_string = "{0:,d}".format(ops)
-        print "  Ops:     {0: >12}".format(time_string)
+            test_ops = "{0:,d}".format(int(average_ops))
+            print "  Ops:     {0: >12}".format(test_ops)
 
-        time_string = "{0:.03f}".format(adjusted_time * 1000000 / ops)
-        print "  Op time: {0: >12}µs".format(time_string)
-
-        time_string = "{0:,d}".format(int(ops / adjusted_time))
-        print "  Ops/sec: {0: >12}".format(time_string)
-    print
+        op_time = "{0:.03f}".format(adjusted_time * 1000000 / ops)
+        ops_sec = "{0:,d}".format(int(ops / adjusted_time))
+        if args.columns:
+            print "{0: <40} {1: >12}µs {2: >15}".format(description, op_time,
+                                                        ops_sec)
+        else:
+            print "  Op time: {0: >12}µs".format(op_time)
+            print "  Ops/sec: {0: >12}".format(ops_sec)
+            print
 
 # The preps column contains functions that setup each test that are not timed.
 # The result returned by the prep is passed through to the test so you can
 # build complex predicates etc. without affecting test times.
-tests = [
 # Prep function     # Test function         # Test description
-(None,              None,                   "-- Testing Node Adds --"),
-(prep_none,         test_add_nodes,         "Add nodes - Cython"),
-(prep_none,         test_add_nodes_large,   "Add nodes - Cython (500K)"),
-(prep_none,         test_add_connected,     "Add fully connected nodes"),
+tests = [
+(['all'],                   None,               None,                   "-- Testing Node Adds --"),
+(['node','spread'],         prep_none,          test_add_nodes,         "Add nodes - Cython"),
+(['node'],                  prep_none,          test_add_nodes_large,   "Add nodes - Cython (500K)"),
+(['node'],                  prep_none,          test_add_connected,     "Add fully connected nodes"),
 
-(None,              None,                   "-- Testing Bind --"),
-(prep_none,         test_stub_bindlink,     "Bind stub_bindlink - Cython"),
-(prep_bind_python,  test_bind,              "Bind bindlink - Cython"),
-(prep_bind_python,  test_validate_bindlink, "Bind validate_bindlink - Cython"),
+(['all'],                   None,               None,                   "-- Testing Atom Traversal --"),
+(['traverse'],              prep_traverse_100K, test_bare_traversal,    "Bare atom traversal 100K - by type"),
+(['traverse'],              prep_traverse_10K,  test_resolve_traversal, "Resolve handle 10K - by type"),
+(['traverse','spread'],     prep_traverse_100K, test_resolve_traversal, "Resolve handle 100K - by type"),
+(['traverse'],              prep_traverse_1M,   test_resolve_traversal, "Resolve handle 1M - by type"),
 
-(None,              None,                   "-- Testing Scheme Eval --"),
-(prep_scheme,       test_scheme_eval,       "Test scheme_eval_h(+ 2 2)"),
-(prep_bind_scheme,  test_bind_scheme,       "Bind - cog-bind"),
-(prep_scheme,       test_add_nodes_scheme,  "Add nodes - Scheme cog-new-node"),
-(prep_scheme,       test_add_nodes_sugar,   "Add nodes - Scheme ConceptNode sugar"),
+(['all'],                   None,               None,                   "-- Testing Bind --"),
+(['bindlink'],              prep_none,          test_stub_bindlink,     "Bind stub_bindlink - Cython"),
+(['bindlink','spread'],     prep_bind_python,   test_bind,              "Bind bindlink - Cython"),
+(['bindlink'],              prep_bind_python,   test_validate_bindlink, "Bind validate_bindlink - Cython"),
+
+(['all'],                   None,               None,                   "-- Testing Scheme Eval --"),
+(['scheme','spread'],       prep_scheme,        test_scheme_eval,       "Test scheme_eval_h(+ 2 2)"),
+(['scheme'],                prep_bind_scheme,   test_bind_scheme,       "Bind - cog-bind"),
+(['scheme'],                prep_scheme,        test_add_nodes_scheme,  "Add nodes - Scheme cog-new-node"),
+(['scheme'],                prep_scheme,        test_add_nodes_sugar,   "Add nodes - Scheme ConceptNode sugar"),
 ]
+
 
 print 
 print "--- OpenCog Python Benchmark - ", str(datetime.datetime.now()), "---"
@@ -272,9 +377,27 @@ print
 
 # Get the per-op adjustment to account for the time of the loops themselves.
 op_time_adjustment = loop_time_per_op()
-print "Per-op loop adjustment: {0:.03f}µs".format(op_time_adjustment * 1000000)
-print
-    
+if args.verbose or args.iterations != 10:
+    if args.iterations > 1:
+        print "Test times averaged over {0:d} iterations.".format(test_iterations)
+    else:
+        print "Test times averaged over 1 iteration."
+
+if not args.verbose:
+    print
+
+if args.verbose:
+    print "Per-op loop adjustment: {0:.03f}µs.".format(op_time_adjustment * 1000000)
+    print
+
+if args.columns:
+    print "{0: <40} {1: >14} {2: >15}".format("Test", "Time per op", "Ops per second")
+    print "{0: <40} {1: >14} {2: >15}".format("----", "-----------", "--------------")
+
 # Run all the tests.
-for prep, test, description in tests:
-    do_test(prep, test, description, op_time_adjustment)
+for run_list, prep, test, description in tests:
+    if args.all or args.test in run_list:
+        do_test(prep, test, description, op_time_adjustment)
+
+# Print an extra line to offset the benchmarks
+print

--- a/opencog/benchmark/python_diary.txt
+++ b/opencog/benchmark/python_diary.txt
@@ -229,3 +229,127 @@ majority of the time is being spent in the code for bind and very little time,
 0.272µs in the above test, is spent converting from Python to C++ and back
 again in the bindings. In the above test, about 1% of the time for the bindlink
 is spent in the Cython bindings and 99% is spent in compiled C++ bindlink code.
+
+
+13 March 2014
+-------------
+Benchamrks performed on 2014 MacBook Air:
+   Intel Core i5
+   1.4 GHz
+   256 KB L2 cache
+   3 MB L3 cache
+   4GB 1600 Mhz DDR3 RAM
+
+Changing AtomTable to use std:unordered_set changes the resolution time from
+UUID to AtomPtr by quite a bit, especially for large numbers of nodes.
+See below.
+
+Here are some timings using new additions to the python benchmark.py before
+the change, i.e with AtomTable using std::set:
+
+--- OpenCog Python Benchmark -  2015-03-13 20:45:36.178418 ---
+
+Test times averaged over 10 iterations
+Per-op loop adjustment: 0.013µs
+
+-- Testing Atom Traversal --
+
+Bare atom traversal 100K - by type
+  Op time:        0.026µs
+  Ops/sec:   38,474,205
+
+Resolve handle 10K - by type
+  Op time:        0.552µs
+  Ops/sec:    1,811,790
+
+Resolve handle 100K - by type
+  Op time:        0.575µs
+  Ops/sec:    1,739,487
+
+Resolve handle 1M - by type
+  Op time:        0.667µs
+  Ops/sec:    1,498,673
+
+The "Bare atom traversal" test is just iterating over the Handle list without
+doing anything which requires a resolution. It's just a pass in Python in the
+loop so it is timing iteration over a Python list. The "Resolve handle traversal" 
+tests call atomspace.isValidHandle(Handle) which requires a resolve from the
+UUID to the actual AtomPtr. Notice that the resolve takes 0.552µs for a 10K
+atomspace, 0.575µs for 100K, and 0.667µs for a 1 million node atomspace.
+
+Here are the timings for the std::unordered_set implementation which just
+substitutes:
+
+    std::unordered_set<Handle,handle_hash> _atom_set;
+
+and makes no other changes to the code.
+
+--- OpenCog Python Benchmark -  2015-03-13 20:39:17.045882 ---
+
+Test times averaged over 10 iterations
+Per-op loop adjustment: 0.012µs
+
+-- Testing Atom Traversal --
+
+Bare atom traversal 100K - by type
+  Total:          0.003s
+  Ops:          100,000
+  Op time:        0.027µs
+  Ops/sec:   37,130,549
+
+Resolve handle 10K - by type
+  Total:          0.005s
+  Ops:           10,000
+  Op time:        0.470µs
+  Ops/sec:    2,125,937
+
+Resolve handle 100K - by type
+  Total:          0.033s
+  Ops:          100,000
+  Op time:        0.334µs
+  Ops/sec:    2,990,124
+
+Resolve handle 1M - by type
+  Total:          0.312s
+  Ops:        1,000,000
+  Op time:        0.312µs
+  Ops/sec:    3,209,804
+
+The resolve time drops from 0.552µs to 0.470µs at 10K nodes in the atomspace, 
+0.575µs to 0.334µs at 100K nodes, and 0.667µs to 0.312µs at 1M nodes. The times 
+actually drop for large traversals using std::unordered_set, probably because
+the processor caches are hitting for almost all the accesses and accesses for
+hash table entries don't take more time as the tables get bigger, unlike binary
+trees which slow down order log N. For really large atomspaces this difference
+will be even greater.
+
+
+13 March 2014
+-------------
+
+Changed benchmark to support columnar output and added several test options:
+
+opencog@36bcd804e00e:~/src/opencog/opencog/benchmark$ python benchmark.py -a
+
+--- OpenCog Python Benchmark -  2015-03-14 00:57:06.467325 ---
+
+Test                                        Time per op  Ops per second
+----                                        -----------  --------------
+Add nodes - Cython                              4.971µs         201,155
+Add nodes - Cython (500K)                       4.943µs         202,302
+Add fully connected nodes                       8.102µs         123,426
+Bare atom traversal 100K - by type              0.026µs      37,953,037
+Resolve Handle 10K - by type                    0.495µs       2,019,088
+Resolve Handle 100K - by type                   0.321µs       3,112,198
+Resolve Handle 1M - by type                     0.298µs       3,357,394
+Bind - stub_bindlink - Cython                   0.189µs       5,300,342
+Bind - bindlink - Cython                       25.146µs          39,767
+Bind - validate_bindlink - Cython               2.365µs         422,890
+Test scheme_eval_h(+ 2 2)                      81.464µs          12,275
+Bind - cog-bind - Scheme                      124.154µs           8,054
+Add nodes - cog-new-node - Scheme             132.907µs           7,524
+Add nodes - ConceptNode sugar - Scheme        118.237µs           8,457
+
+
+
+


### PR DESCRIPTION
Added options to benchmark.py to support:
*  averaging over iterations to reduce drift for smaller tests
*  columnar output
*  help and usage
*  benchmark coverage areas for targeted benchmarking
*  default of faster spread of benchmark timing across areas

Changed `AtomTable`'s `_atom_set` to use `std::unordered_set` which is about twice as fast