### PR TITLE
"opencog" cython package now in multiple directories

### DIFF
--- a/opencog/cython/opencog/__init__.py
+++ b/opencog/cython/opencog/__init__.py
@@ -1,0 +1,2 @@
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)


### PR DESCRIPTION
Now that the Atomspace has been pulled out into it's own project, the cython "opencog" module is now in multiple directories.

/opencog/build/opencog/cython/opencog

and from the atomspace project:
/usr/local/share/opencog/python/opencog (install directory)
/atomspace/build/opencog/cython/opencog (build directory)

This has caused problems when Python doesn't find a module in the first "opencog" package it comes across and then reports that the module is not found. (See thread on opencog discussion group.)

This commit contains a solution using the __path__ package attribute and pkgutil:
http://stackoverflow.com/questions/2699287/what-is-path-useful-for
https://docs.python.org/2/library/pkgutil.html

I'll put a pull request with similar code for the corresponding directory in the atomspace repo. There perhaps should also be a similar entry for the __init.py__ in the atomspace install directory, I'm not sure

The solution appears to solve the immediate problem, but I think it would be good if someone with more Python experience than myself gives their opinion on the best solution. IOW, perhaps it is better not to have the same package name/scope being spread across multiple directories. 

A different approach would be to use different package path names for different directory locations. Eg., opencog.cython.module and atomspace.cython.module. There's a design question here.

@inflector @cosmoharrigan @linas 
opencog/atomspace#20

Parallel pull request in atomspace repo opencog/atomspace#23


