### PR TITLE
Added PLN rules required for Socrates Example

### DIFF
--- a/opencog/reasoning/RuleEngine/rules/pln/abduction.scm
+++ b/opencog/reasoning/RuleEngine/rules/pln/abduction.scm
@@ -1,0 +1,99 @@
+;==============================================================================
+; Abduction Rule
+;
+; AND(Inheritance A C, Inheritance B C) entails Inheritance A B
+;------------------------------------------------------------------------------
+
+(define pln-rule-abduction
+	(BindLink
+		(ListLink
+			(VariableNode "$A")
+			(VariableNode "$B")
+			(VariableNode "$C"))
+		(ImplicationLink
+			(AndLink
+				(InheritanceLink
+					(VariableNode "$A")
+					(VariableNode "$C"))
+				(InheritanceLink
+					(VariableNode "$B")
+					(VariableNode "$C"))
+				(VariableNode "$A")
+				(VariableNode "$B")
+				(VariableNode "$C"))
+			(ExecutionOutputLink
+				(GroundedSchemaNode "scm: pln-formula-abduction")
+				(ListLink
+					(InheritanceLink
+						(VariableNode "$A")
+						(VariableNode "$B"))
+					(InheritanceLink
+						(VariableNode "$A")
+						(VariableNode "$C"))
+					(InheritanceLink
+						(VariableNode "$B")
+						(VariableNode "$C"))
+					(VariableNode "$A")
+					(VariableNode "$B")
+					(VariableNode "$C"))))))
+; -----------------------------------------------------------------------------
+; Abduction Formula
+; -----------------------------------------------------------------------------
+
+; -----------------------------------------------------------------------------
+; Side-effect: TruthValue of AB may be updated
+; -----------------------------------------------------------------------------
+
+(define (pln-formula-abduction AB AC BC A B C)
+	(cog-set-tv!
+		AB
+		(pln-formula-abduction-side-effect-free
+			AB
+			AC
+			BC
+			A
+			B
+			C)))
+; -----------------------------------------------------------------------------
+; This version has no side effects and simply returns a TruthValue
+; -----------------------------------------------------------------------------
+
+(define (pln-formula-abduction-side-effect-free AB AC BC A B C)
+	(let
+		(
+			(sCB 
+				(/ 
+					(* 
+						(cog-stv-strength BC) 
+						(cog-stv-strength C)
+					) 
+					(cog-stv-strength B)
+				)
+			)
+			(sAC (cog-stv-strength AC))
+			(sC (cog-stv-strength C))
+		)
+			(stv
+				(if (eq? 0 (- 1 sAC))
+					0 ; Set Strength to 0 if sNotB equals 0 to avoid
+					  ; division by zero
+					(+                         ; Strength
+						(* sAC sCB)
+						(/
+							(*
+								(-
+									1
+                                    sAC)
+                                (-
+                                    sCB
+                                    (*
+                                        sAC
+                                        sCB)))
+                            (-
+                                1
+                                sAC))))
+                (min
+                    (cog-stv-confidence AC)
+                    (cog-stv-confidence BC))))) ; Confidence
+
+; =============================================================================

--- a/opencog/reasoning/RuleEngine/rules/pln/abduction.scm
+++ b/opencog/reasoning/RuleEngine/rules/pln/abduction.scm
@@ -3,7 +3,7 @@
 ;
 ; AND(Inheritance A C, Inheritance B C) entails Inheritance A B
 ;------------------------------------------------------------------------------
-
+(include "formulas.scm")
 (define pln-rule-abduction
 	(BindLink
 		(ListLink
@@ -17,10 +17,7 @@
 					(VariableNode "$C"))
 				(InheritanceLink
 					(VariableNode "$B")
-					(VariableNode "$C"))
-				(VariableNode "$A")
-				(VariableNode "$B")
-				(VariableNode "$C"))
+					(VariableNode "$C")))
 			(ExecutionOutputLink
 				(GroundedSchemaNode "scm: pln-formula-abduction")
 				(ListLink
@@ -61,39 +58,18 @@
 (define (pln-formula-abduction-side-effect-free AB AC BC A B C)
 	(let
 		(
-			(sCB 
-				(/ 
-					(* 
-						(cog-stv-strength BC) 
-						(cog-stv-strength C)
-					) 
-					(cog-stv-strength B)
-				)
-			)
+			(sCB (inversion-formula 
+				(cog-stv-strength BC)
+				(cog-stv-strength B) 
+				(cog-stv-strength C)))
 			(sAC (cog-stv-strength AC))
 			(sC (cog-stv-strength C))
-		)
-			(stv
-				(if (eq? 0 (- 1 sAC))
-					0 ; Set Strength to 0 if sNotB equals 0 to avoid
-					  ; division by zero
-					(+                         ; Strength
-						(* sAC sCB)
-						(/
-							(*
-								(-
-									1
-                                    sAC)
-                                (-
-                                    sCB
-                                    (*
-                                        sAC
-                                        sCB)))
-                            (-
-                                1
-                                sAC))))
-                (min
-                    (cog-stv-confidence AC)
-                    (cog-stv-confidence BC))))) ; Confidence
+			(sB (cog-stv-strength B))
+			(sA (cog-stv-strength A)))
+		(stv 
+			(simple-deduction-formula sA sC sB sAC sCB) ;Strength
+                	(min
+                    		(cog-stv-confidence AB)
+                    		(cog-stv-confidence BC))))) ; Confidence
 
 ; =============================================================================

--- a/opencog/reasoning/RuleEngine/rules/pln/evaluation-to-member.scm
+++ b/opencog/reasoning/RuleEngine/rules/pln/evaluation-to-member.scm
@@ -1,5 +1,7 @@
 ; ============================================================================= 
