### PR TITLE
Pattern Matcher: added abnormal untyped VariableNode handling

### DIFF
--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -652,7 +652,10 @@ bool DefaultPatternMatchCB::variable_search(PatternMatchEngine *pme,
 	}
 
 	HandleSeq handle_set;
-	_as->getHandlesByType(handle_set, ptype);
+	if (ptype == ATOM)
+		_as->getHandlesByType(handle_set, ptype, true);
+	else
+		_as->getHandlesByType(handle_set, ptype);
 
 	dbgprt("Atomspace reported %lu atoms\n", handle_set.size());
 


### PR DESCRIPTION
Needed for weird stuff like

```
(SatisfactionLink
   (VariableNode "$A")
   (VariableNode "$A")
)
```

I am doing this in a temp small atomspace of course, for unification between two atoms.

Previously `(cog-satisfy ...)` of the above will always return `(stv 0 1)`.