### PR TITLE
You can cog-satisfy anything. You don't have to use BindLink, etc.

### DIFF
--- a/opencog/atoms/bind/ConcreteLink.h
+++ b/opencog/atoms/bind/ConcreteLink.h
@@ -126,6 +126,8 @@ public:
 	// Return the list of variables we are holding.
 	const Variables& get_variables(void) const { return _varlist; }
 
+	const Handle& get_body(void) const { return _body; }
+
 	bool satisfy(PatternMatchCallback&) const;
 
 	void debug_print(void) const;

--- a/opencog/atoms/bind/SatisfactionLink.cc
+++ b/opencog/atoms/bind/SatisfactionLink.cc
@@ -87,6 +87,13 @@ SatisfactionLink::SatisfactionLink(const HandleSeq& hseq,
 	init();
 }
 
+SatisfactionLink::SatisfactionLink(const Handle& body,
+                   TruthValuePtr tv, AttentionValuePtr av)
+	: ConcreteLink(SATISFACTION_LINK, HandleSeq({body}), tv, av)
+{
+	init();
+}
+
 SatisfactionLink::SatisfactionLink(const Handle& vars, const Handle& body,
                    TruthValuePtr tv, AttentionValuePtr av)
 	: ConcreteLink(SATISFACTION_LINK, HandleSeq({vars, body}), tv, av)

--- a/opencog/atoms/bind/SatisfactionLink.h
+++ b/opencog/atoms/bind/SatisfactionLink.h
@@ -72,11 +72,15 @@ protected:
 	void setup_sat_body(void);
 
 public:
-	SatisfactionLink(const HandleSeq&,
+	SatisfactionLink(const Handle& body,
 	         TruthValuePtr tv = TruthValue::DEFAULT_TV(),
 	         AttentionValuePtr av = AttentionValue::DEFAULT_AV());
 
 	SatisfactionLink(const Handle& varcdecls, const Handle& body,
+	         TruthValuePtr tv = TruthValue::DEFAULT_TV(),
+	         AttentionValuePtr av = AttentionValue::DEFAULT_AV());
+
+	SatisfactionLink(const HandleSeq&,
 	         TruthValuePtr tv = TruthValue::DEFAULT_TV(),
 	         AttentionValuePtr av = AttentionValue::DEFAULT_AV());
 

--- a/opencog/query/BindLink.h
+++ b/opencog/query/BindLink.h
@@ -33,6 +33,7 @@ Handle bindlink(AtomSpace*, const Handle&);
 Handle single_bindlink (AtomSpace*, const Handle&);
 Handle pln_bindlink(AtomSpace*, const Handle&);
 TruthValuePtr satisfaction_link(AtomSpace*, const Handle&);
+Handle satisfying_set(AtomSpace*, const Handle&);
 
 } // namespace opencog
 

--- a/opencog/query/PatternSCM.cc
+++ b/opencog/query/PatternSCM.cc
@@ -99,8 +99,10 @@ void PatternSCM::init_in_module(void*)
    // Fuzzy matching.
 	_binders.push_back(new PatternWrap(find_approximate_match, "cog-fuzzy-match"));
 
-	// A bindlink that does not return a value
+	// A bindlink that return a TV
 	_binders.push_back(new PatternWrap(satisfaction_link, "cog-satisfy"));
+
+	_binders.push_back(new PatternWrap(satisfying_set, "cog-satisfying-set"));
 }
 
 PatternSCM::~PatternSCM()

--- a/opencog/query/Satisfier.cc
+++ b/opencog/query/Satisfier.cc
@@ -40,13 +40,20 @@ bool Satisfier::grounding(const std::map<Handle, Handle> &var_soln,
 	return false;
 }
 