-; GeneralEvaluationToMemberRule
+; GeneralEvaluationToMemberRule 
+;	Takes EvaluationLinks with >=2 Arguments and creates a Member Link
+;
 ;	EvaluationLink (pred D (ListLink B C))
 ;		becomes
 ;	MemberLink( B (SatisfyingSetLink( Variable $X 
@@ -9,34 +11,22 @@
 (define pln-rule-evaluation-to-member
 	(BindLink
 		(ListLink
-			(VariableNode "$B")
-			(VariableNode "$C")
+			(VariableNode "$A")
 			(TypedVariableLink
 				(VariableNode "$D")
 				(VariableTypeNode "PredicateNode")))
-		(ImplicationLink
-			(EvaluationLink
-				(VariableNode "$D")
-				(ListLink
-					(VariableNode "$B")
-					(VariableNode "$C")))
-			(ExecutionOutputLink
-				(GroundedSchemaNode "scm:pln-formula-evaluation-to-member")
-				(ListLink
-					(MemberLink
-						(VariableNode "$B")
-						(SatisfyingSetLink
-							(VariableNode "$X")
-							(EvaluationLink
-								(VariableNode "$D")
-								(ListLink
-									(VariableNode "$X")
-									(VariableNode "$C")))))
-					(EvaluationLink
-						(VariableNode "$D")
-						(ListLink
-							(VariableNode "$B")
-							(VariableNode "$C"))))))))
+        (ImplicationLink
+            (EvaluationLink
+                (VariableNode "$D")
+                (VariableNode "$A"))
+            (ExecutionOutputLink
+                (GroundedSchemaNode "scm:pln-formula-evaluation-to-member")
+                (ListLink
+                    (EvaluationLink
+                        (VariableNode "$D")
+                        (VariableNode "$A")))))))
+
+
 ; -----------------------------------------------------------------------------
 ; Evaluation To Member Formula
 ; -----------------------------------------------------------------------------
@@ -45,19 +35,16 @@
 ; Side-effect: TruthValue of the new link stays the same
 ; -----------------------------------------------------------------------------
 
-(define (pln-formula-evaluation-to-member BXDXC DBC)
-	(cog-set-tv!
-		BXDXC
-		(pln-formula-evaluation-to-member-side-effect-free
-			BXDXC
-			DBC)))
-; -----------------------------------------------------------------------------
-; This version has no side effects and simply returns a TruthValue
-; -----------------------------------------------------------------------------
-
-(define (pln-formula-evaluation-to-member-side-effect-free BXDXC DBC)
-	(stv
-		(cog-stv-strength DBC)
-		(cog-stv-confidence DBC)))
+(define (pln-formula-evaluation-to-member DBC)
+	(MemberLink (stv (cog-stv-strength DBC) (cog-stv-confidence DBC))
+		(car (cdr (cog-get-all-nodes DBC)))
+		(SatisfyingSetLink
+			(VariableNode "$X")
+			(EvaluationLink
+				(car (cog-get-all-nodes DBC))
+				(ListLink
+					(cons
+						(VariableNode "$X")
+						(cdr (cdr (cog-get-all-nodes DBC)))))))))
 
 ; =============================================================================

--- a/opencog/reasoning/RuleEngine/rules/pln/evaluation-to-member.scm
+++ b/opencog/reasoning/RuleEngine/rules/pln/evaluation-to-member.scm
@@ -6,6 +6,9 @@
 ;		becomes
 ;	MemberLink( B (SatisfyingSetLink( Variable $X 
 ;		(EvaluationLink (pred D (ListLink X C))))))
+;						&
+;	MemberLink( B (LambdaLink( Variable $X 
+;		(EvaluationLink (pred D (ListLink X C))))))
 ; -----------------------------------------------------------------------------
 
 (define pln-rule-evaluation-to-member
@@ -32,27 +35,59 @@
 ; -----------------------------------------------------------------------------
 
 ; -----------------------------------------------------------------------------
-; Side-effect: TruthValue of the new link stays the same
+; Side-effect: TruthValue of the new links stays the same
 ; -----------------------------------------------------------------------------
 
 (define (pln-formula-evaluation-to-member DBC)
 	(if (= (cog-arity (gdr DBC)) 0)
-		(MemberLink (stv (cog-stv-strength DBC) (cog-stv-confidence DBC))
-			(gdr DBC)
-			(SatisfyingSetLink
-				(VariableNode "$X")
-				(EvaluationLink
-					(gar DBC)
-					(VariableNode "$X"))))
-		(MemberLink (stv (cog-stv-strength DBC) (cog-stv-confidence DBC))
-			(gadr DBC)
-			(SatisfyingSetLink
-				(VariableNode "$X")
-				(EvaluationLink
-					(gar DBC)
-					(ListLink
-						(cons
-							(VariableNode "$X")
-							(cdr (cog-get-all-nodes (gdr DBC))))))))))
+		(begin
+			(MemberLink (stv (cog-stv-strength DBC) (cog-stv-confidence DBC))
+				(gdr DBC)
+				(SatisfyingSetLink
+					(VariableNode "$X")
+					(EvaluationLink
+						(gar DBC)
+						(VariableNode "$X"))))
+			(MemberLink (stv (cog-stv-strength DBC) (cog-stv-confidence DBC))
+    			(gdr DBC)
+    			(LambdaLink
+        			(VariableNode "$X")
+        			(EvaluationLink
+            			(gar DBC)
+						(VariableNode "$X")))))
+		(pln-create-member DBC '() (cog-outgoing-set (gdr DBC)))))
+
+; -----------------------------------------------------------------------------
+; Creating Multiple Links for Multiple Values
+; -----------------------------------------------------------------------------
+
+(define (pln-create-member DBC preceding-nodes trailing-nodes)
+	(if (not (null? trailing-nodes))
+		(begin
+			(MemberLink (stv (cog-stv-strength DBC) (cog-stv-confidence DBC))
+				(car trailing-nodes)
+				(SatisfyingSetLink
+					(VariableNode "$X")
+					(EvaluationLink
+						(gar DBC)
+						(ListLink
+							(append
+								preceding-nodes
+								(cons (VariableNode "$X")
+									(cdr trailing-nodes)))))))
+			(MemberLink (stv (cog-stv-strength DBC) (cog-stv-confidence DBC))
+				(car trailing-nodes)
+				(LambdaLink
+					(VariableNode "$X")
+					(EvaluationLink
+						(gar DBC)
+						(ListLink
+							(append
+								preceding-nodes
+								(cons (VariableNode "$X")
+									(cdr trailing-nodes)))))))
+			(pln-create-member DBC 
+				(reverse (cons (car trailing-nodes) (reverse preceding-nodes)))
+				(cdr trailing-nodes)))))
 
 ; =============================================================================

--- a/opencog/reasoning/RuleEngine/rules/pln/evaluation-to-member.scm
+++ b/opencog/reasoning/RuleEngine/rules/pln/evaluation-to-member.scm
@@ -36,15 +36,23 @@
 ; -----------------------------------------------------------------------------
 
 (define (pln-formula-evaluation-to-member DBC)
-	(MemberLink (stv (cog-stv-strength DBC) (cog-stv-confidence DBC))
-		(car (cdr (cog-get-all-nodes DBC)))
-		(SatisfyingSetLink
-			(VariableNode "$X")
-			(EvaluationLink
-				(car (cog-get-all-nodes DBC))
-				(ListLink
-					(cons
-						(VariableNode "$X")
-						(cdr (cdr (cog-get-all-nodes DBC)))))))))
+	(if (= (cog-arity (gdr DBC)) 0)
+		(MemberLink (stv (cog-stv-strength DBC) (cog-stv-confidence DBC))
+			(gdr DBC)
+			(SatisfyingSetLink
+				(VariableNode "$X")
+				(EvaluationLink
+					(gar DBC)
+					(VariableNode "$X"))))
+		(MemberLink (stv (cog-stv-strength DBC) (cog-stv-confidence DBC))
+			(gadr DBC)
+			(SatisfyingSetLink
+				(VariableNode "$X")
+				(EvaluationLink
+					(gar DBC)
+					(ListLink
+						(cons
+							(VariableNode "$X")
+							(cdr (cog-get-all-nodes (gdr DBC))))))))))
 
 ; =============================================================================

--- a/opencog/reasoning/RuleEngine/rules/pln/evaluation-to-member.scm
+++ b/opencog/reasoning/RuleEngine/rules/pln/evaluation-to-member.scm
@@ -1,0 +1,64 @@
+; ============================================================================= 
+; GeneralEvaluationToMemberRule
+;	EvaluationLink (pred D (ListLink B C))
+;		becomes
+;	MemberLink( B (SatisfyingSetLink( Variable $X 
+;		(EvaluationLink (pred D (ListLink X C))))))
+; -----------------------------------------------------------------------------
+
+(define pln-rule-evaluation-to-member
+	(BindLink
+		(ListLink
+			(VariableNode "$B")
+			(VariableNode "$C")
+			(VariableNode "$D")
+			(TypedVariableLink
+				(VariableNode "$D")
+				(VariableTypeNode "PredicateNode")))
+		(ImplicationLink
+			(EvaluationLink
+				(VariableNode "$D")
+				(ListLink
+					(VariableNode "$B")
+					(VariableNode "$C")))
+			(ExecutionOutputLink
+				(GroundedSchemaNode "scm:pln-formula-evaluation-to-member")
+				(ListLink
+					(MemberLink
+						(VariableNode "$B")
+						(SatisfyingSetLink
+							(VariableNode "$X")
+							(EvaluationLink
+								(VariableNode "$D")
+								(ListLink
+									(VariableNode "$X")
+									(VariableNode "$C")))))
+					(EvaluationLink
+						(VariableNode "$D")
+						(ListLink
+							(VariableNode "$B")
+							(VariableNode "$C"))))))))
+; -----------------------------------------------------------------------------
+; Evaluation To Member Formula
+; -----------------------------------------------------------------------------
+
+; -----------------------------------------------------------------------------
+; Side-effect: TruthValue of the new link stays the same
+; -----------------------------------------------------------------------------
+
+(define (pln-formula-evaluation-to-member BXDXC DBC)
+	(cog-set-tv!
+		BXDXC
+		(pln-formula-evaluation-to-member-side-effect-free
+			BXDXC
+			DBC)))
+; -----------------------------------------------------------------------------
+; This version has no side effects and simply returns a TruthValue
+; -----------------------------------------------------------------------------
+
+(define (pln-formula-evaluation-to-member-side-effect-free BXDXC DBC)
+	(stv
+		(cog-stv-strength DBC)
+		(cog-stv-confidence DBC)))
+
+; =============================================================================

--- a/opencog/reasoning/RuleEngine/rules/pln/evaluation-to-member.scm
+++ b/opencog/reasoning/RuleEngine/rules/pln/evaluation-to-member.scm
@@ -1,4 +1,4 @@
-; ============================================================================= 
+; =============================================================================
 ; GeneralEvaluationToMemberRule 
 ;	Takes EvaluationLinks with >=2 Arguments and creates a Member Link
 ;
@@ -10,6 +10,8 @@
 ;	MemberLink( B (LambdaLink( Variable $X 
 ;		(EvaluationLink (pred D (ListLink X C))))))
 ; -----------------------------------------------------------------------------
+
+(include "formulas.scm")
 
 (define pln-rule-evaluation-to-member
 	(BindLink
@@ -29,65 +31,45 @@
                         (VariableNode "$D")
                         (VariableNode "$A")))))))
 
