### PR TITLE
Fix moses segregation

### DIFF
--- a/opencog/cython/opencog/pymoses.pxd
+++ b/opencog/cython/opencog/pymoses.pxd
@@ -1,3 +1,3 @@
-cdef extern from "moses/moses/main/moses_exec.h" namespace "moses3::moses":
+cdef extern from "moses/moses/main/moses_exec.h" namespace "opencog::moses":
     int moses_exec(int argc, char **argv) except +
 

--- a/opencog/embodiment/AvatarComboVocabulary/AvatarComboVocabulary.h
+++ b/opencog/embodiment/AvatarComboVocabulary/AvatarComboVocabulary.h
@@ -57,7 +57,6 @@ static const definite_object all_agents = "all_agents";
 // and allow several vocabularies to coexist 
 namespace AvatarCombo {
 
-using namespace moses3::combo;
 using namespace opencog::combo;
 
 //return a pointer to class base instance

--- a/opencog/embodiment/AvatarComboVocabulary/avatar_action_symbol.cc
+++ b/opencog/embodiment/AvatarComboVocabulary/avatar_action_symbol.cc
@@ -24,7 +24,7 @@
 #include "avatar_action_symbol.h"
 #include <moses/comboreduct/type_checker/type_tree.h>
 
-using namespace moses3::combo;
+using namespace opencog::combo;
 using namespace avatar_action_symbol_properties;
 
 avatar_action_symbol::avatar_action_symbol() { }

--- a/opencog/embodiment/AvatarComboVocabulary/avatar_action_symbol.h
+++ b/opencog/embodiment/AvatarComboVocabulary/avatar_action_symbol.h
@@ -29,8 +29,6 @@
 #include <moses/comboreduct/combo/action_symbol.h>
 #include "avatar_operator.h"
 
-using namespace moses3::combo;
-
 namespace opencog { namespace combo {
 
 namespace id {

--- a/opencog/embodiment/AvatarComboVocabulary/avatar_builtin_action.cc
+++ b/opencog/embodiment/AvatarComboVocabulary/avatar_builtin_action.cc
@@ -24,7 +24,7 @@
 #include "avatar_builtin_action.h"
 #include <moses/comboreduct/type_checker/type_tree.h>
 
-using namespace moses3::combo;
+using namespace opencog::combo;
 using namespace avatar_builtin_action_properties;
 
 avatar_builtin_action::avatar_builtin_action()

--- a/opencog/embodiment/AvatarComboVocabulary/avatar_builtin_action.h
+++ b/opencog/embodiment/AvatarComboVocabulary/avatar_builtin_action.h
@@ -30,8 +30,6 @@
 
 #include "avatar_operator.h"
 
-using namespace moses3::combo;
-
 namespace opencog { namespace combo {
 
 namespace id {

--- a/opencog/embodiment/AvatarComboVocabulary/avatar_indefinite_object.cc
+++ b/opencog/embodiment/AvatarComboVocabulary/avatar_indefinite_object.cc
@@ -24,7 +24,7 @@
 #include "avatar_indefinite_object.h"
 #include <moses/comboreduct/type_checker/type_tree.h>
 
-using namespace moses3::combo;
+using namespace opencog::combo;
 using namespace avatar_indefinite_object_properties;
 
 avatar_indefinite_object::avatar_indefinite_object()

--- a/opencog/embodiment/AvatarComboVocabulary/avatar_indefinite_object.h
+++ b/opencog/embodiment/AvatarComboVocabulary/avatar_indefinite_object.h
@@ -29,8 +29,6 @@
 #include <moses/comboreduct/combo/indefinite_object.h>
 #include "avatar_operator.h"
 
-using namespace moses3::combo;
-
 namespace opencog { namespace combo {
 
 namespace id {

--- a/opencog/embodiment/AvatarComboVocabulary/avatar_operator.h
+++ b/opencog/embodiment/AvatarComboVocabulary/avatar_operator.h
@@ -30,7 +30,6 @@
 namespace opencog { namespace combo {
 
 using namespace std;
-using namespace moses3::combo;
 
 //this class implement operator_base in a generic way using
 //an enum

--- a/opencog/embodiment/AvatarComboVocabulary/avatar_perception.cc
+++ b/opencog/embodiment/AvatarComboVocabulary/avatar_perception.cc
@@ -24,7 +24,7 @@
 #include "avatar_perception.h"
 #include <moses/comboreduct/type_checker/type_tree.h>
 
-using namespace moses3::combo;
+using namespace opencog::combo;
 using namespace avatar_perception_properties;
 
 avatar_perception::avatar_perception()

--- a/opencog/embodiment/AvatarComboVocabulary/avatar_perception.h
+++ b/opencog/embodiment/AvatarComboVocabulary/avatar_perception.h
@@ -29,8 +29,6 @@
 #include <moses/comboreduct/combo/perception.h>
 #include "avatar_operator.h"
 
-using namespace moses3::combo;
-
 namespace opencog { namespace combo {
 
 namespace id {

--- a/opencog/embodiment/Learning/Filter/EntityRelevanceFilter.h
+++ b/opencog/embodiment/Learning/Filter/EntityRelevanceFilter.h
@@ -35,13 +35,13 @@
 #include <opencog/embodiment/AtomSpaceExtensions/atom_types.h>
 #include <opencog/embodiment/Learning/behavior/WorldProvider.h>
 
-typedef std::vector<moses3::combo::definite_object> definite_object_vec;
+typedef std::vector<opencog::combo::definite_object> definite_object_vec;
 typedef definite_object_vec::iterator definite_object_vec_it;
 typedef definite_object_vec::const_iterator definite_object_vec_const_it;
 typedef std::set<definite_object_vec> definite_object_vec_set;
 typedef definite_object_vec_set::iterator definite_object_vec_set_it;
 typedef definite_object_vec_set::const_iterator definite_object_vec_set_const_it;
-typedef std::map<moses3::combo::definite_object, definite_object_vec_set> agent_to_actions;
+typedef std::map<opencog::combo::definite_object, definite_object_vec_set> agent_to_actions;
 typedef agent_to_actions::iterator agent_to_actions_it;
 typedef agent_to_actions::const_iterator agent_to_actions_const_it;
 
@@ -73,7 +73,7 @@ public:
      * @param type The atom type
      * @return A vector containing all the entities names
      */
-    const moses3::combo::definite_object_set getEntities(Type type = OBJECT_NODE) const;
+    const opencog::combo::definite_object_set getEntities(Type type = OBJECT_NODE) const;
 
     /**
        * Gets the entities (i.e. definite_object) of a given type (and its decendents) in all LocaSpaceMap2D related to a given trick.
@@ -86,7 +86,7 @@ public:
        * @param type The atom type
        * @return A set containing all the entities names
        */
-    const moses3::combo::definite_object_set getEntities(const WorldProvider& wp,
+    const opencog::combo::definite_object_set getEntities(const WorldProvider& wp,
             const std::string& trick,
             const std::string& selfID,
             const std::string& ownerID,
@@ -109,7 +109,7 @@ public:
        *                       start and stop learning
        * @return A set containing all messages meeting the constraint
        */
-    const moses3::combo::message_set getMessages(const WorldProvider& wp,
+    const opencog::combo::message_set getMessages(const WorldProvider& wp,
                                          const std::string& trick,
                                          const std::string& toID = std::string(),
                                          bool exclude_prefix = false,
@@ -131,7 +131,7 @@ public:
        *                       start and stop learning
        * @return A set containing all messages meeting the constraint
        */
-    const moses3::combo::message_set getMessages(const WorldProvider& wp,
+    const opencog::combo::message_set getMessages(const WorldProvider& wp,
                                          Temporal t,
                                          const std::string& toID = std::string(),
                                          bool exclude_prefix = false,
@@ -153,7 +153,7 @@ public:
     *                       start and stop learning
     * @return A set containing all messages meeting the constraint
     */
-    const moses3::combo::message_set getMessages(AtomSpace& as,
+    const opencog::combo::message_set getMessages(AtomSpace& as,
                                          Temporal t,
                                          const std::string& toID = std::string(),
                                          bool exclude_prefix = false,

--- a/opencog/embodiment/Learning/Filter/EntropyFilter.h
+++ b/opencog/embodiment/Learning/Filter/EntropyFilter.h
@@ -61,26 +61,26 @@
 namespace Filter
 {
 
-using namespace moses3::combo;
+using namespace opencog::combo;
 using namespace behavior;
 
-typedef moses3::combo::combo_tree::iterator pre_it;
-typedef moses3::combo::combo_tree::sibling_iterator sib_it;
+typedef opencog::combo::combo_tree::iterator pre_it;
+typedef opencog::combo::combo_tree::sibling_iterator sib_it;
 
 class EntropyFilter
 {
-    typedef moses3::size_tree_order<vertex> combo_tree_order;
+    typedef opencog::size_tree_order<vertex> combo_tree_order;
 
-    typedef std::set<moses3::combo::combo_tree, combo_tree_order> combo_tree_ns_set;
+    typedef std::set<opencog::combo::combo_tree, combo_tree_order> combo_tree_ns_set;
     typedef combo_tree_ns_set::iterator combo_tree_ns_set_it;
     typedef combo_tree_ns_set::const_iterator combo_tree_ns_set_const_it;
 
-    typedef std::map<const moses3::combo::combo_tree, unsigned long, combo_tree_order> combo_tree_time_map;
+    typedef std::map<const opencog::combo::combo_tree, unsigned long, combo_tree_order> combo_tree_time_map;
     typedef combo_tree_time_map::iterator combo_tree_time_map_it;
     typedef combo_tree_time_map::const_iterator combo_tree_time_map_const_it;
 
     typedef std::pair<bool, unsigned long> bool_time_pair;
-    typedef std::map<const moses3::combo::combo_tree, bool_time_pair, combo_tree_order>
+    typedef std::map<const opencog::combo::combo_tree, bool_time_pair, combo_tree_order>
     combo_tree_bool_time_map;
     typedef combo_tree_bool_time_map::iterator combo_tree_bool_time_map_it;
     typedef combo_tree_bool_time_map::const_iterator combo_tree_bool_time_map_const_it;
@@ -102,7 +102,7 @@ class EntropyFilter
     typedef definite_object_hash_set::const_iterator
     definite_object_hash_set_const_it;
 
-    typedef boost::function < bool (const moses3::combo::combo_tree) > EvalFunct;
+    typedef boost::function < bool (const opencog::combo::combo_tree) > EvalFunct;
 
 public:
     //constructor, destructor
@@ -233,7 +233,7 @@ private:
     inline bool getIsMoving(const definite_object& obj);
 
     //eval perception
-    bool evalPerception(Handle smh, const moses3::combo::combo_tree tr);
+    bool evalPerception(Handle smh, const opencog::combo::combo_tree tr);
 
     //build (or rebuild) the set of operands
     //by inserting all new definite_objects, indefinite_objects
@@ -247,7 +247,7 @@ private:
 
     //like above but take in input a combo_tree and the number of arguments
     //that remains to insert on the combo_tree
-    void build_and_insert_atomic_perceptions(const moses3::combo::combo_tree& tr, arity_t arity_rest);
+    void build_and_insert_atomic_perceptions(const opencog::combo::combo_tree& tr, arity_t arity_rest);
 
 };
 

--- a/opencog/embodiment/Learning/FitnessEstimator/DistortedComboSize.h
+++ b/opencog/embodiment/Learning/FitnessEstimator/DistortedComboSize.h
@@ -29,23 +29,23 @@
 namespace FitnessEstimator
 {
 
-using namespace moses3::combo;
+using namespace opencog::combo;
 
-typedef moses3::combo::combo_tree::iterator pre_it;
+typedef opencog::combo::combo_tree::iterator pre_it;
 
 //if DistortedComboSize(tr1)!=size(tr2) then tr1 < tr2
 //otherwise lexicographic_subtree_order
 
-struct DistortedComboSizeOrder : moses3::lexicographic_subtree_order<moses3::combo::vertex> {
+struct DistortedComboSizeOrder : opencog::lexicographic_subtree_order<opencog::combo::vertex> {
     //constructor, destructor
-    DistortedComboSizeOrder(const std::set<moses3::combo::definite_object>& dos)
+    DistortedComboSizeOrder(const std::set<opencog::combo::definite_object>& dos)
             : _dos(dos) {
     }
     ~DistortedComboSizeOrder() {}
     //operator
-    bool operator()(const moses3::combo::combo_tree& tr1, const moses3::combo::combo_tree& tr2) const;
+    bool operator()(const opencog::combo::combo_tree& tr1, const opencog::combo::combo_tree& tr2) const;
 private:
-    const std::set<moses3::combo::definite_object>& _dos;
+    const std::set<opencog::combo::definite_object>& _dos;
 };
 
 struct DistortedComboSize {
@@ -53,10 +53,10 @@ struct DistortedComboSize {
     //for instance random_object has actually size
     //#definite_objects * RANDOM_DISTOR_FACTOR instead of 1
     static int size(const combo_tree& tr,
-                    const std::set<moses3::combo::definite_object>& definite_object_set);
+                    const std::set<opencog::combo::definite_object>& definite_object_set);
 
-    static int vertex_size(const moses3::combo::vertex& v,
-                           const std::set<moses3::combo::definite_object>& definite_object_set);
+    static int vertex_size(const opencog::combo::vertex& v,
+                           const std::set<opencog::combo::definite_object>& definite_object_set);
 
 };
 }

--- a/opencog/embodiment/Learning/FitnessEstimator/NoSpaceLifeFitnessEstimator.h
+++ b/opencog/embodiment/Learning/FitnessEstimator/NoSpaceLifeFitnessEstimator.h
@@ -44,21 +44,21 @@
 #define IS_FE_LRU_CACHE
 #define FE_LRU_CACHE_SIZE 1000000
 
-using namespace moses3;
-using namespace moses3::combo;
+using namespace opencog;
+using namespace opencog::combo;
 
 namespace FitnessEstimator
 {
 
 typedef double fitness_t;
 
-typedef moses3::combo::combo_tree::iterator pre_it;
-typedef moses3::combo::combo_tree::sibling_iterator sib_it;
+typedef opencog::combo::combo_tree::iterator pre_it;
+typedef opencog::combo::combo_tree::sibling_iterator sib_it;
 
 /**
  *fitness estimation using NoSpaceLife and BehaviorDescriptionMatcher
  */
-struct NoSpaceLifeFitnessEstimator: std::unary_function<moses3::combo::combo_tree, fitness_t> {
+struct NoSpaceLifeFitnessEstimator: std::unary_function<opencog::combo::combo_tree, fitness_t> {
 
 public:
 
@@ -82,10 +82,10 @@ public:
                                 const std::string& ownerName,
                                 const std::string& avatarName,
                                 const std::string& trickName,
-                                const moses3::combo::definite_object_set& dos,
+                                const opencog::combo::definite_object_set& dos,
                                 behavior::BehaviorCategory& BDCat,
                                 const std::vector<Temporal>& exemplarTemporals,
-                                const moses3::combo::argument_list_list& all,
+                                const opencog::combo::argument_list_list& all,
                                 int indefinite_object_count,
                                 int operator_count,
                                 int predicate_Count,
@@ -114,7 +114,7 @@ private:
     WorldProvider* _wp; //not const because Combo2BD may add atoms
     //into wp's atomspace
 
-    const moses3::combo::definite_object_set& _dos;
+    const opencog::combo::definite_object_set& _dos;
 
     const std::string& _petName;
     const std::string& _ownerName;
@@ -123,7 +123,7 @@ private:
 
     const behavior::BehaviorCategory& _BDCat; //list of the examplars retreived
     const std::vector<Temporal>& _exemplarTemporals;
-    const moses3::combo::argument_list_list& _all; //argument lists, one for each BD
+    const opencog::combo::argument_list_list& _all; //argument lists, one for each BD
     behavior::BehaviorDescriptionMatcher _BDMatcher;
     SizePenalty _sizePenalty;
 
@@ -131,7 +131,7 @@ private:
     typedef std::vector<fitness_t> fitness_vec;
     typedef fitness_vec::iterator fitness_vec_it;
     typedef fitness_vec::const_iterator fitness_vec_const_it;
-    typedef opencog::lru_cache_arg_result<moses3::combo::combo_tree, fitness_vec> BDCache;
+    typedef opencog::lru_cache_arg_result<opencog::combo::combo_tree, fitness_vec> BDCache;
     mutable BDCache _bd_cache;
     mutable unsigned int _cache_success;
     mutable unsigned int _total_fitness_call;
@@ -147,7 +147,7 @@ private:
     /**
      * private methods
      */
-    int getTrialCount(const moses3::combo::combo_tree& tr) const;
+    int getTrialCount(const opencog::combo::combo_tree& tr) const;
 
 };
 }

--- a/opencog/embodiment/Learning/FitnessEstimator/SizePenalty.h
+++ b/opencog/embodiment/Learning/FitnessEstimator/SizePenalty.h
@@ -37,14 +37,14 @@ private:
     double b;
     double c;
 
-    const std::set<moses3::combo::definite_object>& _dos;
+    const std::set<opencog::combo::definite_object>& _dos;
 
     void setc(int indefinite_object_count, int operator_count,
               int condition_count, int action_count);
 
 public:
 
-    SizePenalty(const std::set<moses3::combo::definite_object>& dos,
+    SizePenalty(const std::set<opencog::combo::definite_object>& dos,
                 int indefinite_object_count = 0, int operator_count = 0,
                 int predicate_count = 0, int action_count = 0);
     ~SizePenalty();
@@ -52,7 +52,7 @@ public:
     //Occam's razor factor
     //tends to 0 when the size of the combo tends to infinity
     //tends to 1 when the size of the combo tends to 1
-    double computeSizePenalty(const moses3::combo::combo_tree& tr) const;
+    double computeSizePenalty(const opencog::combo::combo_tree& tr) const;
 
     void update(int definite_object_count, int operator_count,
                 int condition_count, int action_count);

--- a/opencog/embodiment/Learning/ImitationLearningAPI/PetaverseImitationLearning.h
+++ b/opencog/embodiment/Learning/ImitationLearningAPI/PetaverseImitationLearning.h
@@ -34,7 +34,9 @@
 #include <moses/comboreduct/combo/vertex.h>
 #include <opencog/embodiment/Learning/FitnessEstimator/NoSpaceLifeFitnessEstimator.h>
 
-using namespace moses3;
+// namespace opencog { namespace embodiment {
+
+using namespace opencog;
 
 class PetaverseImitationLearningBase
 {
@@ -42,12 +44,12 @@ class PetaverseImitationLearningBase
 public:
 
     //ns = normal size
-    typedef std::set<moses3::combo::combo_tree, moses3::size_tree_order<moses3::combo::vertex> >
+    typedef std::set<opencog::combo::combo_tree, opencog::size_tree_order<opencog::combo::vertex> >
     combo_tree_ns_set;
 
     typedef double fitness_t;
-    typedef std::set<moses3::combo::definite_object> definite_object_set;
-    typedef std::set<moses3::combo::vertex> operator_set;
+    typedef std::set<opencog::combo::definite_object> definite_object_set;
+    typedef std::set<opencog::combo::vertex> operator_set;
     typedef FitnessEstimator::NoSpaceLifeFitnessEstimator FE;
 
 
@@ -147,7 +149,7 @@ public:
      * is should return the program that has received the maximum reward
      * from the owner.
      */
-    virtual const moses3::combo::combo_tree& best_program() = 0;
+    virtual const opencog::combo::combo_tree& best_program() = 0;
 
     /**
      * This method is called in case there is no best_program,
@@ -156,7 +158,7 @@ public:
      * that is the one that has gotten the highest fitness score
      * of the last fitness estimator (since the last reset_estimator, if so).
      */
-    virtual const moses3::combo::combo_tree& best_program_estimated() = 0;
+    virtual const opencog::combo::combo_tree& best_program_estimated() = 0;
 
     /**
      * This method is called everytime the owner wants the pet to try
@@ -164,7 +166,7 @@ public:
      * a new solution should be returned. Typically this method should return
      * to the owner the best program never tried so far.
      */
-    virtual const moses3::combo::combo_tree& current_program() = 0;
+    virtual const opencog::combo::combo_tree& current_program() = 0;
 
 
     //-----------------------------------------------------------------------
@@ -191,6 +193,6 @@ public:
     virtual void reset_estimator() = 0;
 
 };
-
+		
 #endif
 

--- a/opencog/embodiment/Learning/ImitationLearningAPI/PetaverseVocabularyProvider.h
+++ b/opencog/embodiment/Learning/ImitationLearningAPI/PetaverseVocabularyProvider.h
@@ -37,13 +37,15 @@
 #include <moses/comboreduct/combo/vertex.h>
 #include <opencog/embodiment/AvatarComboVocabulary/AvatarComboVocabulary.h>
 
+// namespace opencog { namespace embodiment {
+
 class PetaverseVocabularyProviderBase
 {
 
 public:
 
-    typedef std::set<moses3::combo::vertex> operator_set;
-    typedef std::set<moses3::combo::indefinite_object> indefinite_object_set;
+    typedef std::set<opencog::combo::vertex> operator_set;
+    typedef std::set<opencog::combo::indefinite_object> indefinite_object_set;
 
     //ctor, dtor
 
@@ -65,4 +67,6 @@ public:
     virtual const indefinite_object_set& get_indefinite_objects() const = 0;
 };
 
+
+		
 #endif

--- a/opencog/embodiment/Learning/LearningServerMessages/SchemaMessage.cc
+++ b/opencog/embodiment/Learning/LearningServerMessages/SchemaMessage.cc
@@ -67,7 +67,7 @@ SchemaMessage::SchemaMessage(const std::string &from, const std::string &to,
 }
 
 SchemaMessage::SchemaMessage(const std::string &from, const std::string &to,
-                             const moses3::combo::combo_tree & comboSchema, const std::string &schemaName,
+                             const opencog::combo::combo_tree & comboSchema, const std::string &schemaName,
                              const std::string &candidateSchemaName) :
         Message(from, to, _schemaMsgType)
 {
@@ -128,7 +128,7 @@ void SchemaMessage::loadPlainTextRepresentation(const char *strMessage)
     }
 }
 
-void SchemaMessage::setSchema(const moses3::combo::combo_tree & comboSchema)
+void SchemaMessage::setSchema(const opencog::combo::combo_tree & comboSchema)
 {
     std::stringstream stream;
     stream << comboSchema;
@@ -136,9 +136,9 @@ void SchemaMessage::setSchema(const moses3::combo::combo_tree & comboSchema)
     this->schema = stream.str();
 }
 
-const moses3::combo::combo_tree SchemaMessage::getComboSchema()
+const opencog::combo::combo_tree SchemaMessage::getComboSchema()
 {
-    using namespace moses3::combo;
+    using namespace opencog::combo;
 
     combo_tree comboSchema;
     std::stringstream stream(schema);

--- a/opencog/embodiment/Learning/LearningServerMessages/SchemaMessage.h
+++ b/opencog/embodiment/Learning/LearningServerMessages/SchemaMessage.h
@@ -57,7 +57,8 @@ public:
     // If candidate schema name isn't set then it is assumed that the
     // message carries the final schema
     SchemaMessage(const std::string &from, const std::string &to,
-                  const moses3::combo::combo_tree & comboSchema, const std::string &schemaName,
+                  const opencog::combo::combo_tree & comboSchema,
+                  const std::string &schemaName,
                   const std::string &candidateSchemaName = "");
 
     /**
@@ -83,14 +84,14 @@ public:
      *
      * @param schema A combom combo_tree representation of the schema
      */
-    void setSchema(const moses3::combo::combo_tree & comboSchema);
+    void setSchema(const opencog::combo::combo_tree & comboSchema);
 
     /**
      * Get the combo combo_tree representation of the schema
      *
      * @return combo_tree representing the schema
      */
-    const moses3::combo::combo_tree getComboSchema();
+    const opencog::combo::combo_tree getComboSchema();
 
     /**
      * Get the string representation of the schema

--- a/opencog/embodiment/Learning/PetaverseHC/HCPetaverseVocabularyProvider.h
+++ b/opencog/embodiment/Learning/PetaverseHC/HCPetaverseVocabularyProvider.h
@@ -40,13 +40,13 @@ using namespace combo;
  */
 
 static const vertex _elementary_operators[] = {
-    moses3::combo::id::sequential_and,
-    moses3::combo::id::action_boolean_if,
+    opencog::combo::id::sequential_and,
+    opencog::combo::id::action_boolean_if,
     // id::action_action_if,
     // id::action_while,
-    moses3::combo::id::boolean_while,
+    opencog::combo::id::boolean_while,
     // id::action_not,
-    moses3::combo::id::logical_not
+    opencog::combo::id::logical_not
 };
 
 static const unsigned int _elementary_operators_size =

--- a/opencog/embodiment/Learning/PetaverseHC/NeighborhoodGenerator.h
+++ b/opencog/embodiment/Learning/PetaverseHC/NeighborhoodGenerator.h
@@ -42,8 +42,8 @@
 
 namespace opencog { namespace hillclimbing {
 
-using namespace moses3::combo;
-using namespace moses3::reduct;
+using namespace opencog::combo;
+using namespace opencog::reduct;
 
 typedef std::set<vertex> object_set;
 typedef object_set::iterator object_set_it;

--- a/opencog/embodiment/Learning/PetaverseHC/hillclimber.h
+++ b/opencog/embodiment/Learning/PetaverseHC/hillclimber.h
@@ -382,7 +382,7 @@ private:
     void populate_neighborhood_from_center() {
         combo_tree center;
         if (_center.empty())
-            center.set_head(moses3::combo::id::sequential_and);
+            center.set_head(opencog::combo::id::sequential_and);
         else center = _center;
         pre_it center_head = center.begin();
         _neighborhoodGenerator.populate_neighborhood(_neighborhood,

--- a/opencog/embodiment/Learning/PetaverseMOSES/moses-learning.h
+++ b/opencog/embodiment/Learning/PetaverseMOSES/moses-learning.h
@@ -26,11 +26,11 @@
 
 #include <opencog/util/tree.h>
 
-#include <opencog/learning/moses/deme/deme_expander.h>
-#include <opencog/learning/moses/metapopulation/metapopulation.h>
-#include <opencog/learning/moses/moses/moses_params.h>
-#include <opencog/learning/moses/scoring/scoring_base.h>
-#include <opencog/learning/moses/optimization/optimization.h>
+#include <moses/moses/deme/deme_expander.h>
+#include <moses/moses/metapopulation/metapopulation.h>
+#include <moses/moses/moses/moses_params.h>
+#include <moses/moses/scoring/scoring_base.h>
+#include <moses/moses/optimization/optimization.h>
 
 #include <opencog/embodiment/Learning/FitnessEstimator/NoSpaceLifeFitnessEstimator.h>
 #include <opencog/embodiment/Learning/FitnessEstimator/DistortedComboSize.h>

--- a/opencog/embodiment/Learning/RewritingRules/RewritingRules.h
+++ b/opencog/embodiment/Learning/RewritingRules/RewritingRules.h
@@ -30,46 +30,46 @@
 #include "hillclimbing_full_reduction.h"
 #include "post_learning_rewriting.h"
 
-namespace moses3 { namespace reduct {
+namespace opencog { namespace reduct {
 
 //hillclimbing
-inline void hillclimbing_full_reduce(moses3::combo::combo_tree& tr, moses3::combo::combo_tree::iterator it)
+inline void hillclimbing_full_reduce(opencog::combo::combo_tree& tr, opencog::combo::combo_tree::iterator it)
 {
     hillclimbing_full_reduction()(tr, it);
 }
 
-inline void hillclimbing_full_reduce(moses3::combo::combo_tree& tr)
+inline void hillclimbing_full_reduce(opencog::combo::combo_tree& tr)
 {
     hillclimbing_full_reduction()(tr);
 }
 
-inline void hillclimbing_perception_reduce(moses3::combo::combo_tree& tr, moses3::combo::combo_tree::iterator it)
+inline void hillclimbing_perception_reduce(opencog::combo::combo_tree& tr, opencog::combo::combo_tree::iterator it)
 {
     hillclimbing_perception_reduction()(tr, it);
 }
 
-inline void hillclimbing_perception_reduce(moses3::combo::combo_tree& tr)
+inline void hillclimbing_perception_reduce(opencog::combo::combo_tree& tr)
 {
     hillclimbing_perception_reduction()(tr);
 }
 
-inline void hillclimbing_action_reduce(moses3::combo::combo_tree& tr, moses3::combo::combo_tree::iterator it)
+inline void hillclimbing_action_reduce(opencog::combo::combo_tree& tr, opencog::combo::combo_tree::iterator it)
 {
     hillclimbing_action_reduction()(tr, it);
 }
 
-inline void hillclimbing_action_reduce(moses3::combo::combo_tree& tr)
+inline void hillclimbing_action_reduce(opencog::combo::combo_tree& tr)
 {
     hillclimbing_action_reduction()(tr);
 }
 
 //post_learning
-inline void post_learning_rewrite(moses3::combo::combo_tree& tr, moses3::combo::combo_tree::iterator it)
+inline void post_learning_rewrite(opencog::combo::combo_tree& tr, opencog::combo::combo_tree::iterator it)
 {
     post_learning_rewriting()(tr, it);
 }
 
-inline void post_learning_rewrite(moses3::combo::combo_tree& tr)
+inline void post_learning_rewrite(opencog::combo::combo_tree& tr)
 {
     post_learning_rewriting()(tr);
 }

--- a/opencog/embodiment/Learning/RewritingRules/hillclimbing_action_reduction.cc
+++ b/opencog/embodiment/Learning/RewritingRules/hillclimbing_action_reduction.cc
@@ -21,11 +21,11 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/comboreduct/reduct/reduct.h>
+#include <moses/comboreduct/reduct/reduct.h>
 #include "hillclimbing_action_reduction.h"
-#include <opencog/comboreduct/reduct/meta_rules.h>
-#include <opencog/comboreduct/reduct/general_rules.h>
-#include <opencog/comboreduct/reduct/action_rules.h>
+#include <moses/comboreduct/reduct/meta_rules.h>
+#include <moses/comboreduct/reduct/general_rules.h>
+#include <moses/comboreduct/reduct/action_rules.h>
 
 namespace opencog { namespace reduct {
 const rule& hillclimbing_action_reduction()

--- a/opencog/embodiment/Learning/RewritingRules/hillclimbing_action_reduction.h
+++ b/opencog/embodiment/Learning/RewritingRules/hillclimbing_action_reduction.h
@@ -26,7 +26,7 @@
 
 #include <moses/comboreduct/reduct/reduct.h>
 
-namespace moses3 { namespace reduct
+namespace opencog { namespace reduct
 {
 const rule& hillclimbing_action_reduction();
 } // ~namespace reduct

--- a/opencog/embodiment/Learning/RewritingRules/hillclimbing_full_reduction.cc
+++ b/opencog/embodiment/Learning/RewritingRules/hillclimbing_full_reduction.cc
@@ -21,13 +21,13 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/comboreduct/reduct/reduct.h>
+#include <moses/comboreduct/reduct/reduct.h>
 #include "hillclimbing_full_reduction.h"
-#include <opencog/comboreduct/reduct/meta_rules.h>
-#include <opencog/comboreduct/reduct/general_rules.h>
-#include <opencog/comboreduct/reduct/action_rules.h>
-#include <opencog/comboreduct/reduct/perception_rules.h>
-#include <opencog/comboreduct/reduct/logical_rules.h>
+#include <moses/comboreduct/reduct/meta_rules.h>
+#include <moses/comboreduct/reduct/general_rules.h>
+#include <moses/comboreduct/reduct/action_rules.h>
+#include <moses/comboreduct/reduct/perception_rules.h>
+#include <moses/comboreduct/reduct/logical_rules.h>
 
 namespace opencog { namespace reduct {
 

--- a/opencog/embodiment/Learning/RewritingRules/hillclimbing_full_reduction.h
+++ b/opencog/embodiment/Learning/RewritingRules/hillclimbing_full_reduction.h
@@ -26,7 +26,7 @@
 
 #include <moses/comboreduct/reduct/reduct.h>
 
-namespace moses3 { namespace reduct {
+namespace opencog { namespace reduct {
 const rule& hillclimbing_full_reduction();
 }}
 

--- a/opencog/embodiment/Learning/RewritingRules/hillclimbing_perception_reduction.cc
+++ b/opencog/embodiment/Learning/RewritingRules/hillclimbing_perception_reduction.cc
@@ -21,11 +21,11 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/comboreduct/reduct/reduct.h>
+#include <moses/comboreduct/reduct/reduct.h>
 #include "hillclimbing_perception_reduction.h"
-#include <opencog/comboreduct/reduct/meta_rules.h>
-#include <opencog/comboreduct/reduct/general_rules.h>
-#include <opencog/comboreduct/reduct/perception_rules.h>
+#include <moses/comboreduct/reduct/meta_rules.h>
+#include <moses/comboreduct/reduct/general_rules.h>
+#include <moses/comboreduct/reduct/perception_rules.h>
 
 namespace opencog { namespace reduct {
 

--- a/opencog/embodiment/Learning/RewritingRules/hillclimbing_perception_reduction.h
+++ b/opencog/embodiment/Learning/RewritingRules/hillclimbing_perception_reduction.h
@@ -26,7 +26,7 @@
 
 #include <moses/comboreduct/reduct/reduct.h>
 
-namespace moses3 { namespace reduct
+namespace opencog { namespace reduct
 {
 const rule& hillclimbing_perception_reduction();
 }}

--- a/opencog/embodiment/Learning/RewritingRules/post_learning_rewriting.cc
+++ b/opencog/embodiment/Learning/RewritingRules/post_learning_rewriting.cc
@@ -21,8 +21,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/comboreduct/reduct/reduct.h>
-#include <opencog/comboreduct/reduct/meta_rules.h>
+#include <moses/comboreduct/reduct/reduct.h>
+#include <moses/comboreduct/reduct/meta_rules.h>
 
 #include "post_learning_rewriting.h"
 #include "post_learning_rules.h"

--- a/opencog/embodiment/Learning/RewritingRules/post_learning_rewriting.h
+++ b/opencog/embodiment/Learning/RewritingRules/post_learning_rewriting.h
@@ -26,7 +26,7 @@
 
 #include <moses/comboreduct/reduct/reduct.h>
 
-namespace moses3 { namespace reduct
+namespace opencog { namespace reduct
 {
 const rule& post_learning_rewriting();
 }}

--- a/opencog/embodiment/Learning/RewritingRules/post_learning_rules.h
+++ b/opencog/embodiment/Learning/RewritingRules/post_learning_rules.h
@@ -26,7 +26,7 @@
 
 #include <moses/comboreduct/reduct/reduct.h>
 
-namespace moses3 { namespace reduct {
+namespace opencog { namespace reduct {
 
 //add a drop action in front of a grab action
 struct post_learning_drop_before_grab

--- a/opencog/embodiment/Learning/main/post_learning-rewriter.cc
+++ b/opencog/embodiment/Learning/main/post_learning-rewriter.cc
@@ -21,8 +21,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/comboreduct/combo/vertex.h>
-#include <opencog/comboreduct/type_checker/type_tree.h>
+#include <moses/comboreduct/combo/vertex.h>
+#include <moses/comboreduct/type_checker/type_tree.h>
 
 #include <opencog/embodiment/Learning/RewritingRules/RewritingRules.h>
 #include <opencog/embodiment/AvatarComboVocabulary/AvatarComboVocabulary.h>


### PR DESCRIPTION
Fixed a bunch of compile errors to support the new standalone MOSES.

I'm still struggling with linking error:

```
/usr/bin/ld: ../../../util/libcogutil.so: undefined reference to symbol '_ZN5boost9re_detail12perl_matcherIN9__gnu_cxx17__normal_iteratorIPKcSsEESaINS_9sub_matchIS6_EEENS_12regex_traitsIcNS_16cpp_regex_traitsIcEEEEE5matchEv'
/usr/lib/gcc/x86_64-linux-gnu/4.8/../../../x86_64-linux-gnu/libboost_regex.so: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```
I don't understand yet but I'm merging already so others can look at it if they want (it was still breaking anyway).