### PR TITLE
Fix cog-bind human-implies-animal-stv

### DIFF
--- a/examples/pattern-matcher/simple.scm
+++ b/examples/pattern-matcher/simple.scm
@@ -67,7 +67,7 @@
            (VariableNode "$H")
            (ConceptNode "human")
         )
-        (ExecutionLink
+        (ExecutionOutputLink
            (GroundedSchemaNode "scm: modify-stv")
            ; This is the list of arguments to pass to the formula.
            ; Notice that *two* arguments are passed.  The first


### PR DESCRIPTION
Bug found when trying to run:
guile> (cog-bind human-implies-animal-stv)

ExecutionLink should be ExecutionOutputLink.



By the way, the document which describes the pattern matcher need to be update:)
https://docs.google.com/a/singularityu.org/presentation/d/15C2lheJNV6UtrIYcJ2zt5UOui_PhxmMNf2OzwGS5oq8/edit?pli=1#slide=id.p
page 9, Example 2

(cog-bind human-implies-animal) should be (cog-bind human-implies-animal-stv)
