### PR TITLE
PLN Attentional Focus fixes

### DIFF
--- a/opencog/query/AttentionalFocusCB.cc
+++ b/opencog/query/AttentionalFocusCB.cc
@@ -36,7 +36,7 @@ AttentionalFocusCB::AttentionalFocusCB(AtomSpace* as) :
 	DefaultPatternMatchCB(as)
 {
 	// Temporarily disable the AF mechanism during PLN development
-	_as->setAttentionalFocusBoundary(AttentionValue::MINSTI);
+	// _as->setAttentionalFocusBoundary(AttentionValue::MINSTI);
 }
 
 bool AttentionalFocusCB::node_match(const Handle& node1, const Handle& node2)
@@ -89,80 +89,4 @@ IncomingSet AttentionalFocusCB::get_incoming_set(const Handle& h)
 	std::sort(filtered_set.begin(), filtered_set.end(), compare_sti);
 
 	return filtered_set;
-}
-
-// XXX FIXME, this is a bad-cut-n-paste job of the DefaultCB,
-// with some unclear modifications..
-bool AttentionalFocusCB::initiate_search(PatternMatchEngine *pme,
-                                         const std::set<Handle> &vars,
-                                         const std::vector<Handle> &clauses)
-{
-	_search_fail = false;
-
-	bool found = neighbor_search(pme, vars, clauses);
-	if (found) return true;
-	if (not _search_fail) return false;
-
-	// If we are here, then we could not find a clause at which to start,
-	// as, apparently, the clauses consist entirely of variables!! So,
-	// basically, we must search the entire!! atomspace, in this case.
-	// Yes, this hurts.
-	_root = clauses[0];
-	_starter_term = _root;
-
-	dbgprt("Start term is: %s\n", _starter_term->toShortString().c_str());
-
-	// XXX TODO -- as a performance optimization, we should try all
-	// the different clauses, and find the one with the smallest number
-	// of atoms of that type, or otherwise try to find a small ("thin")
-	// incoming set to search over.
-
-	// Plunge into the deep end - start looking at all viable
-	// candidates in the AtomSpace.
-	HandleSeq handle_set;
-	_as->getHandleSetInAttentionalFocus(back_inserter(handle_set));
-// xxxxxxxxxxxxxx here xxxxxxxxxxx
-
-	// WARNING: if there's nothing in the attentional focus then get
-	// the whole atomspace  ... XXX This cannot possibly be right!!
-	// If nothig is in attentional focus, then certainly, the whole
-	// atomspace should NOT be searched!! XXX So this is utterly wrong!
-	// However, both RuleUTest and ForwardChainerUTest fail unless
-	// we search the whole atomspace.  So that means that these two
-	// unit tests ae failing to correctly set up the attentional focus
-	// boundary!  Boooo! the tests are broken, they need to be fixed...
-	if (handle_set.empty())
-		_as->getHandlesByType(back_inserter(handle_set), ATOM, true);
-
-#if WHAT_THE_HUHH_THIS_CANT_BE_RIGHT
-	// Get the set of types of the potential candidates
-	// XXX FIXME ... this cannot be right; when-ever would the
-	// first clause just be a variable, all by itself??
-	std::set<Type> ptypes;
-	if (_root->getType() == VARIABLE_NODE)
-		ptypes = _type_restrictions->at(_root);
-
-
-	// Filter by variable types
-	if (not ptypes.empty()) {
-		auto it = remove_if(handle_set.begin(), handle_set.end(),
-		                    [&ptypes](const Handle& h) {
-			                    return ptypes.find(h->getType()) == ptypes.end();
-		                    });
-		handle_set.erase(it, handle_set.end());
-	}
-#endif
-
-#ifdef DEBUG
-	size_t i = 0;
-#endif
-	for (const Handle& h : handle_set)
-	{
-		dbgprt("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n");
-		dbgprt("Loop candidate (%lu/%lu): %s\n", ++i, handle_set.size(),
-		       h->toShortString().c_str());
-		bool rc = pme->explore_neighborhood(_root, _starter_term, h);
-		if (rc) return true;
-	}
-	return false;
 }

--- a/opencog/query/AttentionalFocusCB.cc
+++ b/opencog/query/AttentionalFocusCB.cc
@@ -70,17 +70,7 @@ IncomingSet AttentionalFocusCB::get_incoming_set(const Handle& h)
 		// Returning the empty set abandons the search in this direction.
 		// Search will then backtrack and try a different direction.
 		// ... and that is exactly what should be happening.
-		// But it might also mean that there is an AF bug somewhere ...
-		// Returning the empty set is right thing, but testing is needed.
-		//
-		// XXX TODO Currently, ForwardChainerUTest fails, when we
-		// return the empty set ... this is surely because the
-		// ForwardChainerUTest has not given sufficient stimulous to
-		// to the right atoms, for this to actually work right.
-		// So that test needs to be fixed FIXME ... or AF itself is
-		// broken.
-		// return filtered_set;
-		filtered_set = incoming_set;
+		return filtered_set;
 	}
 
 	// The exploration of the set of patterns proceeds by going through

