### PR TITLE
Simplify get neighbors

### DIFF
--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -510,18 +510,19 @@ public:
     }
 
     /**
-     * Returns neighboring atoms, following links and returning their
-     * target sets.
+     * Returns neighboring atoms, following incoming links and
+     * returning their outgoing sets.
+     *
      * @param h Get neighbours for the atom this handle points to.
-     * @param fanin Whether directional links point to this node should be
-     * considered.
-     * @param fanout Whether directional links point from this node to
-     * another should be considered.
+     * @param fanin Whether directional (ordered) links point to this
+     *              node should beconsidered.
+     * @param fanout Whether directional (ordered) links point from this
+     *               node to another should be considered.
      * @param linkType Follow only these types of links.
      * @param subClasses Follow subtypes of linkType too.
      */
     HandleSeq getNeighbors(const Handle& h, bool fanin, bool fanout,
-            Type linkType=LINK, bool subClasses=true) const
+                           Type linkType=LINK, bool subClasses=true) const
     {
         return getImplconst().getNeighbors(h, fanin, fanout, linkType, subClasses);
     }

--- a/opencog/atomspace/AtomSpaceImpl.cc
+++ b/opencog/atomspace/AtomSpaceImpl.cc
@@ -312,7 +312,8 @@ Handle AtomSpaceImpl::fetchIncomingSet(Handle h, bool recursive)
 }
 
 HandleSeq AtomSpaceImpl::getNeighbors(Handle h, bool fanin,
-        bool fanout, Type desiredLinkType, bool subClasses) const
+                                      bool fanout, Type desiredLinkType,
+                                      bool subClasses) const
 {
     if (h == NULL) {
         throw InvalidParamException(TRACE_INFO,
@@ -320,18 +321,14 @@ HandleSeq AtomSpaceImpl::getNeighbors(Handle h, bool fanin,
     }
     HandleSeq answer;
 
-    HandleSeq iset;
-    h->getIncomingSet(back_inserter(iset));
-    for (HandleSeq::iterator it = iset.begin();
-         it != iset.end(); ++it)
+    for (const LinkPtr& link : h->getIncomingSet())
     {
-        LinkPtr link(LinkCast(*it));
         Type linkType = link->getType();
-        DPRINTF("Atom::getNeighbors(): linkType = %d desiredLinkType = %d\n", linkType, desiredLinkType);
-        if ((linkType == desiredLinkType) || (subClasses && classserver().isA(linkType, desiredLinkType))) {
-            Arity linkArity = link->getArity();
-            for (Arity i = 0; i < linkArity; i++) {
-                Handle handle(link->getOutgoingSet()[i]);
+        DPRINTF("Atom::getNeighbors(): linkType = %d desiredLinkType = %d\n",
+                linkType, desiredLinkType);
+        if ((linkType == desiredLinkType)
+            || (subClasses && classserver().isA(linkType, desiredLinkType))) {
+            for (const Handle& handle : link->getOutgoingSet()) {
                 if (handle == h) continue;
                 if (!fanout && link->isSource(h)) continue;
                 if (!fanin && link->isTarget(h)) continue;

--- a/opencog/atomspace/AtomSpaceImpl.h
+++ b/opencog/atomspace/AtomSpaceImpl.h
@@ -182,18 +182,19 @@ public:
     HandleSeq getIncoming(Handle);
 
     /**
-     * Returns neighboring atoms, following links and returning their
-     * target sets.
+     * Returns neighboring atoms, following incoming links and
+     * returning their outgoing sets.
+     *
      * @param h Get neighbours for the atom this handle points to.
-     * @param fanin Whether directional links point to this node should be
-     * considered.
-     * @param fanout Whether directional links point from this node to
-     * another should be considered.
+     * @param fanin Whether directional (ordered) links point to this
+     *              node should beconsidered.
+     * @param fanout Whether directional (ordered) links point from this
+     *               node to another should be considered.
      * @param linkType Follow only these types of links.
      * @param subClasses Follow subtypes of linkType too.
      */
     HandleSeq getNeighbors(Handle h, bool fanin=true, bool fanout=true,
-            Type linkType=LINK, bool subClasses=true) const;
+                           Type linkType=LINK, bool subClasses=true) const;
 
     /**
      * Purges an atom from the atomtable. Attached storage is not

--- a/opencog/atomspace/Link.cc
+++ b/opencog/atomspace/Link.cc
@@ -123,7 +123,7 @@ bool Link::isSource(Handle handle) const throw (InvalidParamException)
     if (classserver().isA(_type, ORDERED_LINK)) {
         return arity > 0 && _outgoing[0] == handle;
     } else if (classserver().isA(_type, UNORDERED_LINK)) {
-        // if the links is unordered, the outgoing set is scanned, and the
+        // If the link is unordered, the outgoing set is scanned, and the
         // method returns true if any position is equal to the handle given.
         for (Arity i = 0; i < arity; i++) {
             if (_outgoing[i] == handle) {
@@ -159,7 +159,7 @@ bool Link::isSource(size_t i) const throw (IndexErrorException, InvalidParamExce
 
 bool Link::isTarget(Handle handle) const throw (InvalidParamException)
 {
-    // on ordered links, the first position of the outgoing set defines the
+    // On ordered links, the first position of the outgoing set defines the
     // source of the link. The other positions are targets. So, it scans the
     // outgoing set from the second position searching for the given handle. If
     // it is found, true is returned.
@@ -172,7 +172,7 @@ bool Link::isTarget(Handle handle) const throw (InvalidParamException)
         }
         return false;
     } else if (classserver().isA(_type, UNORDERED_LINK)) {
-        // if the links is unordered, all the outgoing set is scanned.
+        // If the links is unordered, all the outgoing set is scanned.
         for (Arity i = 0; i < arity; i++) {
             if (_outgoing[i] == handle) {
                 return true;

--- a/opencog/reasoning/RuleEngine/rule-engine-src/pln/DefaultForwardChainerCB.cc
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/pln/DefaultForwardChainerCB.cc
@@ -170,10 +170,10 @@ HandleSeq DefaultForwardChainerCB::choose_premises(FCMemory& fcmem)
     PLNCommons pc(as_);
     Handle hsource = fcmem.get_cur_source();
 
-    //Get everything associated with the source handle.
+    // Get everything associated with the source handle.
     HandleSeq neighbors = as_->getNeighbors(hsource, true, true, LINK, true);
 
-    //Add all root links of atoms in @param neighbors.
+    // Add all root links of atoms in @param neighbors.
     for (auto hn : neighbors) {
         if (hn->getType() != VARIABLE_NODE) {
             HandleSeq roots;


### PR DESCRIPTION
AtomSpace::getNeighbors is not really doing what I thought. It is only considering neighbors connected via the incoming set of an atom. I've corrected the comment.

There are a few places relying on it, I wonder if they assume the right thing. In particular the forward chainer would want a more neighbors, not just those connected via the incoming set...