### PR TITLE
PLN  module for interacting with  ECAN.

### DIFF
--- a/lib/opencog.conf
+++ b/lib/opencog.conf
@@ -48,10 +48,11 @@ MODULES               = opencog/server/libbuiltinreqs.so,
                         opencog/embodiment/AtomSpaceExtensions/libembodiment-types.so,
                         opencog/embodiment/AtomSpaceExtensions/libAtomSpaceExtensions.so,
                         opencog/cython/libPythonModule.so,
-                        opencog/reasoning/RuleEngine/rule-engine-src/libRuleEngineModule.so
+                        opencog/reasoning/RuleEngine/rule-engine-src/libRuleEngineModule.so                        
 
 # Optional modules, not enabled by default
 #                        opencog/benchmark/module/libbenchmark.so,
+#                        opencog/reasoning/RuleEngine/rule-engine-src/libplnmodule.so
 #                        opencog/persist/zmq/events/libatomspacepublishermodule.so
 #                        opencog/dynamics/attention/libhebbiancreation.so
 #                        opencog/learning/dimensionalembedding/libdimensionalembedding.so
@@ -134,4 +135,7 @@ SENSE_SIMILARITY_DB_PASSWD        = "asdf"
 ZMQ_EVENT_USE_PUBLIC_IP = TRUE
 ZMQ_EVENT_PORT = 5563
 
-
+# Parameters for RuleEngine
+# RULE_ENGINE_TRIGGERED_ON = [1 ,2 ,3]
+# 1-when atom added 2-when atom enters to AF 3-both on 1 and 2
+RULE_ENGINE_TRIGGERED_ON = 1

