### PR TITLE
Pattern matcher clearnup, re-organization, some performance opt.

### DIFF
--- a/opencog/atoms/bind/ConcreteLink.h
+++ b/opencog/atoms/bind/ConcreteLink.h
@@ -80,7 +80,8 @@ protected:
 	void unbundle_virtual(const std::set<Handle>& vars,
 	                      const HandleSeq& clauses,
 	                      HandleSeq& concrete_clauses,
-	                      HandleSeq& virtual_clauses);
+	                      HandleSeq& virtual_clauses,
+	                      std::set<Handle>& black_clauses);
 
 	void check_connectivity(const std::vector<HandleSeq>&);
 

--- a/opencog/atoms/bind/SatisfactionLink.cc
+++ b/opencog/atoms/bind/SatisfactionLink.cc
@@ -52,17 +52,12 @@ void SatisfactionLink::setup_sat_body(void)
 	std::vector<std::set<Handle>> comp_vars;
 	get_connected_components(_varlist.varset, _fixed, comps, comp_vars);
 
-	// If there are no virtuals, and there is only one connected
-	// component, then this is just a single Concrete link; perform
-	// the rest of initialization for just that.  There is a pathological
-	// case where there are no virtuals, but there are multiple
-	// disconnected components.  I think that this is a user-error,
-	// but in fact PLN does have a rule which wants to explore that
-	// combinatoric explosion, on purpose. So we have to allow the
-	// multiple disconnected components for that case.
+	// If there is only one connected component, then this can be handled
+	// during search by a single Concrete link. The multi-clause grounding
+	// mechanism is not required for that case.
 	_num_comps = comps.size();
 	_num_virts = _virtual.size();
