### PR TITLE
Fixed atomspace_bm and added optimized getHandlesOfType (37% faster) 

### DIFF
--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -90,6 +90,8 @@ public:
     inline int getSize() const { return atomTable.getSize(); }
     inline int getNumNodes() const { return atomTable.getNumNodes(); }
     inline int getNumLinks() const { return atomTable.getNumLinks(); }
+    inline int getNumAtomsOfType(Type type, bool subclass = true) const
+        { return atomTable.getNumAtomsOfType(type, subclass); }
 
     //! Clear the atomspace, remove all atoms
     void clear();

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -422,6 +422,43 @@ public:
      * Gets a set of handles that matches with the given type
      * (subclasses optionally).
      *
+     * @param appendToHandles the HandleSeq to which to append the handles.
+     * @param type The desired type.
+     * @param subclass Whether type subclasses should be considered.
+     *
+     * @note The matched entries are appended to a container whose
+     *        OutputIterator is passed as the first argument.
+     *
+     * Example of call to this method, which would return all entries
+     * in AtomSpace:
+     * @code
+     *         std::list<Handle> ret;
+     *         atomSpace.getHandlesByType(back_inserter(ret), ATOM, true);
+     * @endcode
+     */
+    void getHandlesByType(HandleSeq& appendToHandles,
+                          Type type,
+                          bool subclass = false) const
+    {
+        // Get the initial size of the handles vector.
+        size_t initial_size = appendToHandles.size();
+
+        // Determine the number of atoms we'll be adding.
+        size_t size_of_append = atomTable.getNumAtomsOfType(type, subclass);
+
+        // Now reserve size for the addition. This is faster for large
+        // append iterations since appends to the list won't require new
+        // allocations and copies whenever the allocated size is exceeded.
+        appendToHandles.reserve(initial_size + size_of_append);
+
+        // Now defer to the output iterator call, eating the return.
+        getHandlesByType(back_inserter(appendToHandles), type, subclass);
+    }
+
+    /**
+     * Gets a set of handles that matches with the given type
+     * (subclasses optionally).
+     *
      * @param result An output iterator.
      * @param type The desired type.
      * @param subclass Whether type subclasses should be considered.

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -528,6 +528,12 @@ size_t AtomTable::getNumLinks() const
     return linkIndex.size();
 }
 
+size_t AtomTable::getNumAtomsOfType(Type type, bool subclass) const
+{ 
+    std::lock_guard<std::recursive_mutex> lck(_mtx);
+    return typeIndex.getNumAtomsOfType(type, subclass);
+}
+
 Handle AtomTable::getRandom(RandGen *rng) const
 {
     size_t x = rng->randint(getSize());

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -166,6 +166,7 @@ public:
     size_t getSize() const;
     size_t getNumNodes() const;
     size_t getNumLinks() const;
+    size_t getNumAtomsOfType(Type type, bool subclass = true) const;
 
     /**
      * Returns the exact atom for the given name and type.

--- a/opencog/atomspace/TypeIndex.cc
+++ b/opencog/atomspace/TypeIndex.cc
@@ -36,6 +36,31 @@ void TypeIndex::resize(void)
 	FixedIntegerIndex::resize(num_types + 1);
 }
 
+size_t TypeIndex::getNumAtomsOfType(Type type, bool count_subclasses) const
+{
+    iterator it(type, count_subclasses);
+    size_t atom_count = 0;
+    it.s = idx.begin();
+    it.send = idx.end();
+
+    // Loop over all the types looking for type and optional subclasses.
+    Type current_type = 0;
+    while (it.s != it.send)
+    {
+        // If this type is a match...
+        if ((type == current_type) || 
+            (count_subclasses && (classserver().isA(type, it.type))))
+        {
+            // Add the size of the atom set for this type.
+            atom_count += idx.at(current_type).size();
+        }
+        current_type++;
+        ++it.s;
+    }
+
+    return atom_count;
+}
+
 // ================================================================
 
 TypeIndex::iterator TypeIndex::begin(Type t, bool sub) const

--- a/opencog/atomspace/TypeIndex.h
+++ b/opencog/atomspace/TypeIndex.h
@@ -64,6 +64,7 @@ class TypeIndex : public FixedIntegerIndex
 		{
 			remove(a->getType(), a);
 		}
+   		size_t getNumAtomsOfType(Type type, bool subclass) const;
 
 		class iterator
 			: public std::iterator<std::forward_iterator_tag, Handle>

--- a/opencog/benchmark/AtomSpaceBenchmark.cc
+++ b/opencog/benchmark/AtomSpaceBenchmark.cc
@@ -1047,10 +1047,8 @@ timepair_t AtomSpaceBenchmark::bm_getHandlesByType()
 #endif /* HAVE_GUILE */
     case BENCH_TABLE: {
         clock_t t_begin = clock();
-        //size_t max_atoms = asp->getNumAtomsOfType(t,true);
         HandleSeq results;
-        //results.reserve(max_atoms);
-        asp->getHandlesByType(back_inserter(results), t, true);
+        asp->getHandlesByType(results, t, true);
         clock_t time_taken = clock() - t_begin;
         return timepair_t(time_taken,0);
     }

