### PR TITLE
Minor update for sureal and nlp-parse

### DIFF
--- a/opencog/nlp/scm/processing-utils.scm
+++ b/opencog/nlp/scm/processing-utils.scm
@@ -364,7 +364,18 @@
                 (if (string=? "END." line)  ; continuing the tradition of RelEx
                     (break)
                     (begin
-                        (nlp-parse line)
+                        (catch #t
+                            (lambda ()
+                                (nlp-parse line)
+                            )
+                            (lambda (key . parameters)
+                                (begin
+                                    (display "*** Unable to parse: \"")
+                                    (display line)
+                                    (display "\"\n")
+                                )
+                            )
+                        )
                         (set! line (get-line port))
                     )
                 )

--- a/opencog/nlp/sureal/surface-realization.scm
+++ b/opencog/nlp/sureal/surface-realization.scm
@@ -36,7 +36,7 @@
     (if (equal? 'SetLink (cog-type a-set-link))
         (let ((interpretations (cog-chase-link 'ReferenceLink 'InterpretationNode a-set-link)))
             (if (null? interpretations)
-            (create-sentence a-set-link)
+            (delete-duplicates (create-sentence a-set-link))
             (get-sentence interpretations)
             )
         )


### PR DESCRIPTION
- Remove duplicates from the sureal result
- Exception handling for nlp-parse-from-file so that it will keep parsing the rest of the sentences even if some of them can't be parsed successfully for some reason