-
 ; -----------------------------------------------------------------------------
 ; Evaluation To Member Formula
 ; -----------------------------------------------------------------------------
 
 ; -----------------------------------------------------------------------------
-; Side-effect: TruthValue of the new links stays the same
+; Side-effect: TruthValue of the new link/s stays the same
 ; -----------------------------------------------------------------------------
 
-(define (pln-formula-evaluation-to-member DBC)
-	(if (= (cog-arity (gdr DBC)) 0)
-		(begin
-			(MemberLink (stv (cog-stv-strength DBC) (cog-stv-confidence DBC))
-				(gdr DBC)
-				(SatisfyingSetLink
-					(VariableNode "$X")
-					(EvaluationLink
-						(gar DBC)
-						(VariableNode "$X"))))
-			(MemberLink (stv (cog-stv-strength DBC) (cog-stv-confidence DBC))
-    			(gdr DBC)
-    			(LambdaLink
-        			(VariableNode "$X")
-        			(EvaluationLink
-            			(gar DBC)
-						(VariableNode "$X")))))
-		(pln-create-member DBC '() (cog-outgoing-set (gdr DBC)))))
+(define (pln-formula-evaluation-to-member DA)
+	(if (= (cog-arity (gdr DA)) 0)
+		(MemberLink (stv (cog-stv-strength DA) (cog-stv-confidence DA))
+			(gdr DA)
+			(SatisfyingSetLink
+				(VariableNode "$X")
+				(EvaluationLink
+					(gar DA)
+					(VariableNode "$X"))))
+		(ListLink
+			(create-multiple-links DA '() (cog-outgoing-set (gdr DA))))))
 
-; -----------------------------------------------------------------------------
-; Creating Multiple Links for Multiple Values
-; -----------------------------------------------------------------------------
-
-(define (pln-create-member DBC preceding-nodes trailing-nodes)
+(define (create-multiple-links DA preceding-nodes trailing-nodes)
 	(if (not (null? trailing-nodes))
-		(begin
-			(MemberLink (stv (cog-stv-strength DBC) (cog-stv-confidence DBC))
+		(cons
+			(MemberLink (stv (cog-stv-strength DA) (cog-stv-confidence DA))
 				(car trailing-nodes)
 				(SatisfyingSetLink
 					(VariableNode "$X")
 					(EvaluationLink
-						(gar DBC)
+						(gar DA)
 						(ListLink
 							(append
 								preceding-nodes
-								(cons (VariableNode "$X")
+								(cons
+									(VariableNode "$X")
 									(cdr trailing-nodes)))))))
-			(MemberLink (stv (cog-stv-strength DBC) (cog-stv-confidence DBC))
-				(car trailing-nodes)
-				(LambdaLink
-					(VariableNode "$X")
-					(EvaluationLink
-						(gar DBC)
-						(ListLink
-							(append
-								preceding-nodes
-								(cons (VariableNode "$X")
-									(cdr trailing-nodes)))))))
-			(pln-create-member DBC 
+			(create-multiple-links 
+				DA
 				(reverse (cons (car trailing-nodes) (reverse preceding-nodes)))
-				(cdr trailing-nodes)))))
+				(cdr trailing-nodes)))
+		'())) 
 
 ; =============================================================================

--- a/opencog/reasoning/RuleEngine/rules/pln/evaluation-to-member.scm
+++ b/opencog/reasoning/RuleEngine/rules/pln/evaluation-to-member.scm
@@ -11,7 +11,6 @@
 		(ListLink
 			(VariableNode "$B")
 			(VariableNode "$C")
-			(VariableNode "$D")
 			(TypedVariableLink
 				(VariableNode "$D")
 				(VariableTypeNode "PredicateNode")))

--- a/opencog/reasoning/RuleEngine/rules/pln/formulas.scm
+++ b/opencog/reasoning/RuleEngine/rules/pln/formulas.scm
@@ -1,0 +1,52 @@
+; =============================================================================
+; Inversion Formula
+; sBA = (sAB * sB)/sA
+; -----------------------------------------------------------------------------
+
+(define (inversion-formula sAB sA sB)
+	(/ (* sAB sB) sA))
+
+; =============================================================================
+; Simple Deduction Formula
+; IF: 0 <= sAB-max((sA+sB-1)/sA, 0) 0<= min(1, sB/sA) -max((sA+sB-1)/sA, 0)
+; AND 0 <= sBC-max((sB+sC-1)/sB, 0) 0<= min(1, sC/sB)-max((sB+sC-1)/sB, 0)
+; sAC = [sAB.sBC + ((1-sAB)(sC - sBsBC))/(1-sB)] 
+; ELSE:
+; sAC = 0
+; -----------------------------------------------------------------------------
+
+; Consistency Conditions
+(define (consistency1 sA sB sAB)
+	(- sAB
+		(max 
+			(/ 
+				(- 
+					(+ sA sB) 
+					1) 
+				sA) 
+			0)))
+
+(define (consistency2 sA sB sAB)
+	(- 
+		(min 
+			1 
+			(/ sB sA)) 
+		sAB))
+
+; Main Formula
+(define (simple-deduction-formula sA sB sC sAB sBC)
+	(if
+		(and
+				(>= (consistency1 sA sB sAB) 0)
+				(>= (consistency2 sA sB sAB) 0)
+				(>= (consistency1 sB sC sBC) 0)
+				(>= (consistency2 sB sC sBC) 0))
+		(+ 
+			(* sAB sBC) 
+			(/ 
+				(* 
+					(- 1 sAB) 
+					(- sC 
+						(* sB sBC))) 
+				(- 1 sB)))
+		0 ))

--- a/opencog/reasoning/RuleEngine/rules/pln/formulas.scm
+++ b/opencog/reasoning/RuleEngine/rules/pln/formulas.scm
@@ -1,4 +1,14 @@
 ; =============================================================================
+; A list of the helper functions necessary in different inference rules
+; -----------------------------------------------------------------------------
+; Index
+; - inversion-formula
+; - simple-deduction-formula
+; - find-replace
+;------------------------------------------------------------------------------
+
+
+; =============================================================================
 ; Inversion Formula
 ; sBA = (sAB * sB)/sA
 ; -----------------------------------------------------------------------------
@@ -34,6 +44,7 @@
 		sAB))
 
 ; Main Formula
+
 (define (simple-deduction-formula sA sB sC sAB sBC)
 	(if
 		(and
@@ -50,3 +61,18 @@
 						(* sB sBC))) 
 				(- 1 sB)))
 		0 ))
+
+; =============================================================================
+; Basic find and replace formula
+;
+; Returns a new list by replacing first occurance of an element in the 
+; list(here old) to another element in the list(here new).
+; -----------------------------------------------------------------------------
+
+(define (find-replace l old new)
+	(cond
+		((null? l) '())
+		((equal? (car l) old) (cons new (cdr l)))
+		(else
+			(cons (car l) (find-replace (cdr l) old new)))))
+

--- a/opencog/reasoning/RuleEngine/rules/pln/inheritance-to-member.scm
+++ b/opencog/reasoning/RuleEngine/rules/pln/inheritance-to-member.scm
@@ -1,6 +1,6 @@
 ; =============================================================================
 ; InheritanceToMemberRule
-;	InheritanceLink( B C )
+;	InheritanceLink( {B} C )
 ;			becomes
 ;	MemberLink( B C )
 ; -----------------------------------------------------------------------------
@@ -12,7 +12,8 @@
 			(VariableNode "$C"))
 		(ImplicationLink
 			(InheritanceLink
-				(VariableNode "$B")
+				(SetLink
+					(VariableNode "$B"))
 				(VariableNode "$C"))
 			(ExecutionOutputLink
 				(GroundedSchemaNode "scm:pln-formula-inheritance-to-member")
@@ -21,7 +22,8 @@
 						(VariableNode "$B")
 						(VariableNode "$C"))
 					(InheritanceLink
-						(VariableNode "$B")
+						(SetLink
+							(VariableNode "$B"))
 						(VariableNode "$C")))))))
 
 ; -----------------------------------------------------------------------------

--- a/opencog/reasoning/RuleEngine/rules/pln/inheritance-to-member.scm
+++ b/opencog/reasoning/RuleEngine/rules/pln/inheritance-to-member.scm
@@ -1,6 +1,6 @@
 ; =============================================================================
 ; InheritanceToMemberRule
-;	InheritanceLink( {B} C )
+;	InheritanceLink( B C )
 ;			becomes
 ;	MemberLink( B C )
 ; -----------------------------------------------------------------------------
@@ -12,8 +12,7 @@
 			(VariableNode "$C"))
 		(ImplicationLink
 			(InheritanceLink
-				(SetLink
-					(VariableNode "$B"))
+				(VariableNode "$B")
 				(VariableNode "$C"))
 			(ExecutionOutputLink
 				(GroundedSchemaNode "scm:pln-formula-inheritance-to-member")
@@ -22,8 +21,7 @@
 						(VariableNode "$B")
 						(VariableNode "$C"))
 					(InheritanceLink
-						(SetLink
-							(VariableNode "$B"))
+						(VariableNode "$B")
 						(VariableNode "$C")))))))
 
 ; -----------------------------------------------------------------------------

