### PR TITLE
Added dependency on attention-types to dynamics/attention.

### DIFF
--- a/opencog/dynamics/attention/CMakeLists.txt
+++ b/opencog/dynamics/attention/CMakeLists.txt
@@ -38,6 +38,8 @@ ADD_LIBRARY(attention SHARED
 	ImportanceUpdatingAgent
 )
 
+ADD_DEPENDENCIES(attention attention-types)
+
 TARGET_LINK_LIBRARIES(attention server ${ATOMSPACE_LIBRARIES})
 
 # HebbianCreationModule


### PR DESCRIPTION
OpenCog build failed because attention atom types were not built. I think a dependency in dynamics/attention/CMakeLists.txt has been missing.