### PR TITLE
avoid using scheme where it is not needed.

### DIFF
--- a/opencog/reasoning/RuleEngine/rule-engine-src/ControlPolicyParamLoader.cc
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/ControlPolicyParamLoader.cc
@@ -59,6 +59,9 @@ void ControlPolicyParamLoader::load_chaining_rules()
 		istringstream is(rule_names[0]);
 		string var_name;
 		while (getline(is, var_name, ',')) {
+			// I think this is what you want, right????  Don't use
+			// scheme... for something this simple?
+			// Rule *r = new Rule(as_->addNode(VARIABLE_NODE, var_name);
 			Rule *r = new Rule(scm_eval_->eval_h(var_name));
 			rules_.push_back(r);
 			strname_rule_map_[var_name] = r;

--- a/opencog/reasoning/RuleEngine/rule-engine-src/ControlPolicyParamLoader.cc
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/ControlPolicyParamLoader.cc
@@ -40,7 +40,8 @@ ControlPolicyParamLoader::~ControlPolicyParamLoader()
 		delete r;
 }
 
-void ControlPolicyParamLoader::load_chaining_rules() {
+void ControlPolicyParamLoader::load_chaining_rules()
+{
 	vector<string> str_tokens;
 	//FCHAIN_RULES= "[blink-var1,blink-var1,...]:rule_path1","[blink-var2]:rule_path2",...
 	tokenize(config()["FCHAIN_RULES"], back_inserter(str_tokens), ", ");
@@ -66,7 +67,8 @@ void ControlPolicyParamLoader::load_chaining_rules() {
 	}
 }
 
-void ControlPolicyParamLoader::load_mutexes() {
+void ControlPolicyParamLoader::load_mutexes()
+{
 	vector<string> str_tokens;
 
 	//MUTEX = "nameA,nameB,...","namex,namey,..."
@@ -87,12 +89,15 @@ void ControlPolicyParamLoader::load_mutexes() {
 	}
 
 }
-void ControlPolicyParamLoader::load_single_val_params() {
+
+void ControlPolicyParamLoader::load_single_val_params()
+{
 	max_iter_ = config().get_int("ITERATION_SIZE");
 	attention_alloc_ = config().get_bool("ATTENTION_ALLOCATION_ENABLED"); //informs the callbacks to look for atoms only on the attentional focus
 }
 
-void ControlPolicyParamLoader::load_config() {
+void ControlPolicyParamLoader::load_config()
+{
 	try {
 		config().load(conf_path_.c_str());
 	} catch (RuntimeException &e) {
@@ -103,18 +108,22 @@ void ControlPolicyParamLoader::load_config() {
 	load_single_val_params();
 }
 
-int ControlPolicyParamLoader::get_max_iter() {
+int ControlPolicyParamLoader::get_max_iter()
+{
 	return max_iter_;
 }
 
-bool ControlPolicyParamLoader::get_attention_alloc() {
+bool ControlPolicyParamLoader::get_attention_alloc()
+{
 	return attention_alloc_;
 }
 
-vector<Rule*>& ControlPolicyParamLoader::get_rules() {
+vector<Rule*>& ControlPolicyParamLoader::get_rules()
+{
 	return rules_;
 }
 
-vector<vector<Rule*>> ControlPolicyParamLoader::get_mutex_sets() {
+vector<vector<Rule*>> ControlPolicyParamLoader::get_mutex_sets()
+{
 	return mutex_sets_;
 }

--- a/opencog/reasoning/RuleEngine/rule-engine-src/JsonicControlPolicyParamLoader.cc
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/JsonicControlPolicyParamLoader.cc
@@ -19,15 +19,18 @@
 
 JsonicControlPolicyParamLoader::JsonicControlPolicyParamLoader(AtomSpace * as,
 		string conf_path) :
-		ControlPolicyParamLoader(as, conf_path) {
+		ControlPolicyParamLoader(as, conf_path)
+{
 	cur_read_rule_ = NULL;
 }
 
-JsonicControlPolicyParamLoader::~JsonicControlPolicyParamLoader() {
+JsonicControlPolicyParamLoader::~JsonicControlPolicyParamLoader()
+{
 
 }
 
-void JsonicControlPolicyParamLoader::set_disjunct_rules(void) {
+void JsonicControlPolicyParamLoader::set_disjunct_rules(void)
+{
 	for (auto i = rule_mutex_map_.begin(); i != rule_mutex_map_.end(); ++i) {
 		auto mset = i->second;
 		auto cur_rule = i->first;
@@ -41,7 +44,8 @@ void JsonicControlPolicyParamLoader::set_disjunct_rules(void) {
 	}
 }
 
-Rule* JsonicControlPolicyParamLoader::get_rule(string& name) {
+Rule* JsonicControlPolicyParamLoader::get_rule(string& name)
+{
 	for (Rule* r : rules_) {
 		if (r->get_name() == name)
 			return r;
@@ -49,7 +53,8 @@ Rule* JsonicControlPolicyParamLoader::get_rule(string& name) {
 	return NULL;
 }
 
-void JsonicControlPolicyParamLoader::load_config() {
+void JsonicControlPolicyParamLoader::load_config()
+{
 	try {
 		ifstream is(conf_path_);
 		Stream_reader<ifstream, Value> reader(is);
@@ -62,13 +67,15 @@ void JsonicControlPolicyParamLoader::load_config() {
 	}
 }
 
-void JsonicControlPolicyParamLoader::read_array(const Value &v, int lev) {
+void JsonicControlPolicyParamLoader::read_array(const Value &v, int lev)
+{
 	const Array& a = v.get_array();
 	for (Array::size_type i = 0; i < a.size(); ++i)
 		read_json(a[i], lev + 1);
 }
 
-void JsonicControlPolicyParamLoader::read_obj(const Value &v, int lev) {
+void JsonicControlPolicyParamLoader::read_obj(const Value &v, int lev)
+{
 	const Object& o = v.get_obj();
 	for (Object::size_type i = 0; i < o.size(); ++i) {
 		const Pair& p = o[i];
@@ -120,7 +127,8 @@ void JsonicControlPolicyParamLoader::read_obj(const Value &v, int lev) {
 }
 
 void JsonicControlPolicyParamLoader::read_json(const Value &v,
-		int level /* = -1*/) {
+                                               int level /* = -1*/)
+{
 	switch (v.type()) {
 	case obj_type:
 		read_obj(v, level + 1);
@@ -143,11 +151,11 @@ void JsonicControlPolicyParamLoader::read_json(const Value &v,
 	}
 }
 
-void JsonicControlPolicyParamLoader::read_null(const Value &v, int lev) {
-
+void JsonicControlPolicyParamLoader::read_null(const Value &v, int lev)
+{
 }
 
 template<typename > void JsonicControlPolicyParamLoader::read_primitive(
-		const Value &v, int lev) {
-
+		const Value &v, int lev)
+{
 }

--- a/opencog/reasoning/RuleEngine/rule-engine-src/pln/DefaultForwardChainerCB.cc
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/pln/DefaultForwardChainerCB.cc
@@ -25,17 +25,17 @@
 #include "PLNCommons.h"
 
 #include <opencog/query/PatternMatch.h>
-#include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 
 DefaultForwardChainerCB::DefaultForwardChainerCB(AtomSpace* as) :
-		ForwardChainerCallBack(as) {
+		ForwardChainerCallBack(as)
+{
 	as_ = as;
 	fcim_ = new ForwardChainInputMatchCB(as);
 	fcpm_ = new ForwardChainPatternMatchCB(as);
 }
 
-DefaultForwardChainerCB::~DefaultForwardChainerCB() {
+DefaultForwardChainerCB::~DefaultForwardChainerCB()
+{
 	delete fcim_;
 	delete fcpm_;
 }
@@ -46,12 +46,11 @@ vector<Rule*> DefaultForwardChainerCB::choose_rule(FCMemory& fcmem)
 {
 	//create temporary atomspace and copy target
 	AtomSpace rule_atomspace;
-	SchemeEval *sc = get_evaluator(&rule_atomspace);
 	Handle target = fcmem.get_cur_target();
 	if (target == Handle::UNDEFINED or NodeCast(target))
 		throw InvalidParamException(TRACE_INFO,
 				"Needs a target atom of type LINK");
-	sc->eval(SchemeSmob::to_string(target));
+	as_->addAtom(target);
 	//create bindlink with target as an implicant
 	PLNCommons pc(&rule_atomspace);
 	Handle target_cpy = pc.replace_nodes_with_varnode(target, NODE);
@@ -59,7 +58,7 @@ vector<Rule*> DefaultForwardChainerCB::choose_rule(FCMemory& fcmem)
 	//copy rules to the temporary atomspace
 	vector<Rule*> rules = fcmem.get_rules();
 	for (Rule* r : rules)
-		sc->eval(SchemeSmob::to_string(r->get_handle()));
+		as_->addAtom(r->get_handle());
 	//pattern match
 	DefaultImplicator imp(&rule_atomspace);
 	PatternMatch pm;
@@ -92,10 +91,9 @@ vector<Rule*> DefaultForwardChainerCB::choose_rule(FCMemory& fcmem)
 		}
 	}
 	//transfer back bindlinks to main atomspace and  get their handle
-	SchemeEval *scm = get_evaluator(as_);
 	HandleSeq copied_back;
 	for (Handle h : bindlinks)
-		copied_back.push_back(scm->eval_h(SchemeSmob::to_string(h)));
+		copied_back.push_back(as_->addAtom(h));
 	//find the rules containing the bindLink in copied_back
 	vector<Rule*> matched_rules;
 	for (Rule* r : rules)

--- a/tests/reasoning/RuleEngine/CMakeLists.txt
+++ b/tests/reasoning/RuleEngine/CMakeLists.txt
@@ -1,23 +1,9 @@
-INCLUDE_DIRECTORIES (
-	${PROJECT_SOURCE_DIR}/opencog/atomspace
-	${PROJECT_SOURCE_DIR}/opencog/query
-	${PROJECT_SOURCE_DIR}/opencog/util	
-	${PROJECT_SOURCE_DIR}/opencog/reasoning/RuleEngine/rule-engine-src
-	${PROJECT_SOURCE_DIR}/opencog/reasoning/RuleEngine/rule-engine-src/pln
-)
-
-LINK_DIRECTORIES(
-	${PROJECT_BINARY_DIR}/opencog/atomspace
-	${PROJECT_BINARY_DIR}/opencog/query
-	${PROJECT_BINARY_DIR}/opencog/util
-	${PROJECT_BINARY_DIR}/opencog/reasoning/RuleEngine/rule-engine-src
-)
 
 LINK_LIBRARIES(
-	atomspace
+	ruleengine
 	query
 	server
-	ruleengine
+	atomspace
 )
 
 IF (HAVE_GUILE)
@@ -31,5 +17,4 @@ IF (HAVE_GUILE)
 ENDIF (HAVE_GUILE)
 
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/reasoning/RuleEngine/test_cpolicy.json
-    ${PROJECT_BINARY_DIR}/tests/reasoning/RuleEngine/test_cpolicy.json)
-    
+               ${PROJECT_BINARY_DIR}/tests/reasoning/RuleEngine/test_cpolicy.json)

--- a/tests/reasoning/RuleEngine/DefaultForwardChainerCBUTest.cxxtest
+++ b/tests/reasoning/RuleEngine/DefaultForwardChainerCBUTest.cxxtest
@@ -47,6 +47,9 @@ void DefaultForwardChainerCBUTest::tearDown() {}
 
 void DefaultForwardChainerCBUTest::test_choose_rule(void)
 {
+	logger().setPrintToStdoutFlag(true);
+	logger().setLevel(Logger::DEBUG);
+
 	JsonicControlPolicyParamLoader jscp(as, "test_cpolicy.json");
 	jscp.load_config();
 	FCMemory fcmem(as);

--- a/tests/reasoning/RuleEngine/DefaultForwardChainerCBUTest.cxxtest
+++ b/tests/reasoning/RuleEngine/DefaultForwardChainerCBUTest.cxxtest
@@ -11,22 +11,26 @@
 
 using namespace opencog;
 
-class DefaultForwardChainerCBUTest: public CxxTest::TestSuite {
+class DefaultForwardChainerCBUTest: public CxxTest::TestSuite
+{
 private:
 	AtomSpace* as;
 	SchemeEval* eval;
 
 public:
-	DefaultForwardChainerCBUTest(void) {
+	DefaultForwardChainerCBUTest(void)
+	{
 		server(CogServer::createInstance);
 		as = &cogserver().getAtomSpace();
 		eval = new SchemeEval(as);
-		config().set("SCM_PRELOAD", "opencog/atomspace/core_types.scm, "
-				"opencog/scm/utilities.scm, ");
+		config().set("SCM_PRELOAD",
+		      "opencog/atomspace/core_types.scm,"
+		      "opencog/scm/utilities.scm");
 		load_scm_files_from_config(*as);
 	}
 
-	~DefaultForwardChainerCBUTest() {
+	~DefaultForwardChainerCBUTest()
+	{
 		delete as;
 		delete eval;
 	}
@@ -37,43 +41,41 @@ public:
 	void test_choose_target(void);
 };
 
-void DefaultForwardChainerCBUTest::setUp() {
+void DefaultForwardChainerCBUTest::setUp() {}
 
+void DefaultForwardChainerCBUTest::tearDown() {}
+
+void DefaultForwardChainerCBUTest::test_choose_rule(void)
+{
+	JsonicControlPolicyParamLoader jscp(as, "test_cpolicy.json");
+	jscp.load_config();
+	FCMemory fcmem(as);
+	fcmem.set_rules(jscp.get_rules());
+	TS_ASSERT_EQUALS(1, fcmem.get_rules().size());
+	Handle h =
+	eval->eval_h(
+		"(InheritanceLink (ConceptNode \"cat\")(ConceptNode \"animal\"))");
+	TS_ASSERT_DIFFERS(h, Handle::UNDEFINED);
+	fcmem.set_target(h);
+	DefaultForwardChainerCB dfcb(as);
+	vector<Rule*> rule = dfcb.choose_rule(fcmem);
+	TS_ASSERT_EQUALS(1, rule.size());
+	HandleSeq bindlinks;
+	as->getHandlesByType(back_inserter(bindlinks), BIND_LINK);
+	auto it = find(bindlinks.begin(), bindlinks.end(), rule[0]->get_handle());
+	TS_ASSERT_DIFFERS(it, bindlinks.end());
 }
 
-void DefaultForwardChainerCBUTest::tearDown() {
+void DefaultForwardChainerCBUTest::test_choose_target(void)
+{
+	 config().set("SCM_PRELOAD",
+		"tests/reasoning/RuleEngine/simple-assertions.scm");
+	 load_scm_files_from_config(*as);
 
-}
-
-void DefaultForwardChainerCBUTest::test_choose_rule(void) {
-	 JsonicControlPolicyParamLoader jscp(as, "test_cpolicy.json");
-	 jscp.load_config();
+	 Handle target = eval->eval_h("(ConceptNode \"Einstein\")");
 	 FCMemory fcmem(as);
-	 fcmem.set_rules(jscp.get_rules());
-	 TS_ASSERT_EQUALS(1, fcmem.get_rules().size());
-	 Handle h =
-	 eval->eval_h(
-	 "(InheritanceLink (ConceptNode \"cat\")(ConceptNode \"animal\"))");
-	 TS_ASSERT_DIFFERS(h, Handle::UNDEFINED);
-	 fcmem.set_target(h);
+	 fcmem.set_target(target);
 	 DefaultForwardChainerCB dfcb(as);
-	 vector<Rule*> rule = dfcb.choose_rule(fcmem);
-	 TS_ASSERT_EQUALS(1,rule.size());
-	 HandleSeq bindlinks;
-	 as->getHandlesByType(back_inserter(bindlinks),BIND_LINK);
-	 auto it =  find(bindlinks.begin(),bindlinks.end(),rule[0]->get_handle());
-	 TS_ASSERT_DIFFERS(it,bindlinks.end());
+	 HandleSeq hs = dfcb.choose_input(fcmem);
+	 TS_ASSERT(2 == hs.size());
 }
-
-void DefaultForwardChainerCBUTest::test_choose_target(void) {
-     config().set("SCM_PRELOAD", "tests/reasoning/RuleEngine/simple-assertions.scm");
-     load_scm_files_from_config(*as);
-
-     Handle target = eval->eval_h("(ConceptNode \"Einstein\")");
-     FCMemory fcmem(as);
-     fcmem.set_target(target);
-     DefaultForwardChainerCB dfcb(as);
-     HandleSeq hs = dfcb.choose_input(fcmem);
-     TS_ASSERT(2 == hs.size());
-}
-


### PR DESCRIPTION
That, and a bunch of whitespace changes.

The only non-trivial changes here are those of lines 54, 62 and 96 of 
opencog/reasoning/RuleEngine/rule-engine-src/pln/DefaultForwardChainerCB.cc

I think those changes are correct -- it seems to be what you are trying to do here, with scheme, except that scheme is not need to do any of this.  However, I cannot see what's really going on, because the test cases won't run, because the test_cpolicy.json cannot be found, because there is no checking of the search paths for this file, because the search paths are not being taken from the test-config file.  

You probably should be using the code in util/files.cc to find and load text files.

Or you can do something like this:

```
int load_json_file_relative (AtomSpace& as, const std::string& filename,
                            std::vector<std::string> search_paths)
{
    if (search_paths.empty())
        search_paths = DEFAULT_MODULE_PATHS;

    int rc = 2;
    for (const std::string& search_path : search_paths) {
        boost::filesystem::path modulePath(search_path);
        modulePath /= filename;
        logger().debug("Searching path %s", modulePath.string().c_str());
        if (boost::filesystem::exists(modulePath)) {
            rc = load_json_file(as, modulePath.string());
            if (0 == rc) {
                logger().info("Loaded %s", modulePath.string().c_str());
                break;
            }
        }
    }

    if (rc)
    {
       logger().warn("Failed to load file %s: %d %s",
                     filename.c_str(), rc, strerror(rc));
    }
    return rc;
}
```