--- a/opencog/reasoning/RuleEngine/rule-engine-src/CMakeLists.txt
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/CMakeLists.txt
@@ -8,7 +8,7 @@ ADD_LIBRARY(ruleengine SHARED
 	pln/ForwardChainPatternMatchCB.cc
 	pln/ForwardChainerCallBack.h
 	pln/DefaultForwardChainerCB.cc
-	pln/FCMemory.cc
+	pln/FCMemory.cc	
 	RuleEngineModule.cc
 	InferenceSCM.cc
 	Rule.cc
@@ -34,6 +34,30 @@ ADD_LIBRARY(RuleEngineModule SHARED
 )
 
 TARGET_LINK_LIBRARIES(RuleEngineModule ruleengine server)
+
+
+# PLNModule
+IF (TBB_FOUND)
+	INCLUDE_DIRECTORIES (
+		${TBB_INCLUDE_DIR}
+	)
+
+	LINK_DIRECTORIES(
+		${TBB_INCLUDE_DIR}
+		${TBB_LIBRARY_DIRS}
+	)
+
+	ADD_LIBRARY(plnmodule SHARED
+		pln/PLNModule.cc
+	)
+
+	TARGET_LINK_LIBRARIES(plnmodule
+		server
+		tbb
+		ruleengine
+	)
+ENDIF (TBB_FOUND)
+
 
 IF (WIN32)
    INSTALL (TARGETS query DESTINATION "lib${LIB_DIR_SUFFIX}/opencog")

--- a/opencog/reasoning/RuleEngine/rule-engine-src/pln/PLNModule.cc
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/pln/PLNModule.cc
@@ -1,0 +1,131 @@
+/*
+ * PLNModule.cc
+ *
+ * Copyright (C) 2015 by OpenCog Foundation
+ * Written by Misgana Bayetta <misgana.bayetta@gmail.com>
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include <opencog/server/CogServer.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <tbb/task.h>
+#include <opencog/util/tbb.h>
+#include <opencog/util/Config.h>
+#include "PLNModule.h"
+#include "DefaultForwardChainerCB.h"
+#include "ForwardChainer.h"
+
+using namespace opencog;
+
+DECLARE_MODULE(PLNModule);
+
+PLNModule::PLNModule(CogServer& cs) :
+        Module(cs)
+{
+    as_ = &cs.getAtomSpace();
+
+    enum StartingCondition {
+        ATOM_ADDED = 1, ADDED_TO_AF, BOTH
+    };
+    StartingCondition cond = static_cast<StartingCondition>(config().get_int(
+            "RULE_ENGINE_TRIGGERED_ON"));
+
+    switch (cond) {
+    case ATOM_ADDED:
+        add_atom_connection_ = as_->addAtomSignal(
+                boost::bind(&PLNModule::add_atom_signal, this, _1));
+        logger().info("Listening on ATOM_ADDED event.");
+        break;
+    case ADDED_TO_AF:
+        add_af_connection_ = as_->AddAFSignal(
+                boost::bind(&PLNModule::add_af_signal, this, _1, _2, _3));
+        logger().info("Listening on ADDED_TO_AF event.");
+        break;
+    case BOTH:
+        add_atom_connection_ = as_->addAtomSignal(
+                boost::bind(&PLNModule::add_atom_signal, this, _1));
+        add_af_connection_ = as_->AddAFSignal(
+                boost::bind(&PLNModule::add_af_signal, this, _1, _2, _3));
+        logger().info("Listening on BOTH(ATOM_ADDED and ADDED_TO_AF) event.");
+        break;
+    default:
+        break;
+    }
+}
+
+PLNModule::~PLNModule()
+{
+    logger().info("Destroying PLNModule instance.");
+    add_atom_connection_.disconnect();
+    add_af_connection_.disconnect();
+}
+
+void PLNModule::run()
+{
+
+}
+
+void PLNModule::init()
+{
+    logger().info("Initializing PLNModule.");
+}
+/*
+ * Create a task to handle the add_af_signal_handler event to avoid blocking.
+ */
+void PLNModule::add_af_signal(const Handle& source,
+                              const AttentionValuePtr& av_old,
+                              const AttentionValuePtr& av_new)
+{
+    tbb_enqueue_lambda([=] {
+        add_af_signal_handler(source, av_old, av_new);
+    });
+}
+
+/**
+ * Whenever an atom enters in to the attentional focus,  start PLN reasoning.
+ * This can be seen as a reactive(event-condition-action) type of rule engine
+ * scenario.
+ */
+void PLNModule::add_af_signal_handler(const Handle& h,
+                                      const AttentionValuePtr& av_old,
+                                      const AttentionValuePtr& av_new)
+{
+    //!start the chainer xxx more code here
+    DefaultForwardChainerCB dfcb(as_);
+    ForwardChainer fc(as_);
+    fc.do_chain(dfcb, h);
+}
+/*
+ * Create a task to handle the add_atom_signal_handler event to avoid blocking.
+ */
+void PLNModule::add_atom_signal(const Handle& new_atom)
+{
+    tbb_enqueue_lambda([=] {
+        add_atom_signal_handler(new_atom);
+    });
+}
+
+/**
+ * Whenever a new atom is added, start PLN reasoning.
+ */
+void PLNModule::add_atom_signal_handler(const Handle& h)
+{
+    //!Start the chainer xxx more code here/
+    DefaultForwardChainerCB dfcb(as_);
+    ForwardChainer fc(as_);
+    fc.do_chain(dfcb, h);
+}

--- a/opencog/reasoning/RuleEngine/rule-engine-src/pln/PLNModule.h
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/pln/PLNModule.h
@@ -1,0 +1,63 @@
+/*
+ * PLNModule.h
+ *
+ * Copyright (C) 2015 by OpenCog Foundation
+ * Written by Misgana Bayetta <misgana.bayetta@gmail.com>
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef PLNAGENT_H_
+#define PLNAGENT_H_
+
+#include <opencog/server/Module.h>
+
+namespace opencog
+{
+/**
+ * PLN module for backward and forward chaining triggered by atomspace events.
+ * Whenever atoms are created or enter to the attentional focus, the rule engine
+ * forward/backward chainer will be triggered (Reactive rule engine ).Having this
+ * functionality will also help us experiment with the dynamics of ECAN together
+ * with PLN reasoning.
+ */
+class CogServer;
+class AtomSpace;
+class PLNModule: public Module {
+private:
+    AtomSpace * as_;
+    boost::signals2::connection add_af_connection_; //!atom entering to AF
+    boost::signals2::connection add_atom_connection_; //!atom creation
+public:
+    PLNModule(CogServer&);
+    virtual ~PLNModule();
+    virtual void run();
+    const char * id(void);
+    virtual void init(void);
+
+    //! Attentional focus events
+    void add_af_signal(const Handle&, const AttentionValuePtr&,
+                       const AttentionValuePtr&);
+    void add_af_signal_handler(const Handle&, const AttentionValuePtr&,
+                               const AttentionValuePtr&);
+    //! Atom added events
+    void add_atom_signal(const Handle&);
+    void add_atom_signal_handler(const Handle&);
+
+};
+} /* namespace opencog*/
+#endif /* PLNAGENT_H_ */


### PR DESCRIPTION
      The following feature enables the rule engine to function like an event based rule engine and at the same time interact with ECAN. Besides the basic atom added  and attentional focus events, other kinds of events can be added later when the need arises.