### PR TITLE
Finished implementing config file loading for initialize_opencog Python binding

### DIFF
--- a/opencog/cython/opencog/Utilities.cc
+++ b/opencog/cython/opencog/Utilities.cc
@@ -11,17 +11,44 @@
 
 using namespace opencog;
 
+
 void opencog::initialize_opencog(AtomSpace* atomSpace, const char* configFile)
 {
+    std::string logFile;
+    std::string logLevelString;
+    Logger::Level logLevel;
+    std::string backtraceLevelString;
+    Logger::Level backtraceLevel;
+    bool logToStdOut;
+    
     // Load the config file if one was passed in.
     if (configFile)
-        Config().load(configFile);
+    {
+        // Load the config file.
+        config().load(configFile);
+
+        // Setup the logger to match the log settings from the Config file.
+        logFile = config()["LOG_FILE"];
+        logLevelString = config()["LOG_LEVEL"];
+        logLevel = Logger::getLevelFromString(logLevelString);
+        backtraceLevelString = config()["BACK_TRACE_LOG_LEVEL"];
+        backtraceLevel = Logger::getLevelFromString(backtraceLevelString);
+        logToStdOut = config().get_bool("LOG_TO_STDOUT");
+        logger().setFilename(logFile);
+        logger().setLevel(logLevel);
+        logger().setBackTraceLevel(backtraceLevel);
+        logger().setPrintToStdoutFlag(logToStdOut);
+
+        logger().debug("initialize_opencog - config file loaded");
+    }
 
     // Initialize Python.
+    logger().debug("initialize_opencog - initializing Python");
     global_python_initialize();
 
     // Tell the python evaluator to create its singleton instance
     // with our atomspace.
+    logger().debug("initialize_opencog - creating PythonEval singleton instance");
     PythonEval::create_singleton_instance(atomSpace);
 }
 

--- a/tests/cython/utilities/utilities.py
+++ b/tests/cython/utilities/utilities.py
@@ -15,7 +15,7 @@ scheme.__init__(atomspace)
 for scheme_file in scheme_preload:
     load_scm(atomspace, scheme_file)
 
-initialize_opencog(atomspace)
+initialize_opencog(atomspace, "utilities_test.conf")
 
 executed = False
 

--- a/tests/cython/utilities/utilities_test.conf
+++ b/tests/cython/utilities/utilities_test.conf
@@ -1,0 +1,15 @@
+#
+# This file defines configuration settings useful for a Python-script-based
+# OpenCog program that does not use or require a CogServer.
+#
+# Log to the same directory as the script.
+#
+LOG_FILE              = /tmp/utilities_test.log
+
+# Other possible log levels are "error", "warn", "info", "debug" and "fine"
+LOG_LEVEL             = info
+LOG_TO_STDOUT         = false
+
+# The functions in this directory will be loaded at startup for acccess by
+# Python code that runs via EvaluationLink or GroundedSchemaNode.
+PYTHON_PRELOAD_FUNCTIONS = /home/opencog/src/opencog/opencog/python/preload_functions


### PR DESCRIPTION
This one was a real pain given the simplicity of the actual task. I had Config().load instead of config().load and couldn't figure out why the code was executing but the changes weren't sticking.