### PR TITLE
AtomTable: Added a test triggering a bug

### DIFF
--- a/tests/atomspace/AtomTableUTest.cxxtest
+++ b/tests/atomspace/AtomTableUTest.cxxtest
@@ -235,6 +235,17 @@ public:
         Handle hl1 = table->add(l1, false);
 
         table->extract(hn1, true);
+
+        // 2nd part of the same test
+        Handle h3(createNode(CONCEPT_NODE, "3"));
+        os.clear();
+        os.push_back(h3);
+        os.push_back(h3);
+
+        Handle l33 = table->add(createLink(LIST_LINK, os), false);
+        LinkPtr lptr33(LinkCast(l33));
+        HandleSeq hs = lptr33->getOutgoingSet();
+        TS_ASSERT_EQUALS(hs[0], hs[1]);
     }
 
     void testSimpleWithCustomAtomTypes()


### PR DESCRIPTION
Bug report and pull request at the same time.

**The bug:**
  1. Create a node and add it to a link twice, then add the link to the atomtable.
  2. The resulting link contains two handles that are not equal (even though doing ->toShortString() print the same UUID).

**What else I noticed:**

Changing "ConceptNode" to "NumberNode" magically makes this bug go away.  Whatever the AtomTable is doing for NumberNode is more correct than for other nodes.