### PR TITLE
Fchain

### DIFF
--- a/opencog/reasoning/RuleEngine/rule-engine-src/pln/ForwardChainer.cc
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/pln/ForwardChainer.cc
@@ -78,7 +78,7 @@ void ForwardChainer::do_chain(ForwardChainerCallBack& fcb,
     //Variable fulfillment query.
     UnorderedHandleSet var_nodes = pc.get_nodes(hsource, { VARIABLE_NODE });
     if (not var_nodes.empty())
-        return do_pm(hsource,var_nodes);
+        return do_pm(hsource, var_nodes);
 
     //Forward chaining on a particular type of atom.
     int iteration = 0;
@@ -86,8 +86,7 @@ void ForwardChainer::do_chain(ForwardChainerCallBack& fcb,
     init_source(hsource);
     while (iteration < max_iter /*OR other termination criteria*/) {
         log_->info("Iteration %d", iteration);
-        log_->info("Next source %s",
-                   fcmem_.cur_source_->toString().c_str());
+        log_->info("Next source %s", fcmem_.cur_source_->toString().c_str());
 
         //Add more premise to hcurrent_source by pattern matching.
         HandleSeq input = fcb.choose_premises(fcmem_);
@@ -128,10 +127,12 @@ void ForwardChainer::do_chain(ForwardChainerCallBack& fcb,
  * Does pattern matching for a variable containing query.
  * @param source handle containing VariableNode
  */
-void ForwardChainer::do_pm(const Handle& hsource,const UnorderedHandleSet& var_nodes)
+void ForwardChainer::do_pm(const Handle& hsource,
+                           const UnorderedHandleSet& var_nodes)
 {
     DefaultImplicator impl(as_);
     impl.implicand = hsource;
+    PatternMatch pm;
     HandleSeq vars;
     for (auto h : var_nodes)
         vars.push_back(h);
@@ -151,7 +152,6 @@ void ForwardChainer::do_pm(const Handle& hsource,const UnorderedHandleSet& var_n
     as_->removeAtom(hvar_list);
     as_->removeAtom(hclause);
 }
-
 
 void ForwardChainer::init_source(Handle hsource)
 {

--- a/opencog/reasoning/RuleEngine/rule-engine-src/pln/ForwardChainer.h
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/pln/ForwardChainer.h
@@ -29,7 +29,8 @@
 
 #include "FCMemory.h"
 
-namespace opencog {
+namespace opencog
+{
 
 class ForwardChainerCallBack;
 class ForwardChainer {
@@ -54,7 +55,8 @@ private:
     Handle choose_random_source(AtomSpace *);
     void add_to_source_list(Handle h);
     void init_source(Handle source);
-    void do_pm(const Handle& hsource,const UnorderedHandleSet& var_nodes);
+    void do_pm(const Handle& hsource, const UnorderedHandleSet& var_nodes,
+               ForwardChainerCallBack& fcb);
 protected:
     enum source_selection_mode {
         TV_FITNESS_BASED, STI_BASED

--- a/opencog/reasoning/RuleEngine/rule-engine-src/pln/PLNCommons.cc
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/pln/PLNCommons.cc
@@ -50,8 +50,9 @@ Handle PLNCommons::create_quoted(Handle himplicant)
     return hquoted;
 }
 
-Handle PLNCommons::create_bindLink(Handle himplicant, bool vnode_is_typedv)
-    throw (opencog::InvalidParamException)
+Handle PLNCommons::create_bindLink(
+        Handle himplicant, bool vnode_is_typedv)
+                throw (opencog::InvalidParamException)
 {
     if (!LinkCast(himplicant)) {
         throw InvalidParamException(TRACE_INFO, "Input must be a link type ");
@@ -60,7 +61,8 @@ Handle PLNCommons::create_bindLink(Handle himplicant, bool vnode_is_typedv)
     //if(vnode_is_typedv)
     himplicant = replace_nodes_with_varnode(himplicant);
 
-    UnorderedHandleSet variable_nodes = get_nodes(himplicant, {VARIABLE_NODE});
+    UnorderedHandleSet variable_nodes = get_nodes(himplicant,
+                                                  { VARIABLE_NODE });
     HandleSeq list_link_elem;
 
     // For searching ImplicationLinks with variables.
@@ -71,8 +73,8 @@ Handle PLNCommons::create_bindLink(Handle himplicant, bool vnode_is_typedv)
             list_link_elem.push_back(hi);
         }
     } else
-        list_link_elem.insert(list_link_elem.end(),
-                              variable_nodes.begin(), variable_nodes.end());
+        list_link_elem.insert(list_link_elem.end(), variable_nodes.begin(),
+                              variable_nodes.end());
 
     Handle var_listLink = as_->addLink(VARIABLE_LIST, list_link_elem);
 
@@ -82,8 +84,8 @@ Handle PLNCommons::create_bindLink(Handle himplicant, bool vnode_is_typedv)
     return as_->addLink(BIND_LINK, var_listLink, implicationLink);
 }
 
-UnorderedHandleSet PLNCommons::get_nodes(const Handle& hinput,
-                                         const vector<Type>& required_nodes) const
+UnorderedHandleSet PLNCommons::get_nodes(
+        const Handle& hinput, const vector<Type>& required_nodes) const
 {
     // Recursive case
     if (LinkCast(hinput)) {
@@ -114,18 +116,23 @@ UnorderedHandleSet PLNCommons::get_nodes(const Handle& hinput,
 
 bool PLNCommons::exists_in(Handle& hlink, Handle& h)
 {
-    if (not LinkCast(hlink))
-        throw InvalidParamException(TRACE_INFO, "Need a LINK type to look in");
-    auto outg = as_->getOutgoing(hlink);
-    if (find(outg.begin(), outg.end(), h) != outg.end())
+    if (hlink == h) {
         return true;
-    else {
-        for (Handle hi : outg) {
-            if (LinkCast(hi) and exists_in(hi, h))
-                return true;
+    } else {
+        if (not LinkCast(hlink))
+            throw InvalidParamException(TRACE_INFO,
+                                        "Need a LINK type to look in");
+        auto outg = as_->getOutgoing(hlink);
+        if (find(outg.begin(), outg.end(), h) != outg.end())
+            return true;
+        else {
+            for (Handle hi : outg) {
+                if (LinkCast(hi) and exists_in(hi, h))
+                    return true;
+            }
         }
+        return false;
     }
-    return false;
 }
 
 void PLNCommons::clean_up_bind_link(Handle& hbind_link)


### PR DESCRIPTION
This PR enables the forward chainer handle Variable fulfillment query without the groundings being explicitly found in the atomspace. It uses the existing choose_rule method to find applicable rules whose part of their premise matches with variable containing query and applies all matching rules. Applying all matching rule has the caveat of getting crappy results with the interesting ones as mentioned in #1431. I will have to work on this more.
example usage
 
    guile> (clear) (InheritanceLink (ConceptNode "Man") (ConceptNode "Animal"))
    guile> (InheritanceLink (ConceptNode "Socrates") (ConceptNode "Man"))
    guile> (define animal (InheritanceLink (VariableNode "$x")(ConceptNode "Animal")))
    guile> (cog-fc animal)
    returns
    (ListLink
    (InheritanceLink
      (ConceptNode "Man")
      (ConceptNode "Animal")
      )
     (InheritanceLink (stv -nan 0)
        (ConceptNode "Socrates")
        (ConceptNode "Animal")
      )
     )
  and all other kinds of uninteresting results. Which has to be dealt soon.