--- a/opencog/reasoning/RuleEngine/rules/pln/inheritance-to-member.scm
+++ b/opencog/reasoning/RuleEngine/rules/pln/inheritance-to-member.scm
@@ -1,52 +1,28 @@
 ; =============================================================================
 ; InheritanceToMemberRule
-;	InheritanceLink( B (SatisfyingSetLink (Variable $X
-; 		(EvaluationLink (pred D (ListLink X C))))))
+;	InheritanceLink( B C )
 ;			becomes
-;	MemberLink( B (SatisfyingSetLink ( Variable $X 
-;		(EvaluationLink (pred D (ListLink X C))))))
+;	MemberLink( B C )
 ; -----------------------------------------------------------------------------
 
 (define pln-rule-inheritance-to-member
 	(BindLink
 		(ListLink
 			(VariableNode "$B")
-			(VariableNode "$C")
-			(VariableNode "$D")
-			(TypedVariableLink
-				(VariableNode "$D")
-				(VariableTypeNode "PredicateNode")))
+			(VariableNode "$C"))
 		(ImplicationLink
 			(InheritanceLink
 				(VariableNode "$B")
-				(SatisfyingSetLink
-					(VariableNode "$X")
-					(EvaluationLink
-						(VariableNode "$D")
-						(ListLink
-							(VariableNode "$X")
-							(VariableNode "$C")))))
+				(VariableNode "$C"))
 			(ExecutionOutputLink
 				(GroundedSchemaNode "scm:pln-formula-inheritance-to-member")
 				(ListLink
 					(MemberLink
 						(VariableNode "$B")
-						(SatisfyingSetLink
-							(VariableNode "$X")
-							(EvaluationLink
-								(VariableNode "$D")
-								(ListLink
-									(VariableNode "$X")
-									(VariableNode "$C")))))
+						(VariableNode "$C"))
 					(InheritanceLink
 						(VariableNode "$B")
-						(SatisfyingSetLink
-							(VariableNode "$X")
-							(EvaluationLink
-								(VariableNode "$D")
-								(ListLink
-									(VariableNode "$X")
-									(VariableNode "$C"))))))))))
+						(VariableNode "$C")))))))
 
 ; -----------------------------------------------------------------------------
 ; Inheritance To Member Formula
