### PR TITLE
get rid of boost reader-writer locks

### DIFF
--- a/opencog/atomspace/AtomIndex.h
+++ b/opencog/atomspace/AtomIndex.h
@@ -39,7 +39,7 @@ namespace opencog
  * important for choosing a RAM/CPU performance profile customized for
  * the index.
  *
- * Typically, Value will be Handle, possibly PredicateEvaluator*.
+ * Typically, Value will be Handle.
  * The Key will typically be an int, string, etc.
  */
 

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -541,7 +541,6 @@ public:
      * @param result An output iterator.
      * @param type the type of the atoms to be searched
      * @param name the name of the atoms to be searched.
-     *        For searching only links, use "" or a search by type.
      * @param subclass if sub types of the given type are accepted
      *        in this search
      *
@@ -558,18 +557,8 @@ public:
     template <typename OutputIterator> OutputIterator
     getHandlesByName(OutputIterator result,
                      const std::string& name,
-                     Type type = ATOM,
+                     Type type = NODE,
                      bool subclass = true) const
-    {
-        return getAtomTable().getHandlesByName(result, name, type, subclass);
-    }
-
-    /** Identical to above. Do not use in new code.  */
-    template <typename OutputIterator> OutputIterator
-    getHandleSet(OutputIterator result,
-                 const char* name,
-                 Type type,
-                 bool subclass = true) const
     {
         return getAtomTable().getHandlesByName(result, name, type, subclass);
     }

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -323,7 +323,7 @@ public:
     template <typename OutputIterator> OutputIterator
     getHandlesByName(OutputIterator result,
                      const std::string& name,
-                     Type type = ATOM,
+                     Type type = NODE,
                      bool subclass = true) const
     {
         if (name.c_str()[0] == 0)

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -36,6 +36,7 @@
 #include <opencog/util/Logger.h>
 #include <opencog/util/RandGen.h>
 
+#include <opencog/atomspace/atom_types.h>
 #include <opencog/atomspace/AttentionValue.h>
 #include <opencog/atomspace/ClassServer.h>
 #include <opencog/atomspace/FixedIntegerIndex.h>

--- a/opencog/atomspace/ClassServer.h
+++ b/opencog/atomspace/ClassServer.h
@@ -23,11 +23,11 @@
 #ifndef _OPENCOG_CLASS_SERVER_H
 #define _OPENCOG_CLASS_SERVER_H
 
+#include <mutex>
 #include <unordered_map>
 #include <vector>
 
 #include <boost/signals2.hpp>
-#include <boost/thread/shared_mutex.hpp>
 
 #include <opencog/atomspace/types.h>
 #include <opencog/atomspace/atom_types.h>
@@ -55,10 +55,15 @@ private:
     /** Private default constructor for this class to make it a singleton. */
     ClassServer();
 
-    /* Use boost, because we need a reader-writer implementation, which
-     * is not offered by C++11 ... but expected in C++14 ?? */
-    mutable boost::shared_mutex type_mutex;
-    mutable boost::mutex signal_mutex;
+    /* It is very tempting to make the type_mutex into a reader-writer
+     * mutex. However, it appears that this is a bad idea: reader-writer
+     * mutexes cause cache-line ping-ponging when there is contention,
+     * effecitvely serializing access, and are just plain slower when
+     * there is no contention.  Thus, the current implementations seem
+     * to be a lose-lose proposition. See the Anthony Williams post here:
+     * http://permalink.gmane.org/gmane.comp.lib.boost.devel/211180
+     */
+    mutable std::mutex type_mutex;
 
     Type nTypes;
 
@@ -134,8 +139,10 @@ public:
          * the best-case fast-path for it.  Since updates are extremely
          * unlikely after initialization, we use a multi-reader lock,
          * and don't care at all about writer starvation, since there
-         * will almost never be writers. */
-        boost::shared_lock<boost::shared_mutex> l(type_mutex);
+         * will almost never be writers. However, see comments above
+         * about multi-reader-locks -- we are not using them just right
+         * now, because they don't seem to actually help. */
+        std::lock_guard<std::mutex> l(type_mutex);
         if ((sub >= nTypes) || (super >= nTypes)) return false;
         return recursiveMap[super][sub];
     }

--- a/opencog/atomspace/FixedIntegerIndex.cc
+++ b/opencog/atomspace/FixedIntegerIndex.cc
@@ -25,7 +25,7 @@ using namespace opencog;
 
 void FixedIntegerIndex::insert(int i, Handle h)
 {
-	UnorderedUUIDSet &s = idx.at(i);
+	UnorderedIntSet &s = idx.at(i);
 	s.insert(h.value());
 }
 
