### PR TITLE
Added typdef octime_t for opencog/spacetime/

### DIFF
--- a/opencog/spacetime/SpaceServer.cc
+++ b/opencog/spacetime/SpaceServer.cc
@@ -482,7 +482,7 @@ Handle SpaceServer::getSpaceMapNode(std::string _mapName)
     return result;
 }*/
 /*
-bool SpaceServer::addSpaceInfo(Handle objectNode, unsigned long timestamp,
+bool SpaceServer::addSpaceInfo(Handle objectNode, octime_t timestamp,
                               int objX, int objY, int objZ,
                               int objLength, int objWidth, int objHeight,
                               double objYaw, bool isObstacle, const std::string& entityClass) {
@@ -496,7 +496,7 @@ bool SpaceServer::addSpaceInfo(Handle objectNode, unsigned long timestamp,
 }
 */
 
-bool SpaceServer::addSpaceInfo(Handle objectNode, bool isSelfObject, unsigned long timestamp,
+bool SpaceServer::addSpaceInfo(Handle objectNode, bool isSelfObject, octime_t timestamp,
                               int objX, int objY, int objZ,
                               int objLength, int objWidth, int objHeight,
                               double objYaw, bool isObstacle,  std::string entityClass, std::string objectName, std::string material)
@@ -527,7 +527,7 @@ bool SpaceServer::addSpaceInfo(Handle objectNode, bool isSelfObject, unsigned lo
     return true;
 }
 
-Handle SpaceServer::addOrGetSpaceMap(unsigned long timestamp, std::string _mapName, int _xMin, int _yMin, int _zMin,
+Handle SpaceServer::addOrGetSpaceMap(octime_t timestamp, std::string _mapName, int _xMin, int _yMin, int _zMin,
                                      int _xDim, int _yDim, int _zDim, int _floorHeight)
 {
     Handle spaceMapNode = atomspace->getHandle(SPACE_MAP_NODE,_mapName);
@@ -554,7 +554,7 @@ Handle SpaceServer::addOrGetSpaceMap(unsigned long timestamp, std::string _mapNa
     return spaceMapNode;
 }
 
-void SpaceServer::removeSpaceInfo(Handle objectNode, unsigned long timestamp)
+void SpaceServer::removeSpaceInfo(Handle objectNode, octime_t timestamp)
 {
     if (curSpaceMapHandle == Handle::UNDEFINED)
     {
@@ -652,7 +652,7 @@ std::string SpaceServer::mapToString(Handle mapHandle) const
 Handle SpaceServer::mapFromString(const std::string& stringMap)
 {
 /*
-    unsigned long timestamp;
+    octime_t timestamp;
     std::stringstream mapParser;
     {
         std::stringstream parser( stringMap );
@@ -717,7 +717,7 @@ void SpaceServer::addBlockEntityNodes(HandleSeq &toUpdateHandles)
 }
 
 // add blocklist to an entity
-void SpaceServer::addBlocksLisitPredicateToEntity(opencog::spatial::BlockEntity* _entity, const unsigned long timeStamp)
+void SpaceServer::addBlocksLisitPredicateToEntity(opencog::spatial::BlockEntity* _entity, const octime_t timeStamp)
 {
 
     //  Add every block a eval link that it's part of this block entity:
@@ -782,7 +782,7 @@ void SpaceServer::addBlocksLisitPredicateToEntity(opencog::spatial::BlockEntity*
 
 }
 
-void SpaceServer::updateBlockEntityProperties(opencog::spatial::BlockEntity* _entity, unsigned long timestamp)
+void SpaceServer::updateBlockEntityProperties(opencog::spatial::BlockEntity* _entity, octime_t timestamp)
 {
     addBlocksLisitPredicateToEntity(_entity, timestamp);
 
@@ -816,7 +816,7 @@ void SpaceServer::updateBlockEntityProperties(opencog::spatial::BlockEntity* _en
 
 }
 
-void SpaceServer::updateBlockEntitiesProperties(unsigned long timestamp,HandleSeq &toUpdateHandles)
+void SpaceServer::updateBlockEntitiesProperties(octime_t timestamp,HandleSeq &toUpdateHandles)
 {
     vector<opencog::spatial::BlockEntity*>::iterator it = curMap->updateBlockEntityList.begin();
     opencog::spatial::BlockEntity* entity;

--- a/opencog/spacetime/SpaceServer.h
+++ b/opencog/spacetime/SpaceServer.h
@@ -52,6 +52,7 @@
 #include <opencog/spatial/3DSpaceMap/BlockEntity.h>
 
 #include "SpaceServerContainer.h"
+#include "Temporal.h"
 
 namespace opencog
 {
@@ -126,14 +127,14 @@ public:
 
     // add create a new spaceMap for a new scene (it will create a new Octree3DMapMananger)
     // if there is already a spaceMap of this _mapName, just get it and set it to be the current map, not to created a new spaceMap
-    Handle addOrGetSpaceMap(unsigned long timestamp, std::string _mapName, int _xMin, int _yMin, int _zMin, int _xDim, int _yDim, int _zDim, int _floorHeight);
+    Handle addOrGetSpaceMap(octime_t timestamp, std::string _mapName, int _xMin, int _yMin, int _zMin, int _xDim, int _yDim, int _zDim, int _floorHeight);
 
-    bool addSpaceInfo(Handle objectNode, bool isSelfObject, unsigned long timestamp,
+    bool addSpaceInfo(Handle objectNode, bool isSelfObject, octime_t timestamp,
                       int objX, int objY, int objZ,
                       int objLength, int objWidth, int objHeight,
                       double objYaw, bool isObstacle,  std::string entityClass, std::string objectName, std::string material = "");
 
-    void removeSpaceInfo(Handle objectNode, unsigned long timestamp = 0);
+    void removeSpaceInfo(Handle objectNode, octime_t timestamp = 0);
 
     // SpaceServerContainer virtual methods:
     void mapRemoved(Handle mapId);
@@ -196,13 +197,13 @@ public:
     void addBlockEntityNodes(HandleSeq &toUpdateHandles);
 
     // add blocklist to an entity
-    void addBlocksLisitPredicateToEntity(opencog::spatial::BlockEntity* _entity, const unsigned long timeStamp);
+    void addBlocksLisitPredicateToEntity(opencog::spatial::BlockEntity* _entity, const octime_t timeStamp);
 
     // add properties predicate link to an entity node when there is a change
     // this including addBlocksLisitPredicateToEntity
-    void updateBlockEntityProperties(opencog::spatial::BlockEntity* entity, unsigned long timestamp);
+    void updateBlockEntityProperties(opencog::spatial::BlockEntity* entity, octime_t timestamp);
 
-    void updateBlockEntitiesProperties(unsigned long timestamp, HandleSeq &toUpdateHandles);
+    void updateBlockEntitiesProperties(octime_t timestamp, HandleSeq &toUpdateHandles);
 
     // input raw data to the learning server for blockEntities identification learning
     void sendRawAdjancentBlocksDataToLS();
@@ -311,7 +312,7 @@ private:
 //    typedef spatial::LocalSpaceMap2D SpaceMap;
 //    typedef spatial::ObjectMetaData ObjectMetadata;
 //    typedef std::map<Handle, SpaceMap*> HandleToSpaceMap;
-//    typedef std::pair<unsigned long, SpaceMap*> TimestampMap;
+//    typedef std::pair<octime_t, SpaceMap*> TimestampMap;
 
 //    typedef spatial::Octree3DMapManager SpaceMap3D;
 
@@ -455,7 +456,7 @@ private:
 //     * @param the remaining arguments are related to object's spatial information
 //     * @return true if any property of the object has changed (or it's a new object). False, otherwise.
 //     */
-//    bool addSpaceInfo(bool keepPreviousMap, Handle objectNode, unsigned long timestamp,
+//    bool addSpaceInfo(bool keepPreviousMap, Handle objectNode, octime_t timestamp,
 //                              double objX, double objY, double objZ,
 //                              double objLength, double objWidth, double objHeight,
 //                              double objYaw, bool isObstacle = true, const std::string& entityClass = "common");
@@ -464,7 +465,7 @@ private:
 //     * NOTE: This is just used when a whole space map is received
 //     * from a remote SpaceServer (in LearningServer, for instance).
 //     */
-//    Handle addSpaceMap(unsigned long timestamp, SpaceServer::SpaceMap * spaceMap);
+//    Handle addSpaceMap(octime_t timestamp, SpaceServer::SpaceMap * spaceMap);
 
 //    Handle getSpaceMapNode();
 
@@ -477,7 +478,7 @@ private:
 //     * @return handle of the atom that represents the SpaceMap (at the given
 //     * timestamp) where the object was removed
 //     */
-//    Handle removeSpaceInfo(bool keepPreviousMap, Handle objectNode, unsigned long timestamp);
+//    Handle removeSpaceInfo(bool keepPreviousMap, Handle objectNode, octime_t timestamp);
 
 //    /**
 //     * Remove old maps from SpaceServer in order to save memory. SpaceMaps

--- a/opencog/spacetime/Temporal.cc
+++ b/opencog/spacetime/Temporal.cc
@@ -51,7 +51,7 @@ std::ostream& operator<<(std::ostream& out, const Temporal& t)
 // USED TO SEEK MEMORY LEAK
 //int Temporal::numTemporals = 0;
 
-void Temporal::init(unsigned long a, unsigned long b, bool normal) throw (InvalidParamException)
+void Temporal::init(octime_t a, octime_t b, bool normal) throw (InvalidParamException)
 {
 
     // USED TO SEEK MEMORY LEAK
@@ -64,8 +64,8 @@ void Temporal::init(unsigned long a, unsigned long b, bool normal) throw (Invali
             throw InvalidParamException(TRACE_INFO,
                                         "Cannot create a Temporal (normal-distribution) with the variance (%lu) greater than the mean (%lu). This causes negative lower bound.", b,  a);
         }
-        unsigned long long sum = (unsigned long long) a + b;
-        if (sum > (unsigned long long) UINT_MAX) {
+        octime_t long sum = (octime_t long) a + b;
+        if (sum > (octime_t long) UINT_MAX) {
             throw InvalidParamException(TRACE_INFO,
                                         "Temporal - Upper bound reached when creating a Temporal (normal-distribution): %lu.", sum);
         }
@@ -96,12 +96,12 @@ const Temporal& Temporal::undefined_temporal()
     return instance;
 }
 
-Temporal::Temporal(unsigned long a, unsigned long b, bool normal)
+Temporal::Temporal(octime_t a, octime_t b, bool normal)
 {
     init(a, b, normal);
 }
 
-Temporal::Temporal(unsigned long timestamp)
+Temporal::Temporal(octime_t timestamp)
 {
     init(timestamp, timestamp, false);
 }
@@ -115,17 +115,17 @@ bool Temporal::isNormal() const
     return normal;
 }
 
-unsigned long Temporal::getA() const
+octime_t Temporal::getA() const
 {
     return a;
 }
 
-unsigned long Temporal::getB() const
+octime_t Temporal::getB() const
 {
     return b;
 }
 
-unsigned long Temporal::getLowerBound() const
+octime_t Temporal::getLowerBound() const
 {
     if (normal) {
         return (a - b);
@@ -134,7 +134,7 @@ unsigned long Temporal::getLowerBound() const
     }
 }
 
-unsigned long Temporal::getUpperBound() const
+octime_t Temporal::getUpperBound() const
 {
     if (normal) {
         return (a + b);
@@ -165,7 +165,7 @@ std::string Temporal::getTimeNodeName() const
     return buffer;
 }
 
-std::string Temporal::getTimeNodeName(unsigned long timestamp)
+std::string Temporal::getTimeNodeName(octime_t timestamp)
 {
     // NOTE: The strictly correct way to implement this would be like follows:
     //   return Temporal(timestamp).getTimeNodeName();
@@ -178,9 +178,9 @@ std::string Temporal::getTimeNodeName(unsigned long timestamp)
 Temporal Temporal::getFromTimeNodeName(const char* timeNodeName)
 {
     const char* nextToken = timeNodeName;
-    unsigned long a = (unsigned long) strtoul(nextToken,NULL,10);
+    octime_t a = (octime_t) strtoul(nextToken,NULL,10);
 
-    DPRINTF("Temporal::getFromTimeNodeName: %ld %lu %lu / %s\n", a, a, (unsigned long)atof(timeNodeName), timeNodeName);
+    DPRINTF("Temporal::getFromTimeNodeName: %ld %lu %lu / %s\n", a, a, (octime_t)atof(timeNodeName), timeNodeName);
 
     while (*nextToken && *nextToken != ':') {
         nextToken++;
@@ -188,7 +188,7 @@ Temporal Temporal::getFromTimeNodeName(const char* timeNodeName)
     if (!(*nextToken)) {
         return Temporal(a);
     }
-    unsigned long b = (unsigned long)strtoul(++nextToken,NULL,10);
+    octime_t b = (octime_t)strtoul(++nextToken,NULL,10);
 
     DPRINTF("Temporal::getFromTimeNodeName: %ld %lu / %s\n", b, b, nextToken);
 
@@ -204,14 +204,14 @@ Temporal Temporal::getFromTimeNodeName(const char* timeNodeName)
 
 int Temporal::compareTo(const Temporal* other) const
 {
-    unsigned long low1 = this->getLowerBound();
-    unsigned long low2 = other->getLowerBound();
+    octime_t low1 = this->getLowerBound();
+    octime_t low2 = other->getLowerBound();
     if(low1 < low2)
         return -1;
     else if(low2 < low1)
         return 1;
-    unsigned long up1 = this->getUpperBound();
-    unsigned long up2 = other->getUpperBound();
+    octime_t up1 = this->getUpperBound();
+    octime_t up2 = other->getUpperBound();
     if(up1 < up2)
         return -1;
     else if(up2 < up1)

--- a/opencog/spacetime/Temporal.h
+++ b/opencog/spacetime/Temporal.h
@@ -32,6 +32,8 @@
 #include <opencog/util/platform.h>
 #include <opencog/util/exceptions.h>
 
+typedef unsigned long octime_t;
+
 /** \addtogroup grp_spacetime
  *  @{
  */
@@ -47,7 +49,7 @@ private:
     /**
      * Initializes the attributes of this Temporal object. Used by constructors only.
      */
-    void init(unsigned long, unsigned long, bool) throw (InvalidParamException);
+    void init(octime_t, octime_t, bool) throw (InvalidParamException);
 
     /**
      * Creates a unique instance for UNDEFINED_TEMPORAL object
@@ -72,14 +74,14 @@ public:
      *   - a uniform distribution is used (normal argument is ommited or false) and "a" is greater than "b".
      *   - a normal distribution is used (normal argument is true) and "b" is greater than "a" (this causes negative value for the lower bound).
      */
-    Temporal(unsigned long, unsigned long, bool = false);
+    Temporal(octime_t, octime_t, bool = false);
 
     /**
      * Special constructor for timestamps only. Using this constructor passing a timestamp argument T is
      * equivalent to call the more comprehensive constructor passing as follows: Temporal(T,T,false).
      * @param timestamp The value of both lower and upper bounds, since this is a just time point.
      */
-    Temporal(unsigned long);
+    Temporal(octime_t);
 
     /**
      * Destructor
@@ -94,22 +96,22 @@ public:
     /**
      * @return The A attribute of this Temporal: If using normal distribution, the mean value. Otherwise, the lower bound value.
      */
-    unsigned long getA() const;
+    octime_t getA() const;
 
     /**
      * @return The B attribute of this Temporal: If using normal distribution, the variance value (mean +/- variance). Otherwise, the upper bound value.
      */
-    unsigned long getB() const;
+    octime_t getB() const;
 
     /**
      * @return the Lower bound of this Temporal object
      */
-    unsigned long getLowerBound() const;
+    octime_t getLowerBound() const;
 
     /**
      * @return the upper bound of this Temporal object
      */
-    unsigned long getUpperBound() const;
+    octime_t getUpperBound() const;
 
 
     /**
@@ -128,7 +130,7 @@ public:
     /**
      * Gets the name of the TimeNode that represents the given timestamp value
      */
-    static std::string getTimeNodeName(unsigned long);
+    static std::string getTimeNodeName(octime_t);
 
     /**
      * Gets the Temporal object that corresponds to the TimeNode with the given name.
@@ -167,14 +169,14 @@ public:
 
 private:
     bool normal;
-    unsigned long a;
-    unsigned long b;
+    octime_t a;
+    octime_t b;
 
 };
 
 struct hashTemporal {
     int operator()(Temporal* tl) const {
-        int hashCode =  boost::hash<unsigned long>()(tl->getA());
+        int hashCode =  boost::hash<octime_t>()(tl->getA());
         return(hashCode);
     }
 };

--- a/opencog/spacetime/TimeServer.cc
+++ b/opencog/spacetime/TimeServer.cc
@@ -86,7 +86,7 @@ bool TimeServer::remove(Handle h, const Temporal& t, TemporalTable::TemporalRela
     return table->remove(h, t, criterion);
 }
 
-unsigned long TimeServer::getLatestTimestamp() const
+octime_t TimeServer::getLatestTimestamp() const
 {
     std::unique_lock<std::mutex> lock(ts_mutex);
     return latestTimestamp;
@@ -111,7 +111,7 @@ void TimeServer::clear()
     init();
 }
 
-Handle TimeServer::addTimeInfo(Handle h, unsigned long timestamp, TruthValuePtr tv)
+Handle TimeServer::addTimeInfo(Handle h, octime_t timestamp, TruthValuePtr tv)
 {
     OC_ASSERT(atomspace->isValidHandle(h),
             "TimeServer::addTimeInfo: Got an invalid handle as argument\n");
@@ -142,7 +142,7 @@ Handle TimeServer::addTimeInfo(Handle h, const std::string& timeNodeName, TruthV
     return atTimeLink;
 }
 
-bool TimeServer::removeTimeInfo(Handle h, unsigned long timestamp, TemporalTable::TemporalRelationship criterion, bool removeDisconnectedTimeNodes, bool recursive)
+bool TimeServer::removeTimeInfo(Handle h, octime_t timestamp, TemporalTable::TemporalRelationship criterion, bool removeDisconnectedTimeNodes, bool recursive)
 {
     Temporal t(timestamp);
     return removeTimeInfo(h, t, criterion, removeDisconnectedTimeNodes, recursive);

--- a/opencog/spacetime/TimeServer.h
+++ b/opencog/spacetime/TimeServer.h
@@ -127,7 +127,7 @@ public:
     /**
      * Get the timestamp of the more recent upper bound of Temporal object already inserted into this TimeServer.
      */
-    unsigned long getLatestTimestamp() const;
+    octime_t getLatestTimestamp() const;
 
     void clear();
 
@@ -141,7 +141,7 @@ public:
      *
      * @return the Handle of the AtTimeLink added into AtomSpace.
      */
-    Handle addTimeInfo(Handle atom, unsigned long timestamp,
+    Handle addTimeInfo(Handle atom, octime_t timestamp,
                        TruthValuePtr tv = TruthValue::TRUE_TV());
 
     /**
@@ -211,7 +211,7 @@ public:
      *        mathing pair or any of them were not removed)
      */
     bool removeTimeInfo(Handle atom,
-                        unsigned long timestamp,
+                        octime_t timestamp,
                         TemporalTable::TemporalRelationship = TemporalTable::EXACT,
                         bool removeDisconnectedTimeNodes = true,
                         bool recursive = true);
@@ -318,7 +318,7 @@ public:
      */
     template<typename OutputIterator>
     OutputIterator getMapHandles(   OutputIterator outIt,
-                                    unsigned long startMoment, unsigned long endMoment) const
+                                    octime_t startMoment, octime_t endMoment) const
     {
         Temporal t(startMoment, endMoment);
         std::vector<HandleTemporalPair> pairs;
@@ -354,7 +354,7 @@ private:
     /**
      * The timestamp of the more recent upper bound of Temporal object already inserted into this TimeServer
      */
-    unsigned long latestTimestamp;
+    octime_t latestTimestamp;
 
     /**
      * Overrides and declares copy constructor and equals operator as private 


### PR DESCRIPTION
I added "typdef unsigned long octime_t;" to Temporal.h, and replaced every instance of unsigned long with octime_t in every file in opencog/spacetime. This was suggested by the quick tasks wiki page. The project still builds just fine, although I did not run any other tests.