### PR TITLE
removed some x86 specific compile warnings

### DIFF
--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -275,7 +275,7 @@ void DefaultPatternMatchCB::initiate_search(PatternMatchEngine *pme,
 		for (size_t i = 0; i < sz; i++) {
 			Handle h(iset[i]);
 			dbgprt("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n");
-			dbgprt("Loop candidate (%lu/%lu): %s\n", i+1, sz,
+			dbgprt("Loop candidate (%lu/%lu): %s\n", (unsigned long)i+1, (unsigned long)sz,
 			       h->toShortString().c_str());
 			bool rc = pme->explore_neighborhood(_root, _starter_pred, h);
 			if (rc) break;
@@ -331,7 +331,7 @@ void DefaultPatternMatchCB::full_search(PatternMatchEngine *pme,
 	for (const Handle& h : handle_set)
 	{
 		dbgprt("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n");
-		dbgprt("Loop candidate (%lu/%lu): %s\n", ++i, handle_set.size(),
+		dbgprt("Loop candidate (%lu/%lu): %s\n", (unsigned long)++i, (unsigned long)handle_set.size(),
 		       h->toShortString().c_str());
 		bool rc = pme->explore_neighborhood(_root, _starter_pred, h);
 		if (rc) break;

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -471,7 +471,7 @@ bool PatternMatchEngine::tree_compare(const Handle& hp, const Handle& hg)
 			do {
 				// The recursion step: traverse down the tree.
 				dbgprt("tree_comp start downwards unordered link at depth=%lu\n",
-				       more_depth);
+				       (unsigned long)more_depth);
 				var_solutn_stack.push(var_grounding);
 				depth ++;
 
@@ -482,7 +482,7 @@ bool PatternMatchEngine::tree_compare(const Handle& hp, const Handle& hg)
 				more_depth --;
 				depth --;
 				dbgprt("tree_comp down unordered link depth=%lu mismatch=%d\n",
-				       more_depth, match);
+				       (unsigned long)more_depth, match);
 
 				// If we've found a grounding, lets see if the
 				// post-match callback likes this grounding.
@@ -499,7 +499,7 @@ bool PatternMatchEngine::tree_compare(const Handle& hp, const Handle& hg)
 					var_solutn_stack.pop();
 					if (hp != hg) var_grounding[hp] = hg;
 					dbgprt("tree_comp unordered link have gnd at depth=%lu\n",
-					      more_depth);
+					      (unsigned long)more_depth);
 
 					// If a lower part of a tree has more to do, it will have
 					// set the have_more flag.  If it is done, then the


### PR DESCRIPTION
i just add some casts to unsigned long in order to suppress some 32 bits architecure specific warnings.
Those took place on debug printing calls, so i didn't want to add a dependency to boost::format