@@ -56,20 +32,20 @@
 ; Side-effect: TruthValue of the new link stays the same
 ; -----------------------------------------------------------------------------
 
-(define (pln-formula-inheritance-to-member BXDXC IBXDXC)
+(define (pln-formula-inheritance-to-member MBC IBC)
 	(cog-set-tv!
-		BXDXC
+		MBC
 		(pln-formula-member-to-inheritance-side-effect-free
-			BXDXC
-			IBXDXC)))
+			MBC
+			IBC)))
 
 ; -----------------------------------------------------------------------------
 ; This version has no side effects and simply returns a TruthValue
 ; -----------------------------------------------------------------------------
 
-(define (pln-formula-inheritance-to-member-side-effect-free BXDXC IBXDXC)
+(define (pln-formula-inheritance-to-member-side-effect-free MBC IBC)
 	(stv
-		(cog-stv-strength IBXDXC)
-		(cog-stv-confidence IBXDXC)))
+		(cog-stv-strength IBC)
+		(cog-stv-confidence IBC)))
 
 ; =============================================================================

--- a/opencog/reasoning/RuleEngine/rules/pln/inheritance-to-member.scm
+++ b/opencog/reasoning/RuleEngine/rules/pln/inheritance-to-member.scm
@@ -46,6 +46,6 @@
 (define (pln-formula-inheritance-to-member-side-effect-free MBC IBC)
 	(stv
 		(cog-stv-strength IBC)
-		(cog-stv-confidence IBC)))
+		(* (cog-stv-confidence IBC) 0.9))
 
 ; =============================================================================

--- a/opencog/reasoning/RuleEngine/rules/pln/inheritance-to-member.scm
+++ b/opencog/reasoning/RuleEngine/rules/pln/inheritance-to-member.scm
@@ -1,0 +1,75 @@
+; =============================================================================
+; InheritanceToMemberRule
+;	InheritanceLink( B (SatisfyingSetLink (Variable $X
+; 		(EvaluationLink (pred D (ListLink X C))))))
+;			becomes
+;	MemberLink( B (SatisfyingSetLink ( Variable $X 
+;		(EvaluationLink (pred D (ListLink X C))))))
+; -----------------------------------------------------------------------------
+
+(define pln-rule-inheritance-to-member
+	(BindLink
+		(ListLink
+			(VariableNode "$B")
+			(VariableNode "$C")
+			(VariableNode "$D")
+			(TypedVariableLink
+				(VariableNode "$D")
+				(VariableTypeNode "PredicateNode")))
+		(ImplicationLink
+			(InheritanceLink
+				(VariableNode "$B")
+				(SatisfyingSetLink
+					(VariableNode "$X")
+					(EvaluationLink
+						(VariableNode "$D")
+						(ListLink
+							(VariableNode "$X")
+							(VariableNode "$C")))))
+			(ExecutionOutputLink
+				(GroundedSchemaNode "scm:pln-formula-inheritance-to-member")
+				(ListLink
+					(MemberLink
+						(VariableNode "$B")
+						(SatisfyingSetLink
+							(VariableNode "$X")
+							(EvaluationLink
+								(VariableNode "$D")
+								(ListLink
+									(VariableNode "$X")
+									(VariableNode "$C")))))
+					(InheritanceLink
+						(VariableNode "$B")
+						(SatisfyingSetLink
+							(VariableNode "$X")
+							(EvaluationLink
+								(VariableNode "$D")
+								(ListLink
+									(VariableNode "$X")
+									(VariableNode "$C"))))))))))
+
+; -----------------------------------------------------------------------------
+; Inheritance To Member Formula
+; -----------------------------------------------------------------------------
+
+; -----------------------------------------------------------------------------
+; Side-effect: TruthValue of the new link stays the same
+; -----------------------------------------------------------------------------
+
+(define (pln-formula-inheritance-to-member BXDXC IBXDXC)
+	(cog-set-tv!
+		BXDXC
+		(pln-formula-member-to-inheritance-side-effect-free
+			BXDXC
+			IBXDXC)))
+
+; -----------------------------------------------------------------------------
+; This version has no side effects and simply returns a TruthValue
+; -----------------------------------------------------------------------------
+
+(define (pln-formula-inheritance-to-member-side-effect-free BXDXC IBXDXC)
+	(stv
+		(cog-stv-strength IBXDXC)
+		(cog-stv-confidence IBXDXC)))
+
+; =============================================================================

