### PR TITLE
Switched from load-scm-from-file to load

### DIFF
--- a/opencog/reasoning/pln/rules/abduction.scm
+++ b/opencog/reasoning/pln/rules/abduction.scm
@@ -3,7 +3,7 @@
 ;
 ; AND(Inheritance A C, Inheritance B C) entails Inheritance A B
 ;------------------------------------------------------------------------------
-(load-scm-from-file "formulas.scm")
+(load "formulas.scm")
 (define pln-rule-abduction
 	(BindLink
 		(VariableList

--- a/opencog/reasoning/pln/rules/deduction.scm
+++ b/opencog/reasoning/pln/rules/deduction.scm
@@ -4,7 +4,7 @@
 ;
 ; AND(Inheritance A B, Inheritance B C) entails Inheritance A C
 ; -----------------------------------------------------------------------------
-(load-scm-from-file "formulas.scm")
+(load "formulas.scm")
 (define pln-rule-deduction
     (BindLink
         (VariableList


### PR DESCRIPTION
This is the function for relative scm file loading.

load-scm-from-file is generate errors
```
cat: formulas.scm: No such file or directory
```

