### PR TITLE
Added Python generator / yield-based iterators

### DIFF
--- a/opencog/benchmark/benchmark.py
+++ b/opencog/benchmark/benchmark.py
@@ -426,8 +426,7 @@ tests = [
 (['traverse','spread'],     prep_traverse_100K, test_resolve_traversal,     "Resolve Handle 100K - by type"),
 (['traverse'],              prep_traverse_1M,   test_resolve_traversal,     "Resolve Handle 1M - by type"),
 
-
-(['all'],                   None,               None,                       "-- Testing Atom Traversal --"),
+(['all'],                   None,               None,                       "-- Testing Get versus Yield-based Get --"),
 (['get_vs_xget'],           prep_get_100K,      test_get_traverse,          "Get and Traverse 100K - by type"),
 (['get_vs_xget'],           prep_get_100K,      test_xget_traverse,         "Yield Get and Traverse 100K - by type"),
 (['get_vs_xget'],           prep_get_outgoing,  test_get_outgoing,          "Get Outgoing"),


### PR DESCRIPTION
Benchmark comparisons:
```
--- OpenCog Python Benchmark -  2015-03-26 22:17:40.612604 ---

Test                                        Time per op  Ops per second
----                                        -----------  --------------
Get and Traverse 100K - by type                 0.630µs       1,586,687
Yield Get and Traverse 100K - by type           0.437µs       2,289,869
Get Outgoing                                    1.123µs         890,800
Get Outgoing - no temporary list                1.115µs         896,912
Yield Get Outgoing                              0.906µs       1,103,800
```