### PR TITLE
fixed compile error in UseCountUTest.cxxtest :

### DIFF
--- a/tests/atomspace/UseCountUTest.cxxtest
+++ b/tests/atomspace/UseCountUTest.cxxtest
@@ -119,7 +119,7 @@ public:
             size_t isz = iset.size();
             // Don't do them all at once; thrash around a bit.
             // This wastes a lot of CPU, BTW.
-            isz = std::min(isz, 2010UL);  // thrash around
+            isz = std::min(isz, (size_t)2010);  // thrash around
             for (size_t i = 0; i < isz; i++) {
                 Handle n = iset[i]->getOutgoingAtom(1);
 


### PR DESCRIPTION
i was having a compile error while building tests:

`home/panty/Documents/dev/opencog/src/tests/atomspace/UseCountUTest.cxxtest:122:39: note:   deduced conflicting types for parameter ‘const _Tp’ (‘unsigned int’
 and ‘long unsigned int’)
             isz = std::min(isz, 2010UL);  // thrash around
                                       ^
In file included from /usr/include/c++/4.8/bits/char_traits.h:39:0,
                 from /usr/include/c++/4.8/ios:40,
                 from /usr/include/c++/4.8/istream:38,
                 from /usr/include/c++/4.8/sstream:38,
                 from /usr/include/c++/4.8/complex:45,
                 from /usr/include/cxxtest/StdHeaders.h:24,
                 from /usr/include/cxxtest/StdValueTraits.h:22,
                 from /usr/include/cxxtest/ValueTraits.h:400,
                 from /usr/include/cxxtest/TestSuite.h:24,
                 from /usr/include/cxxtest/RealDescriptions.h:20,
                 from /usr/include/cxxtest/TestRunner.h:22,
                 from /home/panty/Documents/dev/opencog/src/build/tests/atomspace/UseCountUTest.cpp:11:
/usr/include/c++/4.8/bits/stl_algobase.h:239:5: note: template<class _Tp, class _Compare> const _Tp& std::min(const _Tp&, const _Tp&, _Compare)
     min(const _Tp& __a, const _Tp& __b, _Compare __comp)`

i fixed it by being sure that std::min was comparing 2 ints of the same size.