-	if (0 == _num_virts and 1 == _num_comps)
+	if (1 == _num_comps)
 	{
 		make_connectivity_map(_pat.cnf_clauses);
 		return;
@@ -70,6 +65,12 @@ void SatisfactionLink::setup_sat_body(void)
 
 	// If we are here, then set up a ConcreteLink for each connected
 	// component.  Use emplace_back to avoid a copy.
+	//
+	// There is a pathological case where there are no virtuals, but
+	// there are multiple disconnected components.  I think that this is
+	// a user-error, but in fact PLN does have a rule which wants to
+	// explore that combinatoric explosion, on purpose. So we have to
+	// allow the multiple disconnected components for that case.
 	_components.reserve(_num_comps);
 	for (size_t i=0; i<_num_comps; i++)
 	{

--- a/opencog/atoms/bind/SatisfactionLink.cc
+++ b/opencog/atoms/bind/SatisfactionLink.cc
@@ -45,9 +45,9 @@ void SatisfactionLink::setup_sat_body(void)
 	validate_clauses(_varlist.varset, _pat.clauses);
 	extract_optionals(_varlist.varset, _pat.clauses);
 	unbundle_virtual(_varlist.varset, _pat.cnf_clauses,
-                    _fixed, _virtual);
+                    _fixed, _virtual, _pat.black);
 
-	// Split the non virtual clauses into connected components
+	// Split the non-virtual clauses into connected components
 	std::vector<HandleSeq> comps;
 	std::vector<std::set<Handle>> comp_vars;
 	get_connected_components(_varlist.varset, _fixed, comps, comp_vars);

--- a/opencog/query/DefaultPatternMatchCB.h
+++ b/opencog/query/DefaultPatternMatchCB.h
@@ -102,7 +102,9 @@ class DefaultPatternMatchCB : public virtual PatternMatchCallback
 		bool _have_evaluatables;
 
 		virtual Handle find_starter(const Handle&, size_t&, Handle&, size_t&);
-		virtual Handle find_thinnest(const HandleSeq&, Handle&, size_t&);
+		virtual Handle find_thinnest(const HandleSeq&,
+		                             const std::set<Handle>&,
+		                             Handle&, size_t&);
 		virtual void find_rarest(const Handle&, Handle&, size_t&);
 
 		bool _search_fail;

--- a/opencog/query/Pattern.h
+++ b/opencog/query/Pattern.h
@@ -82,21 +82,32 @@ struct Pattern
 	/// The actual clauses. Set by validate_clauses()
 	HandleSeq        clauses;
 
-	// The cnf_clauses are the clauses, but with the AbsentLink, NotLink
-	// removed. This simplifies graph discovery, so that when they are
-	// found, they can be rejected (e.g. are not absent)
-	HandleSeq        cnf_clauses;  // AbsentLink, NotLink removed!
+	// The cnf_clauses are the clauses, but with the AbsentLink removed.
+	// This simplifies graph discovery, so that when they are found,
+	// they can be rejected (e.g. are not absent).
+	HandleSeq        cnf_clauses;  // AbsentLink removed!
 
 	// The mandatory clauses must be grounded.
 	HandleSeq        mandatory;
 
-	// The optional clauses don't have to be. This is where the
-	// negated/absent clauses are held, so e.g. if these get grounded,
-	// they might be rejected.
+	// The optional clauses don't have to be grounded, but they might be.
+	// This is where the absent clauses are held, so e.g. if these do get
+	// grounded, they might be rejected (depending on the callback).
 	std::set<Handle> optionals;    // Optional clauses
 
+	// Black-box clauses. These are clauses that contain GPN's. These
+	// have to drop into scheme or python to get evaluated, which means
+	// that they will be slow.  So, we leave these for last, so that the
+	// faster clauses can run first, and rule out un-needed evaluations.
+	std::set<Handle> black;       // Black-box clauses
+
+	// Evaluatable terms are those that hold a GroundedPredicateNode
+	// (GPN) in them, or are stand-ins (e.g. GreaterThanLink, EqualLink).
 	std::set<Handle> evaluatable_terms;   // smallest term that is evaluatable
 	std::set<Handle> evaluatable_holders; // holds something evaluatable.
+
+	// Execuatable terms are those that hold a GroundedSchemaNode (GSN)
+	// in them.
 	std::set<Handle> executable_terms;    // smallest term that is executable
 	std::set<Handle> executable_holders;  // holds something executable.
 

--- a/opencog/query/PatternMatch.cc
+++ b/opencog/query/PatternMatch.cc
@@ -342,11 +342,10 @@ bool ConcreteLink::satisfy(PatternMatchCallback& pmcb) const
 
 bool SatisfactionLink::satisfy(PatternMatchCallback& pmcb) const
 {
-	// We allow a combinatoric explosion of multiple components,
-	// but zero virtuals, because PLN has a use case for this.
-	// I think its a pathological situation, but they really do
-	// want to explore the combinatoric explosion.
-	if (0 == _num_virts and 1 == _num_comps)
+	// If there is just one connected component, we don't have to
+	// do anything special to find a grounding for it.  Proceed
+	// as normal.
+	if (1 == _num_comps)
 	{
 		return ConcreteLink::satisfy(pmcb);
 	}
@@ -385,7 +384,7 @@ bool SatisfactionLink::satisfy(PatternMatchCallback& pmcb) const
 		       i, _num_comps);
 		// Pass through the callbacks, collect up answers.
 		PMCGroundings gcb(pmcb);
-		ConcreteLinkPtr clp(ConcreteLinkCast(_components[i]));
+		ConcreteLinkPtr clp(ConcreteLinkCast(_components.at(i)));
 		clp->satisfy(gcb);
 
 		comp_var_gnds.push_back(gcb._var_groundings);

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1163,7 +1163,6 @@ bool PatternMatchEngine::get_next_untried_helper(bool search_virtual,
 		const RootList& rl(_pat->connectivity_map.at(pursue));
 #endif
 
-		unsolved = false;
 		for (const Handle& root : rl)
 		{
 			if ((issued.end() == issued.find(root))

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -311,12 +311,28 @@ bool PatternMatchEngine::tree_compare(const Handle& hp,
 		{ dbgprt("Its evaluatable, continuing.\n"); }
 	}
 
-	// If both are links, compare them as such.
-	// Unless pattern link is a QuoteLink, in which case, the quoted
-	// contents is compared. (well, that was done up above...)
+	// If both are nodes, compare them as such.
+	NodePtr np(NodeCast(hp));
+	NodePtr ng(NodeCast(hg));
+	if (np and ng)
+	{
+		// Call the callback to make the final determination.
+		bool match = _pmc.node_match(hp, hg);
+		if (match)
+		{
+			dbgprt("Found matching nodes\n");
+			prtmsg("# pattern: ", hp);
+			prtmsg("# match:   ", hg);
+			if (hp != hg) var_grounding[hp] = hg;
+		}
+		return match;
+	}
+
+	// If They're not both are links, then it is clearly a mismatch.
 	LinkPtr lp(LinkCast(hp));
 	LinkPtr lg(LinkCast(hg));
-	if (lp and lg)
+	if (not (lp and lg)) return false;
+
 	{
 #ifdef NO_SELF_GROUNDING
 		// The proposed grounding must NOT contain any bound variables!
@@ -514,7 +530,7 @@ bool PatternMatchEngine::tree_compare(const Handle& hp,
 
 				more_depth --;
 				depth --;
-				dbgprt("tree_comp down unordered link depth=%lu mismatch=%d\n",
+				dbgprt("tree_comp down unordered link depth=%lu match=%d\n",
 				       more_depth, match);
 
 				// If we've found a grounding, lets see if the
@@ -577,22 +593,6 @@ bool PatternMatchEngine::tree_compare(const Handle& hp,
 		return match;
 	}
 
-	// If both are nodes, compare them as such.
-	NodePtr np(NodeCast(hp));
-	NodePtr ng(NodeCast(hg));
-	if (np and ng)
-	{
-		// Call the callback to make the final determination.
-		bool match = _pmc.node_match(hp, hg);
-		if (match)
-		{
-			dbgprt("Found matching nodes\n");
-			prtmsg("# pattern: ", hp);
-			prtmsg("# match:   ", hg);
-			if (hp != hg) var_grounding[hp] = hg;
-		}
-		return match;
-	}
 
 	// If we got to here, there is a clear mismatch, probably because
 	// one is a node, and the other a link.

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -266,6 +266,25 @@ bool PatternMatchEngine::self_compare(const Handle& hp)
 }
 
 /* ======================================================== */
+
+/// If both are nodes, compare them as such.
+bool PatternMatchEngine::node_compare(const Handle& hp,
+                                      const Handle& hg)
+{
+	// Call the callback to make the final determination.
+	bool match = _pmc.node_match(hp, hg);
+	if (match)
+	{
+		dbgprt("Found matching nodes\n");
+		prtmsg("# pattern: ", hp);
+		prtmsg("# match:   ", hg);
+		if (hp != hg) var_grounding[hp] = hg;
+	}
+	return match;
+}
+
+/* ======================================================== */
+/* ======================================================== */
 /**
  * tree_compare compares two trees, side-by-side.
  *
@@ -335,18 +354,7 @@ bool PatternMatchEngine::tree_compare(const Handle& hp,
 	NodePtr np(NodeCast(hp));
 	NodePtr ng(NodeCast(hg));
 	if (np and ng)
-	{
-		// Call the callback to make the final determination.
-		bool match = _pmc.node_match(hp, hg);
-		if (match)
-		{
-			dbgprt("Found matching nodes\n");
-			prtmsg("# pattern: ", hp);
-			prtmsg("# match:   ", hg);
-			if (hp != hg) var_grounding[hp] = hg;
-		}
-		return match;
-	}
+		return node_compare(hp, hg);
 
 	// If they're not both are links, then it is clearly a mismatch.
 	LinkPtr lp(LinkCast(hp));
@@ -386,9 +394,7 @@ bool PatternMatchEngine::tree_compare(const Handle& hp,
 	// If the pattern is defined elsewhere, not here, then we have
 	// to go to where it is defined, and pattern match things there.
 	if (BETA_REDEX == tp)
-	{
 		return redex_compare(lp, lg);
-	}
 
 	// Let the callback perform basic checking.
 	bool match = _pmc.link_match(lp, lg);

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1064,8 +1064,16 @@ void PatternMatchEngine::get_next_untried_clause(void)
 	// First, try to ground all the mandatory clauses, only.
 	// no virtuals, no black boxes, no optionals.
 	if (get_next_untried_helper(false, false, false)) return;
-	if (get_next_untried_helper(true, false, false)) return;
-	if (get_next_untried_helper(true, true, false)) return;
+
+	// Don't bother looking for evaluatables if they are not there.
+	if (not _pat->evaluatable_holders.empty())
+	{
+		if (get_next_untried_helper(true, false, false)) return;
+		if (not _pat->black.empty())
+		{
+			if (get_next_untried_helper(true, true, false)) return;
+		}
+	}
 
 	// If there are no optional clauses, we are done.
 	if (_pat->optionals.empty())
@@ -1078,8 +1086,14 @@ void PatternMatchEngine::get_next_untried_clause(void)
 
 	// Try again, this time, considering the optional clauses.
 	if (get_next_untried_helper(false, false, true)) return;
-	if (get_next_untried_helper(true, false, true)) return;
-	if (get_next_untried_helper(true, true, true)) return;
+	if (not _pat->evaluatable_holders.empty())
+	{
+		if (get_next_untried_helper(true, false, true)) return;
+		if (not _pat->black.empty())
+		{
+			if (get_next_untried_helper(true, true, true)) return;
+		}
+	}
 
 	// If we are here, there are no more unsolved clauses to consider.
 	curr_root = Handle::UNDEFINED;

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -311,7 +311,7 @@ bool PatternMatchEngine::choice_compare(const Handle& hp,
 
 		dbgprt("tree_comp or_link choice %zu of %zu\n", i, iend);
 
-		match = tree_recurse(hop, hg, CALL_CHOICE);
+		bool match = tree_recurse(hop, hg, CALL_CHOICE);
 		if (match)
 		{
 			// If we've found a grounding, lets see if the
@@ -369,7 +369,7 @@ bool PatternMatchEngine::ordered_compare(const Handle& hp,
 	depth ++;
 	more_depth ++;
 
-	match = true;
+	bool match = true;
 	for (size_t i=0; i<oset_sz; i++)
 	{
 		if (not tree_recurse(osp[i], osg[i], CALL_ORDER))
@@ -451,7 +451,7 @@ bool PatternMatchEngine::unorder_compare(const Handle& hp,
 		have_more = false;
 		more_depth ++;
 
-		match = true;
+		bool match = true;
 		for (size_t i=0; i<oset_sz; i++)
 		{
 			if (not tree_recurse(mutation[i], osg[i], CALL_UNORDER))

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1127,7 +1127,6 @@ bool PatternMatchEngine::get_next_untried_helper(bool search_virtual,
 	Handle pursue(Handle::UNDEFINED);
 	Handle unsolved_clause(Handle::UNDEFINED);
 	bool unsolved = false;
-	bool solved = false;
 	unsigned int thinnest = UINT_MAX;
 
 	// Make a list of the as-yet ungrounded variables.
@@ -1165,14 +1164,9 @@ bool PatternMatchEngine::get_next_untried_helper(bool search_virtual,
 #endif
 
 		unsolved = false;
-		solved = false;
 		for (const Handle& root : rl)
 		{
-			if (Handle::UNDEFINED != clause_grounding[root])
-			{
-				solved = true;
-			}
-			else if ((issued.end() == issued.find(root))
+			if ((issued.end() == issued.find(root))
 			        and (search_virtual or not is_evaluatable(root))
 			        and (search_black or not is_black(root))
 			        and (search_optionals or not is_optional(root)))
@@ -1185,13 +1179,13 @@ bool PatternMatchEngine::get_next_untried_helper(bool search_virtual,
 					unsolved = true;
 				}
 			}
-			if (solved and unsolved and thinnest < 2) break;
+			if (unsolved and thinnest < 2) break;
 		}
 
-		if (solved and unsolved and thinnest < 2) break;
+		if (unsolved and thinnest < 2) break;
 	}
 
-	if (solved and unsolved)
+	if (unsolved)
 	{
 		// Pursue is a pointer to a (variable) node that's shared between
 		// several clauses. One of the clauses has been grounded,

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -67,6 +67,9 @@ class PatternMatchEngine
 		bool is_evaluatable(const Handle& h) {
 			return (_pat->evaluatable_holders.count(h) != 0); }
 
+		bool is_black(const Handle& h) {
+			return (_pat->black.count(h) != 0); }
+
 		// -------------------------------------------
 		// Recursive redex support. These are stacks of the clauses
 		// above, that are being searched.
@@ -158,7 +161,7 @@ class PatternMatchEngine
 
 		bool clause_accepted;
 		void get_next_untried_clause(void);
-		bool get_next_untried_helper(bool);
+		bool get_next_untried_helper(bool, bool, bool);
 
 		// --------------------------------------------------
 		// Unordered-link stuff. This needs a major overhaul.

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -162,6 +162,7 @@ class PatternMatchEngine
 		bool clause_accepted;
 		void get_next_untried_clause(void);
 		bool get_next_untried_helper(bool, bool, bool);
+		unsigned int thickness(const Handle&, const std::set<Handle>&);
 
 		// --------------------------------------------------
 		// Unordered-link stuff. This needs a major overhaul.

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -159,6 +159,8 @@ class PatternMatchEngine
 		                    const LinkPtr&, const LinkPtr&);
 		bool ordered_compare(const Handle&, const Handle&,
 		                     const LinkPtr&, const LinkPtr&);
+		bool unorder_compare(const Handle&, const Handle&,
+		                     const LinkPtr&, const LinkPtr&);
 
 		// See PatternMatchEngine.cc for descriptions
 		bool start_sol_up(const Handle&);

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -152,6 +152,8 @@ class PatternMatchEngine
 		bool tree_recurse(const Handle&, const Handle&, Caller);
 		bool redex_compare(const LinkPtr&, const LinkPtr&);
 		bool quote_compare(const Handle&, const Handle&);
+		bool variable_compare(const Handle&, const Handle&);
+		bool self_compare(const Handle&);
 
 		// See PatternMatchEngine.cc for descriptions
 		bool start_sol_up(const Handle&);

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -151,6 +151,7 @@ class PatternMatchEngine
 		bool tree_compare(const Handle&, const Handle&, Caller);
 		bool tree_recurse(const Handle&, const Handle&, Caller);
 		bool redex_compare(const LinkPtr&, const LinkPtr&);
+		bool quote_compare(const Handle&, const Handle&);
 
 		// See PatternMatchEngine.cc for descriptions
 		bool start_sol_up(const Handle&);

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -150,10 +150,11 @@ class PatternMatchEngine
 
 		bool tree_compare(const Handle&, const Handle&, Caller);
 		bool tree_recurse(const Handle&, const Handle&, Caller);
-		bool redex_compare(const LinkPtr&, const LinkPtr&);
 		bool quote_compare(const Handle&, const Handle&);
 		bool variable_compare(const Handle&, const Handle&);
 		bool self_compare(const Handle&);
+		bool node_compare(const Handle&, const Handle&);
+		bool redex_compare(const LinkPtr&, const LinkPtr&);
 
 		// See PatternMatchEngine.cc for descriptions
 		bool start_sol_up(const Handle&);

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -155,6 +155,8 @@ class PatternMatchEngine
 		bool self_compare(const Handle&);
 		bool node_compare(const Handle&, const Handle&);
 		bool redex_compare(const LinkPtr&, const LinkPtr&);
+		bool choice_compare(const Handle&, const Handle&,
+		                    const LinkPtr&, const LinkPtr&);
 
 		// See PatternMatchEngine.cc for descriptions
 		bool start_sol_up(const Handle&);

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -157,6 +157,8 @@ class PatternMatchEngine
 		bool redex_compare(const LinkPtr&, const LinkPtr&);
 		bool choice_compare(const Handle&, const Handle&,
 		                    const LinkPtr&, const LinkPtr&);
+		bool ordered_compare(const Handle&, const Handle&,
+		                     const LinkPtr&, const LinkPtr&);
 
 		// See PatternMatchEngine.cc for descriptions
 		bool start_sol_up(const Handle&);

--- a/tests/query/buggy-equal.scm
+++ b/tests/query/buggy-equal.scm
@@ -80,7 +80,9 @@
                         (VariableNode "$B")
                         (VariableNode "$C")
                     )
-                    (InheritanceLink
+                    ; Don't screw-up in-progress searches
+                    ; by using InheritanceLink here.
+                    (ListLink
                         (VariableNode "$A")
                         (VariableNode "$C")
                     )
@@ -154,7 +156,9 @@
                         (VariableNode "$B")
                         (VariableNode "$C")
                     )
-                    (InheritanceLink
+                    ; Don't screw-up in-progress searches
+                    ; by using InheritanceLink here.
+                    (ListLink
                         (VariableNode "$A")
                         (VariableNode "$C")
                     )


### PR DESCRIPTION
Parts of it had grown from a simple, straight-forwrd thing, to a big swamp. Drain some of that swamp, or at least make it easier to navigate.