### PR TITLE
Call the Query Module's init

### DIFF
--- a/opencog/modules/QueryModule.cc
+++ b/opencog/modules/QueryModule.cc
@@ -24,4 +24,5 @@ QueryModule::~QueryModule()
 void QueryModule::init(void)
 {
 	_pat = new PatternSCM();
+	_pat->module_init();
 }


### PR DESCRIPTION
The new ModuleWrap code path does not call the init method, resulting in QueryModule's scheme primitive not loading on cogserver.

Tried to do it in the constructor of ModuleWrap or PatternSCM, but can't call pure virtual method in constructors.. so doing it on QueryModule.cc instead.