### PR TITLE
Reasoning: More Rule class update

### DIFF
--- a/opencog/reasoning/RuleEngine/rule-engine-src/JsonicControlPolicyParamLoader.cc
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/JsonicControlPolicyParamLoader.cc
@@ -249,17 +249,7 @@ template<typename> void JsonicControlPolicyParamLoader::read_primitive(
  */
 void JsonicControlPolicyParamLoader::set_disjunct_rules(void)
 {
-    for (auto i = rule_mutex_map_.begin(); i != rule_mutex_map_.end(); ++i) {
-        auto mset = i->second;
-        auto cur_rule = i->first;
-        for (string name : mset) {
-            Rule* r = get_rule(name);
-            if (!r)
-                throw invalid_argument(
-                        "A rule by name " + name + " doesn't exist"); //TODO throw appropriate exception
-            cur_rule->add_disjunct_rule(r);
-        }
-    }
+
 }
 
 /**

--- a/opencog/reasoning/RuleEngine/rule-engine-src/Rule.cc
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/Rule.cc
@@ -21,6 +21,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <opencog/query/BindLink.h>
+
 #include "Rule.h"
 
 Rule::Rule(Handle rule)
@@ -61,20 +63,7 @@ string Rule::get_name()
 
 void Rule::set_handle(Handle h) throw (InvalidParamException)
 {
-	// rules must be defined in a BindLink for pattern matching
-	if (h->getType() != BIND_LINK)
-		throw InvalidParamException(TRACE_INFO, "Expected BindLink for rule.");
-
-	HandleSeq outgoing = LinkCast(h)->getOutgoingSet();
-
-	// check for the BindLink's implication
-	if (outgoing.size() != 2 || outgoing[1]->getType() != IMPLICATION_LINK)
-		throw InvalidParamException(TRACE_INFO, "Rule's BindLink missing ImplicationLink.");
-
-	outgoing = LinkCast(outgoing[1])->getOutgoingSet();
-
-	if (outgoing.size() != 2)
-		throw InvalidParamException(TRACE_INFO, "Rule's ImplicationLink structure incorrect.");
+	validate_bindlink(NULL, h);
 
 	rule_handle_ = h;
 }
@@ -91,6 +80,10 @@ Handle Rule::get_handle()
  */
 Handle Rule::get_implicant()
 {
+	// if the rule's handle has not been set yet
+	if (rule_handle_ == Handle::UNDEFINED)
+		return Handle::UNDEFINED;
+
 	HandleSeq outgoing = LinkCast(rule_handle_)->getOutgoingSet();
 
 	return LinkCast(outgoing[1])->getOutgoingSet()[0];
@@ -106,6 +99,10 @@ Handle Rule::get_implicant()
  */
 Handle Rule::get_implicand()
 {
+	// if the rule's handle has not been set yet
+	if (rule_handle_ == Handle::UNDEFINED)
+		return Handle::UNDEFINED;
+
 	HandleSeq outgoing = LinkCast(rule_handle_)->getOutgoingSet();
 
 	return LinkCast(outgoing[1])->getOutgoingSet()[1];

--- a/opencog/reasoning/RuleEngine/rule-engine-src/Rule.cc
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/Rule.cc
@@ -117,16 +117,6 @@ void Rule::set_cost(int p)
 	cost_ = p;
 }
 
-void Rule::add_disjunct_rule(Rule* r)
-{
-	disjunct_rules_.push_back(r);
-}
-
-vector<Rule*> Rule::get_disjunct_rules(void)
-{
-	return disjunct_rules_;
-}
-
 /**
  * Create a new rule where all variables are renamed.
  *
@@ -156,7 +146,7 @@ Rule Rule::standardize_apart()
  */
 Handle Rule::standardize_helper(const Handle h, std::map<Handle, Handle>& dict)
 {
-    if (LinkCast(h))
+	if (LinkCast(h))
 	{
 		HandleSeq old_outgoing = LinkCast(h)->getOutgoingSet();
 		HandleSeq new_outgoing;
@@ -167,9 +157,11 @@ Handle Rule::standardize_helper(const Handle h, std::map<Handle, Handle>& dict)
 		return Handle(createLink(h->getType(), new_outgoing, h->getTruthValue()));
 	}
 
+	// normal node does not need to be changed
 	if (h->getType() != VARIABLE_NODE)
 		return h;
 
+	// use existing mapping if the VariableNode is already mapped
 	if (dict.count(h) == 1)
 		return dict[h];
 

--- a/opencog/reasoning/RuleEngine/rule-engine-src/Rule.h
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/Rule.h
@@ -34,13 +34,6 @@ using namespace std;
  */
 class Rule
 {
-private:
-	Handle rule_handle_;
-	string name_;
-	string category_;
-	int cost_ = -1;
-	vector<Rule*> disjunct_rules_;
-
 public:
 	Rule(Handle rule);
 	virtual ~Rule();
@@ -72,5 +65,16 @@ public:
 	vector<Rule*> get_disjunct_rules(void);
 
 	void add_disjunct_rule(Rule* r);
+
+	Rule standardize_apart();
+
+private:
+	Handle rule_handle_;
+	string name_;
+	string category_;
+	int cost_;
+	vector<Rule*> disjunct_rules_;
+
+	Handle standardize_helper(Handle, std::map<Handle, Handle>&);
 };
 #endif /* RULE_H_ */

--- a/opencog/reasoning/RuleEngine/rule-engine-src/Rule.h
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/Rule.h
@@ -62,9 +62,6 @@ public:
 	Handle get_implicand();
 	string& get_category();
 	int get_cost();
-	vector<Rule*> get_disjunct_rules(void);
-
-	void add_disjunct_rule(Rule* r);
 
 	Rule standardize_apart();
 
@@ -73,7 +70,6 @@ private:
 	string name_;
 	string category_;
 	int cost_;
-	vector<Rule*> disjunct_rules_;
 
 	Handle standardize_helper(Handle, std::map<Handle, Handle>&);
 };

--- a/tests/reasoning/RuleEngine/JsonicControlPolicyParamLoaderUTest.cxxtest
+++ b/tests/reasoning/RuleEngine/JsonicControlPolicyParamLoaderUTest.cxxtest
@@ -38,10 +38,7 @@ void JsonicControlPolicyParamLoaderUTest::test_load_config() {
 	jcpl.load_config();
 	vector<Rule*> rules = jcpl.get_rules();
 	TS_ASSERT_EQUALS(1, rules.size());
-	for (Rule * r : rules) {
-		if (r->get_name() == "pln-rule-deduction")
-			TS_ASSERT(r->get_disjunct_rules().empty());
-	}
+	TS_ASSERT_EQUALS(rules[0]->get_name(), "pln-rule-deduction");
 	TS_ASSERT_EQUALS(false, jcpl.get_attention_alloc());
 	TS_ASSERT_EQUALS(20, jcpl.get_max_iter());
 }


### PR DESCRIPTION
I am doing more mini push to avoid conflict.

- Switched to validate_bindlink (I noticed that function has an unneeded AtomSpace argument...)
- Added another functionality I am using, which is to make a Rule generate a standardize apart version of itself.
- Removed the disjunct_rules_ vector of pointers to make Rule object copy safe (it is better to have another class handle that).

I noticed two Handle to the same NodePtr cannot be compared if they are not added to an AtomSpace yet (because Handle == only compare uuid, which is not set yet), so ended up having to bypass validate_bindlink for the standardize apart version.