### PR TITLE
Multiple atom spaces: failed to correctly copy T V

### DIFF
--- a/opencog/atoms/NumberNode.h
+++ b/opencog/atoms/NumberNode.h
@@ -59,7 +59,7 @@ public:
 
 	NumberNode(Node &n)
 		: Node(NUMBER_NODE, std::to_string(std::stod(n.getName())),
-		       n.getTruthValue(), n.getAttentionValue()),
+		       n.getTruthValue()->clone(), n.getAttentionValue()->clone()),
 		  value(std::stod(n.getName()))
 	{
 		OC_ASSERT(NUMBER_NODE == n.getType(), "Bad NumberNode constructor!");

--- a/opencog/atoms/TypeNode.h
+++ b/opencog/atoms/TypeNode.h
@@ -63,8 +63,7 @@ public:
 	{}
 
 	TypeNode(Node &n)
-		: Node(TYPE_NODE, n.getName(),
-		       n.getTruthValue(), n.getAttentionValue()),
+		: Node(n),
 		  value(classserver().getType(n.getName()))
 	{
 		OC_ASSERT(TYPE_NODE == n.getType(), "Bad TypeNode constructor!");

--- a/opencog/atomspace/Link.h
+++ b/opencog/atomspace/Link.h
@@ -133,7 +133,9 @@ public:
      * Cannot be const, because the get() functions can't be,
      * because thread-safe locking required in the gets. */
     Link(Link &l)
-        : Atom(l.getType(), l.getTruthValue(), l.getAttentionValue())
+        : Atom(l.getType(),
+               l.getTruthValue()->clone(),
+               l.getAttentionValue()->clone())
     {
         init(l.getOutgoingSet());
     }

--- a/opencog/atomspace/Node.h
+++ b/opencog/atomspace/Node.h
@@ -72,7 +72,9 @@ public:
      * because thread-safe locking required in the gets.
      */
     Node(Node &n)
-        : Atom(n.getType(), n.getTruthValue(), n.getAttentionValue())
+        : Atom(n.getType(),
+               n.getTruthValue()->clone(),
+               n.getAttentionValue()->clone())
     {
         init(n._name);
     }

--- a/tests/atomspace/MultiSpaceUTest.cxxtest
+++ b/tests/atomspace/MultiSpaceUTest.cxxtest
@@ -214,8 +214,17 @@ public:
 
 		// The truth value *pointers* should differ; they should
 		// have been copied on atom insertion.
-		// XXX this is currently broken :-(  and should be fixed ... 
-//		TS_ASSERT(h1n1->getTruthValue() != h2n1->getTruthValue());
+		TS_ASSERT(h1n1->getTruthValue() != h2n1->getTruthValue());
+		TS_ASSERT(h1n1->getTruthValue() != h3n1->getTruthValue());
+		TS_ASSERT(h2n1->getTruthValue() != h3n1->getTruthValue());
+
+		TS_ASSERT(h1n2->getTruthValue() != h2n2->getTruthValue());
+		TS_ASSERT(h1n2->getTruthValue() != h3n2->getTruthValue());
+		TS_ASSERT(h2n2->getTruthValue() != h3n2->getTruthValue());
+
+		TS_ASSERT(h1n3->getTruthValue() != h2n3->getTruthValue());
+		TS_ASSERT(h1n3->getTruthValue() != h3n3->getTruthValue());
+		TS_ASSERT(h2n3->getTruthValue() != h3n3->getTruthValue());
 	}
 
 	// Test copying back and forth.

--- a/tests/atomspace/MultiSpaceUTest.cxxtest
+++ b/tests/atomspace/MultiSpaceUTest.cxxtest
@@ -140,10 +140,19 @@ public:
 		// Create three copies of this link in three atomspaces
 		Handle h1 = as1.addLink(LIST_LINK, hnd1, hnd2, hnd3);
 		h1->setTruthValue(tv);
-		Handle h2 = as2.addLink(LIST_LINK, hnd1, hnd2, hnd3);
-		h2->setTruthValue(tv);
-		Handle h3 = as3.addLink(LIST_LINK, hnd1, hnd2, hnd3);
-		h3->setTruthValue(tv);
+		Handle h2 = as2.addAtom(h1);
+		Handle h3 = as3.addAtom(h2);
+
+		// The truth value *pointers* should differ; they should
+		// have been copied on atom insertion.
+		TS_ASSERT(h1->getTruthValue() != h2->getTruthValue());
+		TS_ASSERT(h1->getTruthValue() != h3->getTruthValue());
+		TS_ASSERT(h2->getTruthValue() != h3->getTruthValue());
+
+		// The truth values themselves should be equal, as values.
+		TS_ASSERT(*h1->getTruthValue() == *tv);
+		TS_ASSERT(*h2->getTruthValue() == *tv);
+		TS_ASSERT(*h3->getTruthValue() == *tv);
 
 		// Forget about the link atoms, remember thier UUID's only
 		// UUID's are just long ints ...
@@ -225,6 +234,19 @@ public:
 		TS_ASSERT(h1n3->getTruthValue() != h2n3->getTruthValue());
 		TS_ASSERT(h1n3->getTruthValue() != h3n3->getTruthValue());
 		TS_ASSERT(h2n3->getTruthValue() != h3n3->getTruthValue());
+
+		// The truth values themselves should be equal, as values.
+		TS_ASSERT(*h1n1->getTruthValue() == *tv1);
+		TS_ASSERT(*h2n1->getTruthValue() == *tv1);
+		TS_ASSERT(*h3n1->getTruthValue() == *tv1);
+
+		TS_ASSERT(*h1n2->getTruthValue() == *tv2);
+		TS_ASSERT(*h2n2->getTruthValue() == *tv2);
+		TS_ASSERT(*h3n2->getTruthValue() == *tv2);
+
+		TS_ASSERT(*h1n3->getTruthValue() == *tv3);
+		TS_ASSERT(*h2n3->getTruthValue() == *tv3);
+		TS_ASSERT(*h3n3->getTruthValue() == *tv3);
 	}
 
 	// Test copying back and forth.


### PR DESCRIPTION
When placing the same atom into multiple atomspace, the TV was not being correctly cloned, and ended up being shared.  This is an old bug that seemed likely to resurface and bite multi-atomspace users ...