### PR TITLE
backing store testing update

### DIFF
--- a/opencog/persist/sql/README.md
+++ b/opencog/persist/sql/README.md
@@ -473,8 +473,8 @@ you should:
 So here's a super-short recap:
 
  * Create a user 'opencog_tester' with password 'cheese'.
- * Create a new database: e.g.  `$ createdb test-persist`
- * Create the tables: `$ cat atom.sql | psql test-persist`
+ * Create a new database: e.g.  `$ createdb opencog_test`
+ * Create the tables: `$ cat atom.sql | psql `
  * Create an entry in `~/.odbc.ini`, as explained above.  The entry
    should be called `opencot_test`, and use `opencog_tester` as the user.
  * The file `lib/opencog-test.conf` already has the above as the default
@@ -490,6 +490,7 @@ Unit Test Status
 * As of 2011-04-29 bzr revision 5314, BasicSaveUTest (still) passes.
 * As of 2013-11-26 BasicSaveUTest works and passes, again.
 * As of 2014-06-19 both unit tests work and pass.
+* As of 2015-04-23 both unit tests work and pass.
 
 
 Using the System
@@ -630,13 +631,13 @@ on.
 
 Using SQL Persistence from Scheme
 ---------------------------------
-SQL fetch from store is not automatic!  That is because this layer 
+SQL fetch from store is not automatic!  That is because this layer
 cannot guess the user's intentions. There is no way for this layer
 to guess which atoms might be deleted in a few milliseconds from now,
 or to guess which atoms need to loaded into RAM (do you really want ALL
 of them to be loaded ??)  Some higher level management and policy thread
 will need to make the fetch and store decisions. This layer only
-implements the raw capability: it does not implement the policy. 
+implements the raw capability: it does not implement the policy.
 
 There is one thing that is automatic: when a new atom is added to the
 atomspace, then the database is automatically searched, to see if this

--- a/tests/persist/sql/CMakeLists.txt
+++ b/tests/persist/sql/CMakeLists.txt
@@ -25,12 +25,20 @@ LINK_LIBRARIES(
 
 FIND_PROGRAM(PSQL_EXECUTABLE psql)
 IF (PSQL_EXECUTABLE)
-	SET(ENV{PGPASSWORD} cheese)
-	EXECUTE_PROCESS(COMMAND ${PSQL_EXECUTABLE} -c "SELECT * from TypeCodes;" -d test-persist -U opencog_tester -h localhost
-		OUTPUT_VARIABLE OUT
-		ERROR_VARIABLE ERR
-		RESULT_VARIABLE RC)
-	UNSET(ENV{PGPASSWORD})
+	SET(PG_HOST $ENV{PGHOST})
+	IF (PG_HOST)
+		EXECUTE_PROCESS(COMMAND ${PSQL_EXECUTABLE} -c "SELECT * from TypeCodes;" -d opencog_test -U opencog_tester
+			OUTPUT_VARIABLE OUT
+			ERROR_VARIABLE ERR
+			RESULT_VARIABLE RC)
+	ELSE (PG_HOST)
+		EXECUTE_PROCESS(COMMAND ${PSQL_EXECUTABLE} -c "SELECT * from TypeCodes;" -d opencog_test -U opencog_tester -h localhost
+			OUTPUT_VARIABLE OUT
+			ERROR_VARIABLE ERR
+			RESULT_VARIABLE RC)
+	ENDIF(PG_HOST)
+	UNSET(ENV{PG_HOST})
+
 
 	# Check the return code from PSQL
 	IF (RC)
@@ -47,6 +55,7 @@ ENDIF (PSQL_EXECUTABLE)
 IF (DB_IS_CONFIGURED)
 	ADD_CXXTEST(BasicSaveUTest)
 	ADD_CXXTEST(PersistUTest)
+	MESSAGE(STATUS "Postgres database is configured for unit tests." )
 ELSE (DB_IS_CONFIGURED)
-	MESSAGE(WARNING "SQL database not configured for unit tests! See the README!")
+	MESSAGE(WARNING "Postgres database not configured for unit tests! See the README!")
 ENDIF (DB_IS_CONFIGURED)

--- a/tests/persist/sql/README
+++ b/tests/persist/sql/README
@@ -9,7 +9,7 @@ bother with this configuration, so we disable it to avoid grief.
 To run this test, perform the following steps:
 
 1) If you choose to change the default database name and username, then