-TruthValuePtr opencog::satisfaction_link(AtomSpace* as, const Handle& hsatlink)
+TruthValuePtr opencog::satisfaction_link(AtomSpace* as, const Handle& hlink)
 {
 	Satisfier sater(as);
 
-	SatisfactionLinkPtr bl(SatisfactionLinkCast(hsatlink));
+	SatisfactionLinkPtr bl(SatisfactionLinkCast(hlink));
 	if (NULL == bl)
-		bl = createSatisfactionLink(*LinkCast(hsatlink));
+	{
+		// If it is a BindLink (for example), we want to use that ctor
+		// instead of the default ctor.
+		if (classserver().isA(hlink->getType(), SATISFACTION_LINK))
+			bl = createSatisfactionLink(*LinkCast(hlink));
+		else
+			bl = createSatisfactionLink(hlink);
+	}
 
 	bl->satisfy(sater);
 

--- a/opencog/query/Satisfier.h
+++ b/opencog/query/Satisfier.h
@@ -41,7 +41,7 @@ namespace opencog {
  * grounding of the search pattern.
  *
  * This will set the result TV to TRUE_TV if a grounding is found. More
- * sophisticated TV calculations can be obtained by overloadingthis class.
+ * sophisticated TV calculations can be obtained by overloading this class.
  */
 
 class Satisfier :
@@ -52,6 +52,36 @@ class Satisfier :
 			DefaultPatternMatchCB(as),
 			_result(TruthValue::FALSE_TV()) {}
 		TruthValuePtr _result;
+
+		// Return true if a satisfactory grounding has been
+		// found. Note that in case where you want all possible
+		// groundings, this will usually return false, so the
+		// patternMatchEngine can keep looking for ever more
+		// groundings.
+		virtual bool grounding(const std::map<Handle, Handle> &var_soln,
+		                       const std::map<Handle, Handle> &term_soln);
+};
+
+/**
+ * class SatisfactionSet -- pattern matching callback for finding satsifaction.
+ *
+ * This class is meant to be used with the pattern matcher. When the
+ * pattern matcher calls the callback, it will do so with a particular
+ * grounding of the search pattern.
+ *
+ * This will record every grounding that is found. Thus, after running,
+ * the SatisfyingSet can be examined to see all the groundings that were
+ * found.
+ */
+
+class SatisfactionSet :
+	public virtual DefaultPatternMatchCB
+{
+	public:
+		SatisfactionSet(AtomSpace* as) :
+			DefaultPatternMatchCB(as) {}
+		Handle _body;
+		HandleSeq _satisfying_set;
 
 		// Return true if a satisfactory grounding has been
 		// found. Note that in case where you want all possible

--- a/tests/query/sequence.scm
+++ b/tests/query/sequence.scm
@@ -28,13 +28,11 @@
 ; Should throw an exception in all cases. Shouldn't do donuts on
 ; corn fields.
 (define (off-road)
-	(SatisfactionLink
-		(SequentialAndLink
-			(EvaluationLink
-				(GroundedPredicateNode "scm: stop-go")
-				(ListLink
-					(ConceptNode "corn field")
-				)
+	(SequentialAndLink
+		(EvaluationLink
+			(GroundedPredicateNode "scm: stop-go")
+			(ListLink
+				(ConceptNode "corn field")
 			)
 		)
 	)
@@ -44,28 +42,26 @@
 ;; the matching should stop.  There should be no exceptions or
 ;; errors when evaluating this.
 (define (traffic-lights)
-	(SatisfactionLink
-		(SequentialAndLink
-			(EvaluationLink
-				(GroundedPredicateNode "scm: stop-go")
-				(ListLink green-light)
-			)
+	(SequentialAndLink
+		(EvaluationLink
+			(GroundedPredicateNode "scm: stop-go")
+			(ListLink green-light)
+		)
 
-			(EvaluationLink
-				(GroundedPredicateNode "scm: stop-go")
-				(ListLink green-light)
-			)
+		(EvaluationLink
+			(GroundedPredicateNode "scm: stop-go")
+			(ListLink green-light)
+		)
 
-			(EvaluationLink
-				(GroundedPredicateNode "scm: stop-go")
-				(ListLink red-light)
-			)
+		(EvaluationLink
+			(GroundedPredicateNode "scm: stop-go")
+			(ListLink red-light)
+		)
 
-			(EvaluationLink
-				(GroundedPredicateNode "scm: stop-go")
-				(ListLink
-					(ConceptNode "traffic ticket")
-				)
+		(EvaluationLink
+			(GroundedPredicateNode "scm: stop-go")
+			(ListLink
+				(ConceptNode "traffic ticket")
 			)
 		)
 	)


### PR DESCRIPTION
One short step: you can now call `cog-satisfy` on anything at all. If it has variables in it, they will be grounded. If is has GPN''s in them, they will be evluated. If it has GSN's in it, they will be run. 

If you have to do this over and over again, then please do use `SatisfactionLink`, because it caches the extracted variables, etc. Otherise, its not neeeded. 