### PR TITLE
redefined octime_t and fixed overflow check

### DIFF
--- a/opencog/spacetime/Temporal.cc
+++ b/opencog/spacetime/Temporal.cc
@@ -64,8 +64,9 @@ void Temporal::init(octime_t a, octime_t b, bool normal) throw (InvalidParamExce
             throw InvalidParamException(TRACE_INFO,
                                         "Cannot create a Temporal (normal-distribution) with the variance (%lu) greater than the mean (%lu). This causes negative lower bound.", b,  a);
         }
-        octime_t long sum = (octime_t long) a + b;
-        if (sum > (octime_t long) UINT_MAX) {
+        octime_t sum = a + b;
+        // if the addition caused an overflow
+        if (sum < a) {
             throw InvalidParamException(TRACE_INFO,
                                         "Temporal - Upper bound reached when creating a Temporal (normal-distribution): %lu.", sum);
         }

--- a/opencog/spacetime/Temporal.h
+++ b/opencog/spacetime/Temporal.h
@@ -32,7 +32,7 @@
 #include <opencog/util/platform.h>
 #include <opencog/util/exceptions.h>
 
-typedef unsigned long octime_t;
+typedef uint64_t octime_t;
 
 /** \addtogroup grp_spacetime
  *  @{


### PR DESCRIPTION
Now octime_t is defined as a uint64_t, and the overflow check should work perfectly. http://wiki.opencog.org/w/Quick_tasks#TimeServer should be removed.