### PR TITLE
Cython: Fix the atomspace issues in python binding

### DIFF
--- a/opencog/cython/opencog/CMakeLists.txt
+++ b/opencog/cython/opencog/CMakeLists.txt
@@ -109,6 +109,7 @@ IF (HAVE_SERVER)
 
 	####################### agent finder ########################
 	CYTHON_ADD_MODULE_PYX(agent_finder
+		"${ATOMSPACE_INCLUDE_DIR}/opencog/cython/opencog/atomspace.pxd"
 		"cogserver.pxd"
 		"../../server/Agent.h" "../../server/Request.h"
 		"../../spacetime/SpaceServer.h" "../../spacetime/TimeServer.h"

--- a/opencog/cython/opencog/agent_finder.pyx
+++ b/opencog/cython/opencog/agent_finder.pyx
@@ -31,20 +31,7 @@ import imp
 import traceback
 import opencog.cogserver
 from opencog.cogserver cimport cAgent, stim_t, cRequest
-
-cdef extern from "opencog/atomspace/AtomSpace.h" namespace "opencog":
-    cdef cppclass cAtomSpace "opencog::AtomSpace":
-        AtomSpace()
-
-cdef class AtomSpace:
-    cdef cAtomSpace *atomspace
-    cdef bint owns_atomspace
-
-cdef AtomSpace_factory(cAtomSpace *to_wrap):
-    cdef AtomSpace instance = AtomSpace.__new__(AtomSpace)
-    instance.atomspace = to_wrap
-    instance.owns_atomspace = False
-    return instance
+from opencog.atomspace cimport cAtomSpace, AtomSpace_factory
 
 cdef extern from "agent_finder_types.h" namespace "opencog":
     cdef struct requests_and_agents_t:

--- a/opencog/cython/opencog/cogserver.pxd
+++ b/opencog/cython/opencog/cogserver.pxd
@@ -26,11 +26,9 @@ cdef extern from "opencog/atomspace/Handle.h" namespace "opencog":
     cdef cppclass cHandleSeq "opencog::HandleSeq"
 
 # AtomSpaces
-
+from opencog.atomspace cimport cAtomSpace
 cdef extern from "opencog/server/BaseServer.h" namespace "opencog":
-    cdef cppclass cAtomSpace "opencog::AtomSpace"
-    long server_atomspace()
-
+    cAtomSpace* server_atomspace()
 
 # ideally we'd import these typedefs instead of defining them here but I don't
 # know how to do that with Cython

--- a/opencog/cython/opencog/cogserver.pyx
+++ b/opencog/cython/opencog/cogserver.pyx
@@ -6,14 +6,9 @@ from opencog.cogserver cimport server_atomspace
 
 # For the below to work, we need to put the atomspace.pxd file where
 # cython can find it (viz. /usr/local/include/opencog/cython)
-# from opencog.atomspace cimport cAtomSpace
-from opencog.atomspace import AtomSpace
+from opencog.atomspace cimport AtomSpace_factory
 
 def get_server_atomspace():
-    # We have to pass the atomspace address as long integer,
-    # as otherwise, I cannot figure out how to stop cython
-    # from complaining that it
-    # "Cannot convert 'cAtomSpace *' to Python object"
-    iaddr = server_atomspace()
-    asp = AtomSpace(iaddr)
+    casp = server_atomspace()
+    asp = AtomSpace_factory(casp)
     return asp

--- a/opencog/server/BaseServer.h
+++ b/opencog/server/BaseServer.h
@@ -112,9 +112,9 @@ inline AtomSpace& atomspace(void)
     return server().getAtomSpace();
 }
 
-inline unsigned long server_atomspace(void)
+inline AtomSpace* server_atomspace(void)
 {
-    return (unsigned long) &atomspace();
+    return &atomspace();
 }
 
 /** @}*/


### PR DESCRIPTION
This commit attempt to fix issue #1614, and some part of #1625.

Most of above problems was occured by wrong AtomSpace definition in cython binding. If we wrote `cdef class AtomSpace` in file which not has same name, (e.g. `atomspace.pxd` and `agent_finder.pyx` has different name) cython isn't trying to find its declaration. Instead, cython thinks it is new class. (See http://docs.cython.org/src/userguide/sharing_declarations.html#sharing-extension-types)

To fix this problem, I had deleted duplicated definition of `AtomSpace` class, `AtomSpace_factory` method and imported by cimport statement.

This fix makes atomspace variable work correctly in agent's `run()` method and request's `run()` method. Atoms from that variable are exactly same with cogserver's atoms.

Also, I changed getting server's atomspace by memory address to using pointer. So I think default parameter to get memory address in `AtomSpace` constructor(in atomspace/opencog/cython/opencog/atomspace_details.pyx) is no more need.

Finally, `agent_finder.pyx` needs `atomspace.pxd` in ${ATOMSPACE_INCLUDE_DIR}/opencog/cython/opencog/atomspace.pxd. But there is no `__init__.py` in that directory. I'll PR this problem to atomspace repository.

Execute log after fix
```
TestAgent
param atomspace address
<opencog.atomspace.AtomSpace object at 0x7fc8a2b855d0>
server atomspace address
<opencog.atomspace.AtomSpace object at 0x7fc8a2b855b0>
python shell address
<opencog.atomspace.AtomSpace object at 0x7fc8a2b85590>

param atomspace dir count
61
server atomspace dir count
61
python shell dir count
61

param person exist?
[(DefinedLinguisticConceptNode "person" (av 0 0 0) (stv 1.000000 0.000000)) ; [44]
]
server person exist?
[(DefinedLinguisticConceptNode "person" (av 0 0 0) (stv 1.000000 0.000000)) ; [44]
]
python shell person exist?
[]

clear server atomspace

param person exist?
[]
server person exist?
[]
python shell person exist?
[]

add person to server atomspace
```