### PR TITLE
Added cog-get-pred equilvalent: get_predicates, and new get_predicates_for to C++ and Python

### DIFF
--- a/opencog/atomutils/AtomUtils.h
+++ b/opencog/atomutils/AtomUtils.h
@@ -35,6 +35,8 @@ namespace opencog
  *  @{
  */
 
+const bool NO_SUBCLASSES = false;
+
 /**
  * General purpose utilities for processing atoms in the Atom.
  *
@@ -82,7 +84,101 @@ UnorderedHandleSet get_outgoing_nodes(const Handle& hinput,
  */
 UnorderedHandleSet get_distant_neighbors(const Handle& h, int dist = 1);
 
+/**
+ * Returns a list of all the EvaluationLinks with Predicates of the given type
+ * that the atom specified by 'target' participates in. 
+ * (C++ implementation of cog-get-pred)
+ *
+  * For example, given existence of the following:
+ *
+ *     EvaluationLink
+ *        PredicateNode "IsA"
+ *        ListLink
+ *           ConceptNode "dog"
+ *           ConceptNode "mammal"
+ *
+ *     EvaluationLink
+ *        PredicateNode "IsA"
+ *        ListLink
+ *           ConceptNode "dog"
+ *           ConceptNode "vertebrate"
+ *
+ *     EvaluationLink
+ *        PredicateNode "eats"
+ *        ListLink
+ *           ConceptNode "dog"
+ *           ConceptNode "meat"
+ *
+ * and, given a get_predicates target of:
+ *
+ *     ConceptNode "dog"
+ *
+ * and predicateType PREDICATE_NODE (or "PredicateNode"), then get_predicates
+ * returns evaluation links for:
+ *  
+ *     dog IsA mammal
+ *     dog IsA vertebrate
+ *     dog eats meat
+ *
+ * @param target Search for predicates that target.
+ * @param predicateType Search only for predicates of this type.
+ * @param subClasses Follow subtypes of linkType too.
+ */
+HandleSeq get_predicates(const Handle& target, 
+                         Type predicateType=PREDICATE_NODE,
+                         bool subClasses=true);
+
+/**
+ * Returns a list of all the EvaluationLinks with the specified predicate
+ * that the atom specified by 'target' participates in. 
+ *
+ * For example, given the following:
+ *
+ *     EvaluationLink
+ *        PredicateNode "IsA"
+ *        ListLink
+ *           ConceptNode "dog"
+ *           ConceptNode "mammal"
+ *
+ *     EvaluationLink
+ *        PredicateNode "IsA"
+ *        ListLink
+ *           ConceptNode "dog"
+ *           ConceptNode "vertebrate"
+ *
+ *     EvaluationLink
+ *        PredicateNode "eats"
+ *        ListLink
+ *           ConceptNode "dog"
+ *           ConceptNode "meat"
+ *
+ * then, given a target of:
+ *
+ *     ConceptNode "dog"
+ *
+ * and predicate:
+ *
+ *     PredicateNode "IsA"
+ *
+ * then get_predicates_for returns a list of all of the EvaluationLinks in 
+ * which the dog has the "IsA" predicate, but not the one for "eats". So:
+ * 
+ *     dog IsA mammal 
+ *     dog IsA vertebrate
+ *
+ * but NOT:
+ *
+ *     dog eats meat
+ *
+ * @param target Search for predicates that target.
+ * @param predicateType Search only for predicates of this type.
+ * @param subClasses Follow subtypes of linkType too.
+ */
+HandleSeq get_predicates_for(const Handle& target, 
+                             const Handle& predicate);
+
 /** @}*/
 }
+
 
 #endif // _OPENCOG_ATOM_UTILS_H