--- a/opencog/reasoning/RuleEngine/rules/pln/member-to-evaluation.scm
+++ b/opencog/reasoning/RuleEngine/rules/pln/member-to-evaluation.scm
@@ -21,26 +21,17 @@
 					(VariableNode "$X")
 					(EvaluationLink
 						(VariableNode "$D")
-						(ListLink
-							(VariableNode "$X")
-							(VariableNode "$C")))))
+						(VariableNode "$C"))))
 			(ExecutionOutputLink
 				(GroundedSchemaNode "scm:pln-formula-member-to-evaluation")
 				(ListLink
-					(EvaluationLink
-						(VariableNode "$D")
-						(ListLink
-							(VariableNode "$B")
-							(VariableNode "$C")))
 					(MemberLink
 						(VariableNode "$B")
 						(SatisfyingSetLink
 							(VariableNode "$X")
 							(EvaluationLink
 								(VariableNode "$D")
-								(ListLink
-									(VariableNode "$X")
-									(VariableNode "$C"))))))))))
+								(VariableNode "$C")))))))))
 
 ; -----------------------------------------------------------------------------
 ; Member To Evaluation Formula
@@ -50,20 +41,12 @@
 ; Side-effect: TruthValue of the new link stays the same
 ; -----------------------------------------------------------------------------
 
-(define (pln-formula-member-to-evaluation DBC BXDXC)
-	(cog-set-tv!
-		DBC
-		(pln-formula-member-to-evaluation-side-effect-free
-			DBC
-			BXDXC)))
-
-; -----------------------------------------------------------------------------
-; This version has no side effects and simply returns a TruthValue
-; -----------------------------------------------------------------------------
-
-(define (pln-formula-member-to-evaluation-side-effect-free DBC BXDXC)
-	(stv
-		(cog-stv-strength BXDXC)
-		(cog-stv-confidence BXDXC)))
+(define (pln-formula-member-to-evaluation BXDC)
+	(EvaluationLink (stv (cog-stv-strength BXDC) (cog-stv-confidence BXDC))
+		(car (cdr (cdr (cog-get-all-nodes BXDC))))
+		(ListLink
+			(cons
+				(car (cog-get-all-nodes BXDC))
+				(cdr (cdr (cdr (cdr (cog-get-all-nodes BXDC)))))))))
 
 ; =============================================================================

--- a/opencog/reasoning/RuleEngine/rules/pln/member-to-evaluation.scm
+++ b/opencog/reasoning/RuleEngine/rules/pln/member-to-evaluation.scm
@@ -5,6 +5,7 @@
 ;		becomes
 ;	EvaluationLink (pred D (ListLink B C))
 ; -----------------------------------------------------------------------------
+(include "formulas.scm")
 
 (define pln-rule-member-to-evaluation
 	(BindLink
@@ -49,17 +50,9 @@
 		(EvaluationLink (stv (cog-stv-strength BXDC) (cog-stv-confidence BXDC))
 			(gaddr BXDC)
 			(ListLink
-				(find-replace (cog-outgoing-set (gdddr BXDC)) (VariableNode "$X") (gar BXDC))))))
-
-; -----------------------------------------------------------------------------
-; Helper Function for creating ListLink for EvaluationLink
-; -----------------------------------------------------------------------------
-
-(define (find-replace l old new)
-	(cond
-		((null? l) '())
-		((equal? (car l) old) (cons new (cdr l)))
-		(else
-			(cons (car l) (find-replace (cdr l) old new))))) 
+				(find-replace 
+					(cog-outgoing-set (gdddr BXDC)) 
+					(VariableNode "$X") 
+					(gar BXDC))))))
 
 ; =============================================================================

--- a/opencog/reasoning/RuleEngine/rules/pln/member-to-evaluation.scm
+++ b/opencog/reasoning/RuleEngine/rules/pln/member-to-evaluation.scm
@@ -42,11 +42,15 @@
 ; -----------------------------------------------------------------------------
 
 (define (pln-formula-member-to-evaluation BXDC)
-	(EvaluationLink (stv (cog-stv-strength BXDC) (cog-stv-confidence BXDC))
-		(car (cdr (cdr (cog-get-all-nodes BXDC))))
-		(ListLink
-			(cons
-				(car (cog-get-all-nodes BXDC))
-				(cdr (cdr (cdr (cdr (cog-get-all-nodes BXDC)))))))))
+	(if (= (cog-arity (gdddr BXDC)) 0)
+		(EvaluationLink (stv (cog-stv-strength BXDC) (cog-stv-confidence BXDC))
+			(gaddr BXDC)
+			(gar BXDC))
+		(EvaluationLink (stv (cog-stv-strength BXDC) (cog-stv-confidence BXDC))
+			(gaddr BXDC)
+			(ListLink
+				(cons
+					(gar BXDC)
+					(cdr (cog-outgoing-set (gdddr BXDC))))))))
 
 ; =============================================================================

--- a/opencog/reasoning/RuleEngine/rules/pln/member-to-evaluation.scm
+++ b/opencog/reasoning/RuleEngine/rules/pln/member-to-evaluation.scm
@@ -1,0 +1,70 @@
+; ============================================================================= 
+; GeneralMemberToEvaluationRule
+;	MemberLink( B (SatisfyingSetLink( Variable $X 
+;		(EvaluationLink (pred D (ListLink X C))))))
+;		becomes
+;	EvaluationLink (pred D (ListLink B C))
+; -----------------------------------------------------------------------------
+
+(define pln-rule-member-to-evaluation
+	(BindLink
+		(ListLink
+			(VariableNode "$B")
+			(VariableNode "$C")
+   			(VariableNode "$D")
+   			(TypedVariableLink
+    			(VariableNode "$D")
+    			(VariableTypeNode "PredicateNode")))
+	(ImplicationLink
+		(MemberLink
+			(VariableNode "$B")
+			(SatisfyingSetLink
+				(VariableNode "$X")
+				(EvaluationLink
+					(VariableNode "$D")
+					(ListLink
+						(VariableNode "$X")
+						(VariableNode "$C")))))
+		(ExecutionOutputLink
+			(GroundedSchemaNode "scm:pln-formula-member-to-evaluation")
+			(ListLink
+				(EvaluationLink
+					(VariableNode "$D")
+					(ListLink
+						(VariableNode "$B")
+						(VariableNode "$C")))
+				(MemberLink
+					(VariableNode "$B")
+					(SatisfyingSetLink
+						(VariableNode "$X")
+						(EvaluationLink
+							(VariableNode "$D")
+							(ListLink
+								(VariableNode "$X")
+								(VariableNode "$C"))))))))))
+
+; -----------------------------------------------------------------------------
+; Member To Evaluation Formula
+; -----------------------------------------------------------------------------
+
+; -----------------------------------------------------------------------------
+; Side-effect: TruthValue of the new link stays the same
+; -----------------------------------------------------------------------------
+
+(define (pln-formula-member-to-evaluation DBC BXDXC)
+	(cog-set-tv!
+		DBC
+		(pln-formula-member-to-evaluation-side-effect-free
+			DBC
+			BXDXC)))
+
+; -----------------------------------------------------------------------------
+; This version has no side effects and simply returns a TruthValue
+; -----------------------------------------------------------------------------
+
+(define (pln-formula-member-to-evaluation-side-effect-free DBC BXDXC)
+	(stv
+		(cog-stv-strength BXDXC)
+		(cog-stv-confidence BXDXC)))
+
+; =============================================================================