@@ -36,14 +36,14 @@ Handle FixedIntegerIndex::get(int i) const
 
 void FixedIntegerIndex::remove(int i, Handle h)
 {
-	UnorderedUUIDSet &s = idx.at(i);
+	UnorderedIntSet &s = idx.at(i);
 	s.erase(h.value());
 }
 
 size_t FixedIntegerIndex::size(void) const
 {
 	size_t cnt = 0;
-	std::vector<UnorderedUUIDSet >::const_iterator s;
+	std::vector<UnorderedIntSet >::const_iterator s;
 	for (s = idx.begin(); s != idx.end(); ++s)
 	{
 		cnt += s->size();
@@ -53,10 +53,10 @@ size_t FixedIntegerIndex::size(void) const
 
 void FixedIntegerIndex::remove(bool (*filter)(Handle))
 {
-	std::vector<UnorderedUUIDSet >::iterator s;
+	std::vector<UnorderedIntSet >::iterator s;
 	for (s = idx.begin(); s != idx.end(); ++s)
 	{
-		UnorderedUUIDSet::iterator i, j;
+		UnorderedIntSet::iterator i, j;
 	
 		i = s->begin();
 		while (i != s->end())

--- a/opencog/atomspace/FixedIntegerIndex.h
+++ b/opencog/atomspace/FixedIntegerIndex.h
@@ -34,6 +34,8 @@ namespace opencog
  *  @{
  */
 
+typedef std::unordered_set<int> UnorderedIntSet;
+
 /**
  * Implements an integer index as an RB-tree (C++ map)
  */
@@ -41,7 +43,7 @@ class FixedIntegerIndex
 	: public AtomIndex<int, Handle>
 {
 	protected:
-		std::vector<UnorderedUUIDSet> idx; 
+		std::vector<UnorderedIntSet> idx;
 		void resize(size_t);
 
 	public:

--- a/opencog/atomspace/Handle.h
+++ b/opencog/atomspace/Handle.h
@@ -43,8 +43,6 @@ namespace opencog
 
 //! UUID == Universally Unique Identifier
 typedef unsigned long UUID;
-typedef std::unordered_set<UUID> UnorderedUUIDSet;
-
 
 class Atom;
 typedef std::shared_ptr<Atom> AtomPtr;

--- a/opencog/atomspace/ImportanceIndex.cc
+++ b/opencog/atomspace/ImportanceIndex.cc
@@ -77,14 +77,14 @@ UnorderedHandleSet ImportanceIndex::getHandleSet(
         AttentionValue::sti_t lowerBound,
         AttentionValue::sti_t upperBound) const
 {
-	UnorderedUUIDSet set;
+	UnorderedIntSet set;
 
 	// The indexes for the lower bound and upper bound lists is returned.
 	int lowerBin = importanceBin(lowerBound);
 	int upperBin = importanceBin(upperBound);
 
 	// Build a list of atoms whose importance is equal to the lower bound.
-	const UnorderedUUIDSet &sl = idx[lowerBin];
+	const UnorderedIntSet &sl = idx[lowerBin];
 
 	// For the lower bound and upper bound index, the list is filtered,
 	// because there may be atoms that have the same importanceIndex
@@ -110,12 +110,12 @@ UnorderedHandleSet ImportanceIndex::getHandleSet(
 	// For every index within lowerBound and upperBound,
 	// add to the list.
 	while (++lowerBin < upperBin) {
-		const UnorderedUUIDSet &ss = idx[lowerBin];
+		const UnorderedIntSet &ss = idx[lowerBin];
 		set.insert(ss.begin(), ss.end());
 	}
 
 	// The two lists are concatenated.
-	const UnorderedUUIDSet &uset = idx[upperBin];
+	const UnorderedIntSet &uset = idx[upperBin];
 	std::copy_if(uset.begin(), uset.end(), inserter(set),
 		[&](UUID uuid)->bool {
 			Handle h(uuid);

--- a/opencog/atomspace/TypeIndex.h
+++ b/opencog/atomspace/TypeIndex.h
@@ -74,10 +74,10 @@ class TypeIndex:
 			private:
 				Type type;
 				bool subclass;
-				std::vector<UnorderedUUIDSet>::const_iterator s;
-				std::vector<UnorderedUUIDSet>::const_iterator send;
+				std::vector<UnorderedIntSet>::const_iterator s;
+				std::vector<UnorderedIntSet>::const_iterator send;
 				Type currtype;
-				UnorderedUUIDSet::const_iterator se;
+				UnorderedIntSet::const_iterator se;
 		};
 
 		iterator begin(Type, bool) const;

--- a/opencog/embodiment/Learning/Filter/ActionFilter.cc
+++ b/opencog/embodiment/Learning/Filter/ActionFilter.cc
@@ -24,6 +24,7 @@
 
 #include <opencog/util/exceptions.h>
 #include <opencog/atomspace/Node.h>
+#include <opencog/atomspace/atom_types.h>
 #include <opencog/spacetime/atom_types.h>
 
 #include <opencog/embodiment/Control/PerceptionActionInterface/PAI.h>

--- a/opencog/embodiment/Learning/Filter/EntropyFilter.cc
+++ b/opencog/embodiment/Learning/Filter/EntropyFilter.cc
@@ -29,6 +29,7 @@
 #include <opencog/util/numeric.h>
 #include <opencog/util/lru_cache.h>
 
+#include <opencog/atomspace/atom_types.h>
 #include <opencog/comboreduct/type_checker/type_tree.h>
 #include <opencog/spacetime/SpaceServer.h>
 #include <opencog/spacetime/TimeServer.h>


### PR DESCRIPTION
Per observation from Curtis Faith of Anthony Williams post on reader writer locks: in the current boost implementation, they are essentially pointless and wasteful. So remove them.

Remove some misc dead code too.