--- a/opencog/benchmark/benchmark.py
+++ b/opencog/benchmark/benchmark.py
@@ -495,9 +495,9 @@ tests = [
 (['scheme'],                prep_scheme,            test_add_nodes_sugar,       "Add nodes - ConceptNode sugar - Scheme"),
 
 (['all'],                   None,                   None,                       "-- Testing Get Predicates --"),
-(['predicates','spread'],   prep_predicates,        test_get_predicates,        "Predicates get_predicates"),
-(['predicates'],            prep_predicates,        test_get_predicates_for,    "Predicates get_predicates_for"),
-(['predicates'],            prep_predicates,        test_get_predicates_scheme, "Predicates cog-get-pred - Scheme"),
+(['predicates','spread'],   prep_predicates,        test_get_predicates,        "Predicates - get_predicates"),
+(['predicates'],            prep_predicates,        test_get_predicates_for,    "Predicates - get_predicates_for"),
+(['predicates'],            prep_predicates,        test_get_predicates_scheme, "Predicates - cog-get-pred - Scheme"),
 ]
 
 

--- a/opencog/benchmark/python_diary.txt
+++ b/opencog/benchmark/python_diary.txt
@@ -380,3 +380,46 @@ Test scheme_eval_h(+ 2 2)                      44.901µs          22,271
 Bind - cog-bind - Scheme                       88.626µs          11,283
 Add nodes - cog-new-node - Scheme              97.150µs          10,293
 Add nodes - ConceptNode sugar - Scheme         84.870µs          11,782
+
+
+04 April 2015
+-------------
+Added three new tests to compare speeds for new C++ and Cython versions
+of cog-get-pred and a new function get_predicates_for which returns only
+returns evaluation links with a specific predicate. The Cython version is
+67 times faster since it can avoid the Scheme interpreter overhead.
+
+As measure by Curtis on:
+  MacBook Pro - Retina, 15-inch, Early 2013
+  Intel Core i7 2.7 Ghz - Quad core
+  16GB 1600 Mhz DDR3
+
+Linux running under boot2docker VirtualBox VM in a Docker container with:
+  Ubuntu 14.04.2 LTS (trusty)
+  Python 2.7.6
+  gcc (Ubuntu 4.8.2-19ubuntu1) 4.8.2
+  guile (GNU Guile) 2.0.9
+
+Test                                        Time per op  Ops per second
+----                                        -----------  --------------
+Add nodes - Cython                              4.627µs         216,143
+Add nodes - Cython (500K)                       4.734µs         211,251
+Add fully connected nodes                       5.800µs         172,399
+Bare atom traversal 100K - by type              0.003µs     333,092,757
+Resolve Handle 10K - by type                    0.420µs       2,381,165
+Resolve Handle 100K - by type                   0.319µs       3,135,133
+Resolve Handle 1M - by type                     0.312µs       3,204,695
+Get and Traverse 100K - by type                 0.657µs       1,522,818
+Yield Get and Traverse 100K - by type           0.420µs       2,381,177
+Get Outgoing                                    0.944µs       1,059,799
+Get Outgoing - no temporary list                0.933µs       1,071,909
+Yield Get Outgoing                              0.766µs       1,305,331
+Bind - stub_bindlink - Cython                   0.164µs       6,093,768
+Bind - bindlink - Cython                       14.514µs          68,899
+Test scheme_eval_h(+ 2 2)                      75.527µs          13,240
+Bind - cog-bind - Scheme                       98.502µs          10,152
+Add nodes - cog-new-node - Scheme             125.868µs           7,944
+Add nodes - ConceptNode sugar - Scheme        111.437µs           8,973
+Predicates get_predicates                       1.995µs         501,140
+Predicates get_predicates_for                   1.793µs         557,721
+Predicates cog-get-pred - Scheme              135.691µs           7,369

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -183,3 +183,16 @@ cdef extern from "opencog/spacetime/TimeServer.h" namespace "opencog":
     cdef cppclass cTimeServer "opencog::TimeServer":
         TimeServer()
 