--- a/opencog/reasoning/RuleEngine/rules/pln/member-to-evaluation.scm
+++ b/opencog/reasoning/RuleEngine/rules/pln/member-to-evaluation.scm
@@ -11,37 +11,36 @@
 		(ListLink
 			(VariableNode "$B")
 			(VariableNode "$C")
-   			(VariableNode "$D")
    			(TypedVariableLink
-    			(VariableNode "$D")
-    			(VariableTypeNode "PredicateNode")))
-	(ImplicationLink
-		(MemberLink
-			(VariableNode "$B")
-			(SatisfyingSetLink
-				(VariableNode "$X")
-				(EvaluationLink
-					(VariableNode "$D")
-					(ListLink
-						(VariableNode "$X")
-						(VariableNode "$C")))))
-		(ExecutionOutputLink
-			(GroundedSchemaNode "scm:pln-formula-member-to-evaluation")
-			(ListLink
-				(EvaluationLink
-					(VariableNode "$D")
-					(ListLink
+    				(VariableNode "$D")
+    				(VariableTypeNode "PredicateNode")))
+		(ImplicationLink
+			(MemberLink
+				(VariableNode "$B")
+				(SatisfyingSetLink
+					(VariableNode "$X")
+					(EvaluationLink
+						(VariableNode "$D")
+						(ListLink
+							(VariableNode "$X")
+							(VariableNode "$C")))))
+			(ExecutionOutputLink
+				(GroundedSchemaNode "scm:pln-formula-member-to-evaluation")
+				(ListLink
+					(EvaluationLink
+						(VariableNode "$D")
+						(ListLink
+							(VariableNode "$B")
+							(VariableNode "$C")))
+					(MemberLink
 						(VariableNode "$B")
-						(VariableNode "$C")))
-				(MemberLink
-					(VariableNode "$B")
-					(SatisfyingSetLink
-						(VariableNode "$X")
-						(EvaluationLink
-							(VariableNode "$D")
-							(ListLink
-								(VariableNode "$X")
-								(VariableNode "$C"))))))))))
+						(SatisfyingSetLink
+							(VariableNode "$X")
+							(EvaluationLink
+								(VariableNode "$D")
+								(ListLink
+									(VariableNode "$X")
+									(VariableNode "$C"))))))))))
 
 ; -----------------------------------------------------------------------------
 ; Member To Evaluation Formula

