### PR TITLE
Rename target by source in the context of the forward chainer

### DIFF
--- a/opencog/reasoning/RuleEngine/rule-engine-src/README.md
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/README.md
@@ -48,21 +48,21 @@ The implementation of the forward chainer is pretty straight forward.  The call 
 the do_chain method.  I have tried to use config files as a ways to declare what rules to use during the chaining process. The rules are read
 by `load_fc_conf` method. The current state of the code does the forward chaining algorithm stated in the wiki page.
  
-Below is a kind of pseudo code of the do_bc function
+Below is a kind of pseudo code of the do_chain function
 
-	do_chain(htarget)
-		hcurrent_target	
+	do_chain(hsource)
+		hcurrent_source	
 		steps = 0
 		while (steps <= ITERATION_SIZE /*or !terminate*/) 
 			if steps == 0
-				if htarget == Handle::UNDEFINED
-					hcurrent_target = choose_target_from_atomspace(main_atom_space); //start FC on a random target
+				if hsource == Handle::UNDEFINED
+					hcurrent_source = choose_source_from_atomspace(main_atom_space); //start FC on a random source
 				else
-					hcurrent_target = htarget;
+					hcurrent_source = hsource;
 	    	else 
-				if (!target_list_.empty())
-					hcurrent_target = choose_target_from_list(target_list_)
-			choose_input(hcurrent_target); //add more premise via pattern matching of related atoms to hcurrent_target
+				if (!source_list_.empty())
+					hcurrent_source = choose_source_from_list(source_list_)
+			choose_input(hcurrent_source); //add more premise via pattern matching of related atoms to hcurrent_source
 			choose_rule()
 			patternmatch(hcurrent_chosen_rule) // call the pattern matching with the chosen rule wrapped in a BindLink
 			steps++
@@ -77,7 +77,7 @@ Below is a kind of pseudo code of the do_bc function
 
 ####How to call the forward chainer from a scheme interface?####
 
-One can use the `cog-fc` scheme binding to start forward chaining on a particular target.
+One can use the `cog-fc` scheme binding to start forward chaining on a particular source.
 
 **Example**: suppose there is some knowledges about the ConceptNode Socrates then one can do a bunch of forward chaining inference
 by calling `(cog-fc (ConceptNode "Socrates"))` from a scheme shell or interfaces. All results of the inferences are returned in 

--- a/opencog/reasoning/RuleEngine/rule-engine-src/pln/DefaultForwardChainerCB.h
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/pln/DefaultForwardChainerCB.h
@@ -37,18 +37,18 @@ private:
     AtomSpace * as_;
     ForwardChainInputMatchCB* fcim_;
     ForwardChainPatternMatchCB* fcpm_;