-   edit tests/persist/sql/CMakeLists.txt and uncomment 
+   edit tests/persist/sql/CMakeLists.txt and uncomment
    SET(DB_IS_CONFIGURED 1)  It probbly easier to just use the default
    database name and username; see below.
 
@@ -25,7 +25,7 @@ To run this test, perform the following steps:
 
 2c) Create a test database. This can be done at the shell prompt:
 
-    $ createdb test-persist
+    $ createdb opencog_test
 
 2d) If you get an error from the above, about missing createdb permissions,
     Try doing this:
@@ -41,22 +41,22 @@ To run this test, perform the following steps:
     consistent with the ~/.odbc.ini file. Do NOT use your login password!
     Pick something else! Create the user at the shell prompt:
 
-    $ psql -c "CREATE USER opencog_tester WITH PASSWORD 'cheese'" -d test-persist
+    $ psql -c "CREATE USER opencog_tester WITH PASSWORD 'cheese'" -d opencog_test
 
 2f) Check that the above worked, by manually logging in:
 
-    $  psql test-persist -U opencog_tester -W -h localhost
+    $  psql opencog_test -U opencog_tester -W -h localhost
 
     If you can't login, something up above failed.
 
 2g) Initialize the test database by creating tables. Do this with:
 
-    $ cat opencog/persist/sql/atom.sql | psql test-persist -U opencog_tester -W -h localhost
+    $ cat opencog/persist/sql/atom.sql | psql opencog_test -U opencog_tester -W -h localhost
 
 2h) Verify that the tables were created. Login as before, then enter \d
     at the postgres prompt.  You should see this:
 
-    test-persist=> \d
+    opencog_test=> \d
                   List of relations
      Schema |   Name    | Type  |     Owner
     --------+-----------+-------+----------------
@@ -71,7 +71,7 @@ To run this test, perform the following steps:
 2i) Verify that opencog_tester has write permissions to the tables. Do
     this by entering the below.
 
-    test-persist=> INSERT INTO TypeCodes (type, typename) VALUES (97, 'SemanticRelationNode');
+    opencog_test=> INSERT INTO TypeCodes (type, typename) VALUES (97, 'SemanticRelationNode');
 
     You should see the appropriate respone:
 
@@ -96,7 +96,7 @@ To run this test, perform the following steps:
     Trace       = 0
     TraceFile   =
     CommLog     = No
-    Database    = test-persist
+    Database    = opencog_test
     Servername  = localhost
     Port        = 5432
     Username    = opencog_tester
@@ -122,7 +122,7 @@ To run this test, perform the following steps:
     used is the one in the BUILD directory not the SOURCE directory!
 
 3b) If the above still doesn't work, make sure that postgres is actually
-    listening on port 5432, and not some other port.  If it is using a 
+    listening on port 5432, and not some other port.  If it is using a
     different port, then change ~/.odbc.ini to that.  The postgres config
-    can be found in /etc/postgresql/9.1/main/postgresql.conf, look for 
+    can be found in /etc/postgresql/9.1/main/postgresql.conf, look for
     "port =" near the begining of the file.


### PR DESCRIPTION
* Enable testing of backing store when postgres database is running on a remote server. 
* Testing while using docker containers are configured as defined in https://github.com/opencog/docker/blob/master/opencog/docker-compose.yml will be possible.
* This will be enabled on buildbot
* Documentation changes for consistency with examples and opencog-test.conf