### PR TITLE
Python Shell bug-fixes.

### DIFF
--- a/opencog/shell/PythonShell.cc
+++ b/opencog/shell/PythonShell.cc
@@ -65,4 +65,30 @@ void PythonShell::set_socket(ConsoleSocket *s)
     if (!evaluator) evaluator = &PythonEval::instance();
 }
 
+void PythonShell::eval(const std::string &expr, ConsoleSocket *s)
+{
+    bool selfie = self_destruct;
+    self_destruct = false;
+    GenericShell::eval(expr, s);
+    if (selfie) {
+        self_destruct = true;
+
+        // Eval an empty string as a end-of-file marker. This is needed
+        // to flush pending input in the python sehll, as otherwise,
+        // there is no way to know that no more python input will
+        // arrive!
+        GenericShell::eval("", s);
+    }
+}
+
+void PythonShell::socketClosed(void)
+{
+    // Eval an empty string as a end-of-file marker. This is needed
+    // to flush pending input in the python sehll, as otherwise,
+    // there is no way to know that no more python input will
+    // arrive!
+    GenericShell::eval("", NULL);
+    GenericShell::socketClosed();
+}
+
 #endif

--- a/opencog/shell/PythonShell.h
+++ b/opencog/shell/PythonShell.h
@@ -53,6 +53,8 @@ protected:
 public:
     PythonShell(void);
     virtual ~PythonShell();
+    virtual void eval(const std::string &, ConsoleSocket *);
+    virtual void socketClosed(void);
 };
 
 /** @}*/


### PR DESCRIPTION
It is impossible to find out where the end of a block of python code is, 
until you get an end-of-file on input.  So, on end-of-file, evaluate any
pending unevaluated input.