--- a/opencog/reasoning/RuleEngine/rules/pln/member-to-evaluation.scm
+++ b/opencog/reasoning/RuleEngine/rules/pln/member-to-evaluation.scm
@@ -49,8 +49,17 @@
 		(EvaluationLink (stv (cog-stv-strength BXDC) (cog-stv-confidence BXDC))
 			(gaddr BXDC)
 			(ListLink
-				(cons
-					(gar BXDC)
-					(cdr (cog-outgoing-set (gdddr BXDC))))))))
+				(find-replace (cog-outgoing-set (gdddr BXDC)) (VariableNode "$X") (gar BXDC))))))
+
+; -----------------------------------------------------------------------------
+; Helper Function for creating ListLink for EvaluationLink
+; -----------------------------------------------------------------------------
+
+(define (find-replace l old new)
+	(cond
+		((null? l) '())
+		((equal? (car l) old) (cons new (cdr l)))
+		(else
+			(cons (car l) (find-replace (cdr l) old new))))) 
 
 ; =============================================================================

--- a/opencog/reasoning/RuleEngine/rules/pln/member-to-inheritance.scm
+++ b/opencog/reasoning/RuleEngine/rules/pln/member-to-inheritance.scm
@@ -2,7 +2,7 @@
 ; MemberToInheritanceRule
 ;	MemberLink( B C )
 ;			becomes
-;	InheritanceLink( {B} C )
+;	InheritanceLink( B C )
 ; -----------------------------------------------------------------------------
 
 (define pln-rule-member-to-inheritance
@@ -18,8 +18,7 @@
 				(GroundedSchemaNode "scm:pln-formula-member-to-inheritance")
 				(ListLink
 					(InheritanceLink
-						(SetLink
-							(VariableNode "$B"))
+						(VariableNode "$B")
 						(VariableNode "$C"))
 					(MemberLink
 						(VariableNode "$B")

--- a/opencog/reasoning/RuleEngine/rules/pln/member-to-inheritance.scm
+++ b/opencog/reasoning/RuleEngine/rules/pln/member-to-inheritance.scm
@@ -2,7 +2,7 @@
 ; MemberToInheritanceRule
 ;	MemberLink( B C )
 ;			becomes
-;	InheritanceLink( B C )
+;	InheritanceLink( {B} C )
 ; -----------------------------------------------------------------------------
 
 (define pln-rule-member-to-inheritance
@@ -18,7 +18,8 @@
 				(GroundedSchemaNode "scm:pln-formula-member-to-inheritance")
 				(ListLink
 					(InheritanceLink
-						(VariableNode "$B")
+						(SetLink
+							(VariableNode "$B"))
 						(VariableNode "$C"))
 					(MemberLink
 						(VariableNode "$B")

--- a/opencog/reasoning/RuleEngine/rules/pln/member-to-inheritance.scm
+++ b/opencog/reasoning/RuleEngine/rules/pln/member-to-inheritance.scm
@@ -1,0 +1,75 @@
+; =============================================================================
+; MemberToInheritanceRule
+;	MemberLink( B (SatisfyingSetLink ( Variable $X 
+;		(EvaluationLink (pred D (ListLink X C))))))
+;			becomes
+;	InheritanceLink( B (SatisfyingSetLink (Variable $X
+; 		(EvaluationLink (pred D (ListLink X C))))))
+; -----------------------------------------------------------------------------
+
+(define pln-rule-member-to-inheritance
+	(BindLink
+		(ListLink
+			(VariableNode "$B")
+			(VariableNode "$C")
+			(VariableNode "$D")
+			(TypedVariableLink
+				(VariableNode "$D")
+				(VariableTypeNode "PredicateNode")))
+		(ImplicationLink
+			(MemberLink
+				(VariableNode "$B")
+				(SatisfyingSetLink
+					(VariableNode "$X")
+					(EvaluationLink
+						(VariableNode "$D")
+						(ListLink
+							(VariableNode "$X")
+							(VariableNode "$C")))))
+			(ExecutionOutputLink
+				(GroundedSchemaNode "scm:pln-formula-member-to-inheritance")
+				(ListLink
+					(InheritanceLink
+						(VariableNode "$B")
+						(SatisfyingSetLink
+							(VariableNode "$X")
+							(EvaluationLink
+								(VariableNode "$D")
+								(ListLink
+									(VariableNode "$X")
+									(VariableNode "$C")))))
+					(MemberLink
+						(VariableNode "$B")
+						(SatisfyingSetLink
+							(VariableNode "$X")
+							(EvaluationLink
+								(VariableNode "$D")
+								(ListLink
+									(VariableNode "$X")
+									(VariableNode "$C"))))))))))
+
+; -----------------------------------------------------------------------------
+; Member To Inheritance Formula
+; -----------------------------------------------------------------------------
+
+; -----------------------------------------------------------------------------
+; Side-effect: TruthValue of the new link stays the same
+; -----------------------------------------------------------------------------
+
+(define (pln-formula-member-to-inheritance IBXDXC BXDXC)
+	(cog-set-tv!
+		IBXDXC
+		(pln-formula-member-to-inheritance-side-effect-free
+			IBXDXC
+			BXDXC)))
+
+; -----------------------------------------------------------------------------
+; This version has no side effects and simply returns a TruthValue
+; -----------------------------------------------------------------------------
+
+(define (pln-formula-member-to-inheritance-side-effect-free IBXDXC BXDXC)
+	(stv
+		(cog-stv-strength BXDXC)
+		(cog-stv-confidence BXDXC)))
+
+; =============================================================================

--- a/opencog/reasoning/RuleEngine/rules/pln/member-to-inheritance.scm
+++ b/opencog/reasoning/RuleEngine/rules/pln/member-to-inheritance.scm
@@ -46,6 +46,6 @@
 (define (pln-formula-member-to-inheritance-side-effect-free IBC MBC)
 	(stv
 		(cog-stv-strength MBC)
-		(cog-stv-confidence MBC)))
+		(* (cog-stv-confidence MBC) 0.9)))
 
 ; =============================================================================

--- a/opencog/reasoning/RuleEngine/rules/pln/member-to-inheritance.scm
+++ b/opencog/reasoning/RuleEngine/rules/pln/member-to-inheritance.scm
@@ -1,52 +1,28 @@
 ; =============================================================================
 ; MemberToInheritanceRule
-;	MemberLink( B (SatisfyingSetLink ( Variable $X 
-;		(EvaluationLink (pred D (ListLink X C))))))
+;	MemberLink( B C )
 ;			becomes
-;	InheritanceLink( B (SatisfyingSetLink (Variable $X
-; 		(EvaluationLink (pred D (ListLink X C))))))
+;	InheritanceLink( B C )
 ; -----------------------------------------------------------------------------
 
 (define pln-rule-member-to-inheritance
 	(BindLink
 		(ListLink
 			(VariableNode "$B")
-			(VariableNode "$C")
-			(VariableNode "$D")
-			(TypedVariableLink
-				(VariableNode "$D")
-				(VariableTypeNode "PredicateNode")))
+			(VariableNode "$C"))
 		(ImplicationLink
 			(MemberLink
 				(VariableNode "$B")
-				(SatisfyingSetLink
-					(VariableNode "$X")
-					(EvaluationLink
-						(VariableNode "$D")
-						(ListLink
-							(VariableNode "$X")
-							(VariableNode "$C")))))
+				(VariableNode "$C"))
 			(ExecutionOutputLink
 				(GroundedSchemaNode "scm:pln-formula-member-to-inheritance")
 				(ListLink
 					(InheritanceLink
 						(VariableNode "$B")
-						(SatisfyingSetLink
-							(VariableNode "$X")
-							(EvaluationLink
-								(VariableNode "$D")
-								(ListLink
-									(VariableNode "$X")
-									(VariableNode "$C")))))
+						(VariableNode "$C"))
 					(MemberLink
 						(VariableNode "$B")
-						(SatisfyingSetLink
-							(VariableNode "$X")
-							(EvaluationLink
-								(VariableNode "$D")
-								(ListLink
-									(VariableNode "$X")
-									(VariableNode "$C"))))))))))
+						(VariableNode "$C")))))))
 
 ; -----------------------------------------------------------------------------
 ; Member To Inheritance Formula
@@ -56,20 +32,20 @@
 ; Side-effect: TruthValue of the new link stays the same
 ; -----------------------------------------------------------------------------
 
-(define (pln-formula-member-to-inheritance IBXDXC BXDXC)
+(define (pln-formula-member-to-inheritance IBC MBC)
 	(cog-set-tv!
-		IBXDXC
+		IBC
 		(pln-formula-member-to-inheritance-side-effect-free
-			IBXDXC
-			BXDXC)))
+			IBC
+			MBC)))
 
 ; -----------------------------------------------------------------------------
 ; This version has no side effects and simply returns a TruthValue
 ; -----------------------------------------------------------------------------
 
-(define (pln-formula-member-to-inheritance-side-effect-free IBXDXC BXDXC)
+(define (pln-formula-member-to-inheritance-side-effect-free IBC MBC)
 	(stv
-		(cog-stv-strength BXDXC)
-		(cog-stv-confidence BXDXC)))
+		(cog-stv-strength MBC)
+		(cog-stv-confidence MBC)))
 
 ; =============================================================================


### PR DESCRIPTION
Added 5 PLN rules:
1. Abduction Rule
2. Member To Evaluation Rule
3. Evaluation To Member Rule
4. Member To Inheritance Rule
5. Inheritance To Member Rule

With these five rules plus the deduction rule, the socrates assertions written in `socrates-r2l.scm` in the python PLN examples directory runs as expected.