### PR TITLE
Module move fixes

### DIFF
--- a/tests/cython/PythonModuleUTest.cxxtest
+++ b/tests/cython/PythonModuleUTest.cxxtest
@@ -81,7 +81,7 @@ public:
         config().set("SERVER_CYCLE_DURATION", "10");  // in milliseconds
         TestCogServer& cogserver = static_cast<TestCogServer&>(server(TestCogServer::createInstance)); 
 
-        config().set("MODULES", "opencog/cython/libPythonModule.so");
+        config().set("MODULES", "opencog/modules/python/libPythonModule.so");
         cogserver.loadModules();
     }
 

--- a/tests/nlp/viterbi/ViterbiUTest.cxxtest
+++ b/tests/nlp/viterbi/ViterbiUTest.cxxtest
@@ -58,8 +58,8 @@ class ViterbiUTest: public CxxTest::TestSuite
 
 			// Load the required data
 			config().set("MODULES",
-				"opencog/nlp/types/libnlp-types.so, "
-				"opencog/query/libQueryModule.so");
+				"opencog/modules/libnlp-types.so, "
+				"opencog/modules/libQueryModule.so");
 
 			cogserver().loadModules();
 

--- a/tests/persist/zmq/events/AtomSpacePublisherModuleUTest.cxxtest
+++ b/tests/persist/zmq/events/AtomSpacePublisherModuleUTest.cxxtest
@@ -69,7 +69,8 @@ public:
 
         url = "tcp://localhost:" + config()["ZMQ_EVENT_PORT"];
 
-        config().set("MODULES", "opencog/persist/zmq/events/libatomspacepublishermodule.so");
+        config().set("MODULES",
+                     "opencog/modules/events/libatomspacepublishermodule.so");
         
         logger().setFilename(config()["LOG_FILE"]);
         logger().setLevel(Logger::getLevelFromString(config()["LOG_LEVEL"]));

--- a/tests/reasoning/engine/RuleUTest.cxxtest
+++ b/tests/reasoning/engine/RuleUTest.cxxtest
@@ -103,7 +103,7 @@ void RuleUTest::setUp()
     load_scm_files_from_config(*as);
     
     config().set("MODULES",
-        "opencog/query/libQueryModule.so");
+        "opencog/modules/libQueryModule.so");
     
     cogserver().loadModules();
 }


### PR DESCRIPTION
The following unit tests were failing due to not having the right module paths

RuleUTest
AtomSpacePublisherModuleUTest
PythonModuleUTest