--- a/opencog/query/AttentionalFocusCB.cc
+++ b/opencog/query/AttentionalFocusCB.cc
@@ -32,6 +32,13 @@ using namespace opencog;
    #define dbgprt(f, varargs...)
 #endif
 
+AttentionalFocusCB::AttentionalFocusCB(AtomSpace* as) :
+	DefaultPatternMatchCB(as)
+{
+	// Temporarily disable the AF mechanism during PLN development
+	_as->setAttentionalFocusBoundary(AttentionValue::MINSTI);
+}
+
 bool AttentionalFocusCB::node_match(const Handle& node1, const Handle& node2)
 {
 	return node1 == node2 and

--- a/opencog/query/AttentionalFocusCB.h
+++ b/opencog/query/AttentionalFocusCB.h
@@ -35,8 +35,7 @@ private:
 		return lptr1->getSTI() > lptr2->getSTI();
 	}
 public:
-	AttentionalFocusCB(AtomSpace * as) :
-		DefaultPatternMatchCB(as) {}
+	AttentionalFocusCB(AtomSpace*);
 
 	// Only match nodes if they are in the attentional focus
 	bool node_match(const Handle&, const Handle&);

--- a/opencog/query/AttentionalFocusCB.h
+++ b/opencog/query/AttentionalFocusCB.h
@@ -45,11 +45,6 @@ public:
 
 	// Only get incoming sets that are in the attentional focus
 	IncomingSet get_incoming_set(const Handle&);
-
-	// Starts from atoms in the attentional focus, with the right types
-	bool initiate_search(PatternMatchEngine *pme,
-	                     const std::set<Handle> &vars,
-	                     const std::vector<Handle> &clauses);
 };
 
 } //namespace opencog

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -456,11 +456,12 @@ bool DefaultPatternMatchCB::disjunct_search(PatternMatchEngine *pme,
 	if (found) return true;
 	if (not _search_fail) return false;
 
-	// The bizarro case: if we found nothing, then there are no links!
-	// Ergo, every clause must be a lone variable, all by itself. This
-	// is a bit pathological, but we handle it anyway, with the
-	// variable_search() method.  Note, however, that variable_search()
-	// does not look at the clauses, it looks at the varset instead.
+	// The PLN Reasoning case: if we found nothing, then there are no
+	// links!  Ergo, every clause must be a lone variable, all by
+	// itself. This is how some PLN rules start: the specify a single
+	// variable, all by itself, and set some type restrictions on it,
+	// and that's all. We deal with this in the variable_search()
+	// method.
 	_search_fail = false;
 	found = variable_search(pme, vars, clauses);
 	return found;
@@ -521,10 +522,12 @@ bool DefaultPatternMatchCB::link_type_search(PatternMatchEngine *pme,
 		}
 	}
 
-	// The bizarro case: if we found nothing, then there are no links!
-	// Ergo, every clause must be a lone variable, all by itself. This
-	// is a bit pathological, but we handle it anyway, with the
-	// variable_search() method, below.
+	// The PLN Reasoning case: if we found nothing, then there are no
+	// links!  Ergo, every clause must be a lone variable, all by
+	// itself. This is how some PLN rules start: the specify a single
+	// variable, all by itself, and set some type restrictions on it,
+	// and that's all. We deal with this in the variable_search()
+	// method.
 	if (Handle::UNDEFINED == _root)
 	{
 		_search_fail = true;

--- a/tests/reasoning/RuleEngine/ForwardChainerUTest.cxxtest
+++ b/tests/reasoning/RuleEngine/ForwardChainerUTest.cxxtest
@@ -27,7 +27,9 @@ public:
 	{
 		server(CogServer::createInstance);
 		as_ = &cogserver().getAtomSpace();
-		as_->clear();
+
+		// Disable the AF mechanism during testing!
+		as_->setAttentionalFocusBoundary(AttentionValue::MINSTI);
 		config().set("SCM_PRELOAD",
 		             "opencog/atomspace/core_types.scm, "
 		             "opencog/scm/utilities.scm, "


### PR DESCRIPTION
I suspect that the default attentional-focus boundary is interfering with PLN development, and is making things confusing, by "hiding" some atoms from the forward chainer, etc.

The PLN pattern-matcher uses the attentional-focus filter. The default attentonal-focus boundary is **above** the default STI of atoms in the atomspace.  The net result seems to hide some/many/most atoms from PLN, butcause the attntional-focus agents are not currently running.  So, for example,  the ForwardChainerUTest was failing, when the AF filter was fixed to work correctly. 

During PLN development and testing, you almost surely want to call 
```
atomspace->setAttentionalFocusBoundary(AttentionValue::MINSTI);
```
as otherwise, you might not see all the atoms you are expecting to see ...
