### PR TITLE
SuReal: update test to not rely on nodes order

### DIFF
--- a/tests/nlp/sureal/SuRealUTest.cxxtest
+++ b/tests/nlp/sureal/SuRealUTest.cxxtest
@@ -223,12 +223,25 @@ void SuRealUTest::test_disconnected(void)
                          (PredicateNode "ran")
                          (ListLink (ConceptNode "he"))))))
                      )");
-    std::string result = _evaluator->eval(R"(
-                                          (equal? s-result
-                                                  (list (list "he" "ran" "slowly" "and" "she" "walked" "quickly" ".")
-                                                   (list "she" "walked" "slowly" "and" "he" "ran" "quickly" ".")))
-                                          )");
-    TSM_ASSERT("Failed to sureal on disconnected clauses!", result == "#t\n");
+
+    std::string result = _evaluator->eval("(equal? 2 (length s-result))");
+    TSM_ASSERT("Failed to get the correct number of realization!", result == "#t\n");
+
+    result = _evaluator->eval(R"(
+                              (not
+                               (equal?
+                                #f
+                                (member (list "he" "ran" "slowly" "and" "she" "walked" "quickly" ".") s-result)))
+                              )");
+    TSM_ASSERT("Failed to get the first expected result!", result == "#t\n");
+
+    result = _evaluator->eval(R"(
+                              (not
+                               (equal?
+                                #f
+                                (member (list "she" "walked" "slowly" "and" "he" "ran" "quickly" ".") s-result)))
+                              )");
+    TSM_ASSERT("Failed to get the second expected result!", result == "#t\n");
 
     logger().debug("END TEST: %s", __FUNCTION__);
 }


### PR DESCRIPTION
Recent changes make nodes order non-deterministic.  Changed test to handle that.