-    HandleSeq get_rootlinks(Handle htarget, AtomSpace* as, Type link_type,
+    HandleSeq get_rootlinks(Handle hsource, AtomSpace* as, Type link_type,
     bool subclasses = false);
-    target_selection_mode ts_mode_;
+    source_selection_mode ts_mode_;
 public:
-    DefaultForwardChainerCB(AtomSpace* as, target_selection_mode ts_mode =
+    DefaultForwardChainerCB(AtomSpace* as, source_selection_mode ts_mode =
             TV_FITNESS_BASED);
     virtual ~DefaultForwardChainerCB();
 
     //callbacks
     virtual vector<Rule*> choose_rule(FCMemory& fcmem);
     virtual HandleSeq choose_premises(FCMemory& fcmem);
-    virtual Handle choose_next_target(FCMemory& fcmem);
+    virtual Handle choose_next_source(FCMemory& fcmem);
     virtual HandleSeq apply_rule(FCMemory& fcmem);
 };
 

--- a/opencog/reasoning/RuleEngine/rule-engine-src/pln/FCMemory.cc
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/pln/FCMemory.cc
@@ -49,14 +49,14 @@ void FCMemory::set_rules(vector<Rule*> rules)
 {
     rules_ = rules;
 }
-void FCMemory::set_target(Handle target)
+void FCMemory::set_source(Handle source)
 {
-    cur_target_ = target;
-    target_list_.push_back(cur_target_);
+    cur_source_ = source;
+    source_list_.push_back(cur_source_);
 }
-HandleSeq FCMemory::get_target_list(void)
+HandleSeq FCMemory::get_source_list(void)
 {
-    return target_list_;
+    return source_list_;
 }
 HandleSeq FCMemory::get_premise_list(void)
 {
@@ -96,13 +96,13 @@ void FCMemory::add_inference(int iter_step, HandleSeq product,
         inf.matched_nodes.push_back(mn);
     inf_history_.push_back(inf);
 }
-Handle FCMemory::get_cur_target(void)
+Handle FCMemory::get_cur_source(void)
 {
-    return cur_target_;
+    return cur_source_;
 }
-bool FCMemory::isin_target_list(Handle h)
+bool FCMemory::isin_source_list(Handle h)
 {
-    return (find(target_list_.begin(), target_list_.end(), h) != target_list_.end());
+    return (find(source_list_.begin(), source_list_.end(), h) != source_list_.end());
 }
 bool FCMemory::isin_premise_list(Handle h)
 {

--- a/opencog/reasoning/RuleEngine/rule-engine-src/pln/FCMemory.h
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/pln/FCMemory.h
@@ -41,10 +41,10 @@ private:
     friend class ForwardChainer; /*<allow access to private*/
     bool search_in_af_;
     vector<Rule*> rules_; /*<loaded rules*/
-    HandleSeq target_list_; /*<selected targets on each forward chaining steps*/
+    HandleSeq source_list_; /*<selected sources on each forward chaining steps*/
     HandleSeq premise_list_; /*<list of premises*/
     Rule* cur_rule_;
-    Handle cur_target_;
+    Handle cur_source_;
     vector<Inference> inf_history_; /*<inference history*/
     AtomSpace* as_;
 public:
@@ -52,8 +52,8 @@ public:
     ~FCMemory();
     vector<Rule*> get_rules(void);
     void set_rules(vector<Rule*> rules);
-    void set_target(Handle target);
-    HandleSeq get_target_list(void);
+    void set_source(Handle source);
+    HandleSeq get_source_list(void);
     HandleSeq get_premise_list(void);
     void update_premise_list(HandleSeq input);
     bool is_search_in_af(void);
@@ -62,8 +62,8 @@ public:
     void set_cur_rule(Rule* r);
     void add_inference(int iteration, HandleSeq product,
                        HandleSeq matched_nodes);
-    Handle get_cur_target(void);
-    bool isin_target_list(Handle h);
+    Handle get_cur_source(void);
+    bool isin_source_list(Handle h);
     bool isin_premise_list(Handle h);
     HandleSeq get_result(void);
     vector<Inference>& get_inf_history(void);

--- a/opencog/reasoning/RuleEngine/rule-engine-src/pln/ForwardChainInputMatchCB.h
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/pln/ForwardChainInputMatchCB.h
@@ -34,9 +34,9 @@ private:
 	HandleSeq _input_match;
 public:
 	/**
-	 * @param main_as the main atomspace where initial target is fetched from
-	 * @param target_list_as the chaining specific atomspace where targets is copied from the main atomspace
-	 *  where PLN rules are applied on target lists for new knowledge discovery.
+	 * @param main_as the main atomspace where initial source is fetched from
+	 * @param source_list_as the chaining specific atomspace where sources is copied from the main atomspace
+	 *  where PLN rules are applied on source lists for new knowledge discovery.
 	 *
 	 *  one can set the above two pointers to  the same atomspace object (wich now is the default way)
 	 *  if there is no intention of chaining in a separate atomspace.

--- a/opencog/reasoning/RuleEngine/rule-engine-src/pln/ForwardChainPatternMatchCB.h
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/pln/ForwardChainPatternMatchCB.h
@@ -40,12 +40,12 @@ public:
 	virtual ~ForwardChainPatternMatchCB();
 	HandleSeq get_products(void);
 	void set_fcmem(FCMemory *fcmem);
-	//the follwing callbacks are used for guiding the PM to look only the target list
+	//the follwing callbacks are used for guiding the PM to look only the source list
 	bool node_match(Handle& node1, Handle& node2);
 	bool link_match(LinkPtr& lpat, LinkPtr& lsoln);
 
 	/**
-	 * A callback handler of the Pattern matcher used to store references to new conclusion the target list
+	 * A callback handler of the Pattern matcher used to store references to new conclusion the source list
 	 */
 	bool grounding(const std::map<Handle, Handle> &var_soln,
 				const std::map<Handle, Handle> &pred_soln);

--- a/opencog/reasoning/RuleEngine/rule-engine-src/pln/ForwardChainer.h
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/pln/ForwardChainer.h
@@ -45,21 +45,23 @@ private:
     void init();
     //TODO this is duplicate method
     /**
-     * choose a random target to start forward chaining with. This is useful when there is no target
-     * specified ahead to the forward chaining process.
-     * @param as - the atomspace instance from which target is selected
+     * choose a random source to start forward chaining with. This is
+     * useful when there is no source specified ahead to the forward
+     * chaining process.
+     *
+     * @param as - the atomspace instance from which source is selected
      */
-    Handle choose_random_target(AtomSpace *);
-    void add_to_target_list(Handle h);
-    void init_target(Handle target);
+    Handle choose_random_source(AtomSpace *);
+    void add_to_source_list(Handle h);
+    void init_source(Handle source);
 protected:
-    enum target_selection_mode {
+    enum source_selection_mode {
         TV_FITNESS_BASED,STI_BASED
     };
 public:
     ForwardChainer(AtomSpace * as, string conf_path = "");
     virtual ~ForwardChainer();
-    void do_chain(ForwardChainerCallBack& fcb, Handle htarget =
+    void do_chain(ForwardChainerCallBack& fcb, Handle hsource =
             Handle::UNDEFINED);
     HandleSeq get_chaining_result(void);
 

--- a/opencog/reasoning/RuleEngine/rule-engine-src/pln/ForwardChainerCallBack.h
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/pln/ForwardChainerCallBack.h
@@ -29,7 +29,7 @@
 
 namespace opencog {
 
-enum target_selection_mode {
+enum source_selection_mode {
     TV_FITNESS_BASED, STI_BASED
 };
 
@@ -48,21 +48,21 @@ public:
     }
     /**
      * given a set of rules,choose next rule to be applied based on
-     * target matching rule premises,fitness evaluation,weight of rule in the current context...etc
+     * source matching rule premises,fitness evaluation,weight of rule in the current context...etc
      */
     virtual std::vector<Rule*> choose_rule(FCMemory& fcmem) = 0;
     /**
      * Choose additional premises to the chainer based on fitness
      * evaluation in the focus set.
      * @return a set of Handles chosen as a result of applying fitness
-     * criteria with respect to the current target.
+     * criteria with respect to the current source.
      */
     virtual HandleSeq choose_premises(FCMemory& fcmem) = 0;
     /**
-     * choose next target from the target list
-     * @return a handle to the chosen target from target list
+     * choose next source from the source list
+     * @return a handle to the chosen source from source list
      */
-    virtual Handle choose_next_target(FCMemory& fcmem) = 0;
+    virtual Handle choose_next_source(FCMemory& fcmem) = 0;
     /**
      * apply chosen rule. the default will wrap a custom PM callback class.
      * i.e invokes _pattern_matcher.

--- a/opencog/reasoning/RuleEngine/rule-engine-src/pln/PLNCommons.cc
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/pln/PLNCommons.cc
@@ -237,7 +237,7 @@ void PLNCommons::get_root_links(Handle h, HandleSeq& parents)
     }
 }
 
-float PLNCommons::target_tv_fitness(Handle h)
+float PLNCommons::tv_fitness(Handle h)
 {
     TruthValuePtr ptv = as_->getTV(h);
     confidence_t c = ptv->getConfidence();

--- a/opencog/reasoning/RuleEngine/rule-engine-src/pln/PLNCommons.h
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/pln/PLNCommons.h
@@ -123,12 +123,17 @@ public:
 		return hbest;
 	}
 	/**
-	 * calculates fitness values in target_list_atom_space using the formula F = s^x * c^(2-x)
+	 * Calculates fitness values in source_list_atom_space (or
+	 * target_list_atom_space for the BC) using the formula
+	 *
+	 * F = s^x * c^(2-x)
+	 *
 	 * where s is strength,c is confidence and x is some fixed value
+	 *
 	 * @param h - a handle
 	 * @return a fitness value
 	 */
-	float target_tv_fitness(Handle h);
+	float tv_fitness(Handle h);
 };
 
 #endif /* PLNCOMMONS_H_ */

--- a/tests/reasoning/RuleEngine/DefaultForwardChainerCBUTest.cxxtest
+++ b/tests/reasoning/RuleEngine/DefaultForwardChainerCBUTest.cxxtest
@@ -38,7 +38,7 @@ public:
 	void setUp(void);
 	void tearDown(void);
 	void test_choose_rule(void);
-	void test_choose_target(void);
+	void test_choose_source(void);
 };
 
 void DefaultForwardChainerCBUTest::setUp() {}
@@ -69,15 +69,15 @@ void DefaultForwardChainerCBUTest::test_choose_rule(void)
 	TS_ASSERT_DIFFERS(it, bindlinks.end());*/
 }
 
-void DefaultForwardChainerCBUTest::test_choose_target(void)
+void DefaultForwardChainerCBUTest::test_choose_source(void)
 {
 	 config().set("SCM_PRELOAD",
 		"tests/reasoning/RuleEngine/simple-assertions.scm");
 	 load_scm_files_from_config(*as);
 
-	 Handle target = eval->eval_h("(ConceptNode \"Einstein\")");
+	 Handle source = eval->eval_h("(ConceptNode \"Einstein\")");
 	 FCMemory fcmem(as);
-	 fcmem.set_target(target);
+	 fcmem.set_source(source);
 	 DefaultForwardChainerCB dfcb(as);
 	 HandleSeq hs = dfcb.choose_premises(fcmem);
 	 TS_ASSERT(5 == hs.size());


### PR DESCRIPTION
I found the use of target in the FC code very counter intuitive.