### PR TITLE
Backward Chainer: Fixed grounding premises

### DIFF
--- a/opencog/reasoning/RuleEngine/rule-engine-src/pln/BackwardChainer.h
+++ b/opencog/reasoning/RuleEngine/rule-engine-src/pln/BackwardChainer.h
@@ -121,6 +121,7 @@ private:
 	Rule select_rule(const std::vector<Rule>& rules);
 
 	HandleSeq match_knowledge_base(const Handle& htarget, Handle htarget_vardecl, bool check_history, std::vector<VarMap>& vmap);
+	HandleSeq ground_premises(const Handle& htarget, std::vector<VarMap>& vmap);
 	bool unify(const Handle& htarget, const Handle& hmatch, Handle htarget_vardecl, VarMap& result);
 
 	Handle gen_sub_varlist(const Handle& parent_varlist, const std::set<Handle>& varset);


### PR DESCRIPTION
Almost there.  However, for some reason PM cannot match 
```
(AndLink (stv 1.000000 0.000000)
  (InheritanceLink (stv 1.000000 0.000000)
    (VariableNode "$x") ; [57]
    (ConceptNode "American") ; [58]
  ) ; [59]
  (InheritanceLink (stv 1.000000 0.000000)
    (VariableNode "$y") ; [60]
    (ConceptNode "weapon") ; [61]
  ) ; [62]
  (EvaluationLink (stv 1.000000 0.000000)
    (PredicateNode "sell") ; [63]
    (ListLink (stv 1.000000 0.000000)
      (VariableNode "$x") ; [57]
      (VariableNode "$y") ; [60]
      (VariableNode "$z") ; [64]
    ) ; [65]
  ) ; [66]
  (InheritanceLink (stv 1.000000 0.000000)
    (VariableNode "$z") ; [64]
    (ConceptNode "hostile") ; [67]
  ) ; [68]
) ; [69]
```
even though all the clauses are solved and in the Atomspace already.

Doing a "cog-prt-atomspace" crashes cogserver again!  I suspect there are still bugs with multiple atomspace (as @linas said cogserver should never crash when doing simple printing!!!)