--- a/opencog/benchmark/AtomSpaceBenchmark.h
+++ b/opencog/benchmark/AtomSpaceBenchmark.h
@@ -80,6 +80,7 @@ class AtomSpaceBenchmark
     std::string memoize_or_compile(std::string);
 
     std::vector<std::string>  methodNames;
+
 public:
     unsigned int Nreps;
     unsigned int Nloops;
@@ -125,6 +126,7 @@ public:
     void buildAtomSpace(long atomspaceSize=(1 << 16), float percentLinks = 0.1, 
             bool display = true);
     Handle getRandomHandle();
+    void setTestAllMethods() { setMethod("all"); }
 
     timepair_t bm_noop();
     timepair_t bm_addNode();

--- a/opencog/benchmark/atomspace_bm.cc
+++ b/opencog/benchmark/atomspace_bm.cc
@@ -60,17 +60,7 @@ int main(int argc, char** argv)
              break;
            case 'A':
              benchmarker.buildTestData = true;
-             benchmarker.setMethod("noop");
-             benchmarker.setMethod("addNode");
-             benchmarker.setMethod("addLink");
-             benchmarker.setMethod("getType");
-             benchmarker.setMethod("getTV");
-             benchmarker.setMethod("setTV");
-             benchmarker.setMethod("getNodeHandles");
-             benchmarker.setMethod("getOutgoingSet");
-             benchmarker.setMethod("getIncomingSet");
-             benchmarker.setMethod("removeAtom");
-             benchmarker.setMethod("getHandleSet");
+             benchmarker.setTestAllMethods();
              break;
            case 'X':
              benchmarker.testKind = opencog::AtomSpaceBenchmark::BENCH_TABLE;

--- a/opencog/benchmark/diary.txt
+++ b/opencog/benchmark/diary.txt
@@ -881,3 +881,27 @@ much.
   addNode          195
   addLink          101
   removeAtom       170
+
+
+======================================================================
+01 April 2015:
+
+Updated the benchmark and getHandlesByType to use .reserve on the HandleSeq
+to eliminate unnecessary copies of the Handles during resize.
+
+This resulted in the following improvement:
+
+Before:
+                      -m getHandlesByType
+   test               AtomSpace
+   name               K-ops/sec
+   ----               ---------
+  getHandlesByType    0.320
+
+After:                
+                      -m getHandlesByType
+   test               AtomSpace
+   name               K-ops/sec
+   ----               ---------
+  getHandlesByType    0.439
+

--- a/tests/pln/CMakeLists.txt
+++ b/tests/pln/CMakeLists.txt
@@ -1,9 +1,8 @@
 IF (HAVE_NOSETESTS)
 
-    # Basic test, just does the cython wrapper for opencog/util
-    ADD_TEST(PLNTest ${NOSETESTS_EXECUTABLE} -vs
+    ADD_TEST(PythonPLNTest ${NOSETESTS_EXECUTABLE} -vs
         ${CMAKE_SOURCE_DIR}/tests/pln)
-    SET_TESTS_PROPERTIES(PLNTest
+    SET_TESTS_PROPERTIES(PythonPLNTest
         PROPERTIES ENVIRONMENT "PYTHONPATH=${PROJECT_BINARY_DIR}/opencog/cython:${PROJECT_SOURCE_DIR}/opencog/python:${PROJECT_SOURCE_DIR}/opencog/nlp")
 
 ENDIF (HAVE_NOSETESTS)


### PR DESCRIPTION
Consolidated the -A and moved it to AtomSpaceBenchmark.cc so that it runs valid tests
Fixed problems with benchmark generating random types that break with new validation
Ported over the old changes to add a getNumAtomsOfType as per pull Linas's request in #1409
Optimized getHandlesOfType to use vector.reserve to avoid copies and memory management.