+
+cdef extern from "opencog/atomutils/AtomUtils.h" namespace "opencog":
+    # C++: 
+    #   
+    #   HandleSeq get_predicates(const Handle& target, 
+    #                     Type predicateType=PREDICATE_NODE,
+    #                     bool subClasses=true)
+    #   void finalize_opencog();
+    #   void configuration_load(const char* configFile);
+    #
+    cdef vector[cHandle] c_get_predicates "get_predicates" (cHandle& target, Type t, bint subclass)
+    cdef vector[cHandle] c_get_predicates_for "get_predicates_for" (cHandle& target, cHandle& predicate)
+

--- a/opencog/cython/opencog/atomspace_details.pyx
+++ b/opencog/cython/opencog/atomspace_details.pyx
@@ -396,6 +396,56 @@ cdef class AtomSpace:
             yield Atom(temp_handle,self)
             inc(c_handle_iter)
 
+    def get_predicates(self, Atom target, Type predicate_type = types.PredicateNode, subclasses=True):
+        cdef vector[cHandle] handle_vector
+        cdef bint want_subclasses = subclasses
+        cdef Handle target_h = target.h
+        handle_vector = c_get_predicates(deref(target_h.h), predicate_type, want_subclasses)
+        return convert_handle_seq_to_python_list(handle_vector,self)
+
+    def xget_predicates(self, Atom target, Type predicate_type = types.PredicateNode, subclasses=True):
+        cdef vector[cHandle] handle_vector
+        cdef bint want_subclasses = subclasses
+        cdef Handle target_h = target.h
+        handle_vector = c_get_predicates(deref(target_h.h), predicate_type, want_subclasses)
+        
+        # This code is the same for all the x iterators but there is no
+        # way in Cython to yield out of a cdef function and no way to pass a 
+        # vector into a Python def function, so we have to repeat code. ARGGG!
+        cdef vector[cHandle].iterator c_handle_iter
+        cdef cHandle current_c_handle
+        c_handle_iter = handle_vector.begin()
+        while c_handle_iter != handle_vector.end():
+            current_c_handle = deref(c_handle_iter)
+            temp_handle = Handle(current_c_handle.value())
+            yield Atom(temp_handle,self)
+            inc(c_handle_iter)
+
+    def get_predicates_for(self, Atom target, Atom predicate):
+        cdef vector[cHandle] handle_vector
+        cdef Handle target_h = target.h
+        cdef Handle predicate_h = predicate.h
+        handle_vector = c_get_predicates_for(deref(target_h.h), deref(predicate_h.h))
+        return convert_handle_seq_to_python_list(handle_vector,self)
+
+    def xget_predicates_for(self, Atom target, Atom predicate):
+        cdef vector[cHandle] handle_vector
+        cdef Handle target_h = target.h
+        cdef Handle predicate_h = predicate.h
+        handle_vector = c_get_predicates_for(deref(target_h.h), deref(predicate_h.h))
+        
+        # This code is the same for all the x iterators but there is no
+        # way in Cython to yield out of a cdef function and no way to pass a 
+        # vector into a Python def function, so we have to repeat code. ARGGG!
+        cdef vector[cHandle].iterator c_handle_iter
+        cdef cHandle current_c_handle
+        c_handle_iter = handle_vector.begin()
+        while c_handle_iter != handle_vector.end():
+            current_c_handle = deref(c_handle_iter)
+            temp_handle = Handle(current_c_handle.value())
+            yield Atom(temp_handle,self)
+            inc(c_handle_iter)
+
     @classmethod
     def include_incoming(cls, atoms):
         """

--- a/opencog/scm/utilities.scm
+++ b/opencog/scm/utilities.scm
@@ -650,7 +650,11 @@
   atom 'anchor'.
 
   Thus, for example, suppose the atom-space contains a link of the
-  form (ReferenceLink (ConceptNode \"asdf\") (WordNode \"pqrs\"))
+  form 
+        (ReferenceLink
+            (ConceptNode \"asdf\")
+            (WordNode \"pqrs\")
+        )
   Then, the call
      (cog-get-link 'ReferenceLink 'ConceptNode (WordNode \"pqrs\"))
   will return a list containing that link. Note that \"endpoint-type\"

--- a/tests/atomutils/AtomUtilsUTest.cxxtest
+++ b/tests/atomutils/AtomUtilsUTest.cxxtest
@@ -95,7 +95,6 @@ void AtomUtilsUTest::test_get_outgoing_nodes()
 	                 UnorderedHandleSet({P}));
 }
 
-
 // Test get_outgoing_nodes()
 void AtomUtilsUTest::test_get_predicates()
 {
@@ -105,29 +104,28 @@ void AtomUtilsUTest::test_get_predicates()
 		bacon = as.addNode(CONCEPT_NODE, "bacon"),
 		programmer_bacon = as.addLink(LIST_LINK, programmer, bacon),
 		eats = as.addNode(PREDICATE_NODE, "eats"),
-		eatsEvaluationLink = as.addLink(EVALUATION_LINK, eats,
+		programmerEatsBacon = as.addLink(EVALUATION_LINK, eats,
 										programmer_bacon),
 		lover = as.addNode(DEFINED_RELATIONSHIP_NODE, "lover"),
-		loverEvaluationLink = as.addLink(EVALUATION_LINK, lover,
+		programmerBaconLover = as.addLink(EVALUATION_LINK, lover,
 										 programmer_bacon),
 		anotherNode = as.addNode(CONCEPT_NODE, "pigs"),
 		anotherLink = as.addLink(LIST_LINK, anotherNode, bacon);
 		
 	// Test get_predicates(default).
-	HandleSeq shouldGetHandles {eatsEvaluationLink, loverEvaluationLink};
-	TS_ASSERT_EQUALS(get_predicates(bacon), shouldGetHandles);
+	HandleSeq baconReferences {programmerEatsBacon, programmerBaconLover};
+	TS_ASSERT_EQUALS(get_predicates(bacon), baconReferences);
 
 	// Test get_predicates with specific type.
-	HandleSeq shouldGetHandlesTwo {loverEvaluationLink};
-	TS_ASSERT_EQUALS(get_predicates(bacon, DEFINED_RELATIONSHIP_NODE),
-	                 shouldGetHandlesTwo);
+	HandleSeq baconLovers {programmerBaconLover};
+	TS_ASSERT_EQUALS(get_predicates(bacon, DEFINED_RELATIONSHIP_NODE), 
+					 baconLovers);
 
 	// Test get_predicates with specific type and no subclasses.
-	HandleSeq shouldGetHandlesThree {eatsEvaluationLink};
+	HandleSeq eatersOfBacon {programmerEatsBacon};
 	TS_ASSERT_EQUALS(get_predicates(bacon, PREDICATE_NODE, NO_SUBCLASSES),
-	                 shouldGetHandlesThree);
+	                 eatersOfBacon);
 }
-
 
 // Test get_outgoing_nodes()
 void AtomUtilsUTest::test_get_predicates_for()

--- a/tests/atomutils/AtomUtilsUTest.cxxtest
+++ b/tests/atomutils/AtomUtilsUTest.cxxtest
@@ -38,6 +38,8 @@ public:
 
 	void test_get_distant_neighbors();
 	void test_get_outgoing_nodes();
+	void test_get_predicates();
+	void test_get_predicates_for();
 };
 
 // Test get_distant_neighbors()
@@ -92,3 +94,84 @@ void AtomUtilsUTest::test_get_outgoing_nodes()
 	TS_ASSERT_EQUALS(get_outgoing_nodes(ABP, {PREDICATE_NODE}),
 	                 UnorderedHandleSet({P}));
 }
+
+
+// Test get_outgoing_nodes()
+void AtomUtilsUTest::test_get_predicates()
+{
+	AtomSpace as;
+	Handle
+		programmer = as.addNode(CONCEPT_NODE, "programmer"),
+		bacon = as.addNode(CONCEPT_NODE, "bacon"),
+		programmer_bacon = as.addLink(LIST_LINK, programmer, bacon),
+		eats = as.addNode(PREDICATE_NODE, "eats"),
+		eatsEvaluationLink = as.addLink(EVALUATION_LINK, eats,
+										programmer_bacon),
+		lover = as.addNode(DEFINED_RELATIONSHIP_NODE, "lover"),
+		loverEvaluationLink = as.addLink(EVALUATION_LINK, lover,
+										 programmer_bacon),
+		anotherNode = as.addNode(CONCEPT_NODE, "pigs"),
+		anotherLink = as.addLink(LIST_LINK, anotherNode, bacon);
+		
+	// Test get_predicates(default).
+	HandleSeq shouldGetHandles {eatsEvaluationLink, loverEvaluationLink};
+	TS_ASSERT_EQUALS(get_predicates(bacon), shouldGetHandles);
+
+	// Test get_predicates with specific type.
+	HandleSeq shouldGetHandlesTwo {loverEvaluationLink};
+	TS_ASSERT_EQUALS(get_predicates(bacon, DEFINED_RELATIONSHIP_NODE),
+	                 shouldGetHandlesTwo);
+
+	// Test get_predicates with specific type and no subclasses.
+	HandleSeq shouldGetHandlesThree {eatsEvaluationLink};
+	TS_ASSERT_EQUALS(get_predicates(bacon, PREDICATE_NODE, NO_SUBCLASSES),
+	                 shouldGetHandlesThree);
+}
+
+
+// Test get_outgoing_nodes()
+void AtomUtilsUTest::test_get_predicates_for()
+{
+	AtomSpace as;
+	Handle
+		// Dog is a mammal, canine, animal.
+		dog = as.addNode(CONCEPT_NODE, "dog"),
+		mammal = as.addNode(CONCEPT_NODE, "mammal"),
+		dog_mammal = as.addLink(LIST_LINK, dog, mammal),
+		canine = as.addNode(CONCEPT_NODE, "canine"),
+		dog_canine = as.addLink(LIST_LINK, dog, canine),
+		animal = as.addNode(CONCEPT_NODE, "animal"),
+		dog_animal = as.addLink(LIST_LINK, dog, animal),
+		isA = as.addNode(PREDICATE_NODE, "IsA"),
+		dogIsAMammal = as.addLink(EVALUATION_LINK, isA, dog_mammal),
+		dogIsACanine = as.addLink(EVALUATION_LINK, isA, dog_canine),
+		dogIsAAnimal = as.addLink(EVALUATION_LINK, isA, dog_animal),
+
+		// Dog eats bacon.
+		bacon = as.addNode(CONCEPT_NODE, "bacon"),
+		dog_bacon = as.addLink(LIST_LINK, dog, bacon),
+		eats = as.addNode(PREDICATE_NODE, "eats"),
+		dogEatsBacon = as.addLink(EVALUATION_LINK, eats, dog_bacon),
+
+		// Programmer eats bacon.
+		programmer = as.addNode(CONCEPT_NODE, "programmer"),
+		programmer_bacon = as.addLink(LIST_LINK, programmer, bacon),
+		programmerEatsBacon = as.addLink(EVALUATION_LINK, eats, programmer_bacon);
+		
+	// Test for dog IsA.
+	HandleSeq dogIsA {dogIsAMammal, dogIsACanine, dogIsAAnimal};
+	TS_ASSERT_EQUALS(get_predicates_for(dog, isA), dogIsA);
+
+	// Test for dog eats.
+	HandleSeq dogEats {dogEatsBacon};
+	TS_ASSERT_EQUALS(get_predicates_for(dog, eats), dogEats);
+
+	// Test for programmer eats.
+	HandleSeq programmerEats {programmerEatsBacon};
+	TS_ASSERT_EQUALS(get_predicates_for(programmer, eats), programmerEats);
+
+	// Test for eats bacon.
+	HandleSeq eatsBacon {dogEatsBacon, programmerEatsBacon};
+	TS_ASSERT_EQUALS(get_predicates_for(bacon, eats), eatsBacon);
+}
+

--- a/tests/cython/atomspace/test_atomspace.py
+++ b/tests/cython/atomspace/test_atomspace.py
@@ -243,7 +243,62 @@ class AtomSpaceTest(TestCase):
         self.assertTrue(a1 in self.space)
         self.assertTrue(h2 in self.space)
 
-        self.assertTrue(len(self.space), 3)
+        self.assertEquals(len(self.space), 3)
+
+    def test_get_predicates(self):
+        dog = self.space.add_node(types.ConceptNode, "dog")
+        mammal = self.space.add_node(types.ConceptNode, "mammal")
+        canine = self.space.add_node(types.ConceptNode, "canine")
+        animal = self.space.add_node(types.ConceptNode, "animal")
+        dog_mammal = self.space.add_link(types.ListLink, [dog, mammal])
+        dog_canine = self.space.add_link(types.ListLink, [dog, canine])
+        dog_animal = self.space.add_link(types.ListLink, [dog, animal])
+        isA = self.space.add_node(types.PredicateNode, "IsA")
+        dogIsAMammal = self.space.add_link(types.EvaluationLink, [isA, dog_mammal])
+        dogIsACanine = self.space.add_link(types.EvaluationLink, [isA, dog_canine])
+        dogIsAAnimal = self.space.add_link(types.EvaluationLink, [isA, dog_animal])
+
+        dog_predicates = self.space.get_predicates(dog)
+        self.assertEquals(len(dog_predicates), 3)
+
+        count = 0
+        for dogIs in self.space.xget_predicates(dog):
+            count += 1
+        self.assertEquals(count, 3)
+
+    def test_get_predicates_for(self):
+        dog = self.space.add_node(types.ConceptNode, "dog")
+        mammal = self.space.add_node(types.ConceptNode, "mammal")
+        canine = self.space.add_node(types.ConceptNode, "canine")
+        animal = self.space.add_node(types.ConceptNode, "animal")
+        dog_mammal = self.space.add_link(types.ListLink, [dog, mammal])
+        dog_canine = self.space.add_link(types.ListLink, [dog, canine])
+        dog_animal = self.space.add_link(types.ListLink, [dog, animal])
+        isA = self.space.add_node(types.PredicateNode, "IsA")
+        dogIsAMammal = self.space.add_link(types.EvaluationLink, [isA, dog_mammal])
+        dogIsACanine = self.space.add_link(types.EvaluationLink, [isA, dog_canine])
+        dogIsAAnimal = self.space.add_link(types.EvaluationLink, [isA, dog_animal])
+
+        human = self.space.add_node(types.ConceptNode, "human")
+        dog_human = self.space.add_link(types.ListLink, [dog, human])
+        loves = self.space.add_node(types.PredicateNode, "loves")
+        dogLovesHumans = self.space.add_link(types.EvaluationLink, [loves, dog_human])
+
+        dog_predicates = self.space.get_predicates_for(dog, isA)
+        self.assertEquals(len(dog_predicates), 3)
+
+        dog_predicates = self.space.get_predicates_for(dog, loves)
+        self.assertEquals(len(dog_predicates), 1)
+
+        count = 0
+        for dogIsA in self.space.xget_predicates_for(dog, isA):
+            count += 1
+        self.assertEquals(count, 3)
+
+        count = 0
+        for dogLoves in self.space.xget_predicates_for(dog, loves):
+            count += 1
+        self.assertEquals(count, 1)
 
 class AtomTest(TestCase):
 


### PR DESCRIPTION
This also includes the Cython Python bindings and a Python binding test for get_predicates and get_predicates_for as well as the yield generator versions: xget_predicates and xget_predicates_for.