### PR TITLE
Python -- handle end-of-file

### DIFF
--- a/opencog/shell/GenericShell.cc
+++ b/opencog/shell/GenericShell.cc
@@ -169,7 +169,7 @@ void GenericShell::eval(const std::string &expr, ConsoleSocket *s)
 
 	// Launch the evaluator, possibly in a different thread,
 	// and then send out whatever is reported back.
-	do_eval(expr);
+	line_discipline(expr);
 	std::string retstr = poll_output();
 	while (0 < retstr.size())
 	{
@@ -189,13 +189,13 @@ void GenericShell::eval(const std::string &expr, ConsoleSocket *s)
 
 /* ============================================================== */
 /**
- * Evaluate the expression
+ * Handle special characters, evaluate the expression
  */
-void GenericShell::do_eval(const std::string &expr)
+void GenericShell::line_discipline(const std::string &expr)
 {
 	size_t len = expr.length();
 
-    logger().debug("[GenericShell] do_eval: expr, len of %zd ='%s'", len, expr.c_str());
+	logger().info("[GenericShell] line disc: expr, len of %zd ='%s'", len, expr.c_str());
 
 	// Make sure there is at least one character if we are checking
 	// for abort, interrrupt, escape, etc.
@@ -251,8 +251,8 @@ void GenericShell::do_eval(const std::string &expr)
 		// by itself. This means "leave the shell". We leave the shell by
 		// unsetting the shell pointer in the ConsoleSocket.
 		// 0x4 is ASCII EOT, which is what ctrl-D at keybd becomes.
-		if ((false == evaluator->input_pending()) &&
-		    ((EOT == expr[len-1]) || ((1 == len) && ('.' == expr[0]))))
+		if ((false == evaluator->input_pending()) and
+		    ((EOT == expr[len-1]) or ((1 == len) and ('.' == expr[0]))))
 		{
 			self_destruct = true;
 			put_output("");
@@ -263,16 +263,21 @@ void GenericShell::do_eval(const std::string &expr)
 	}
 
 	/* 
-	 * Sometimes the newline gets cut !?!? This may not be true any
-	 * longer, with the new whiz-bang socket code.
-	 *
-	 * Re-insert it; otherwise, comments within procedures will
-	 * have the effect of commenting out the rest of the procedure,
-	 * leading to garbage.
-	 *
-	 * (This is a pointless string copy, it should be eliminated)
+	 * The newline is always cut. Re-insert it; otherwise, comments
+	 * within procedures will have the effect of commenting out the
+	 * rest of the procedure, leading to garbage.
+	 * (This is a pointless string copy, it should be eliminated.)
 	 */
 	std::string input = expr + "\n";
+	do_eval(input);
+}
+
+/* ============================================================== */
+/**
+ * Evaluate the expression. Assumes line discipline was already done.
+ */
+void GenericShell::do_eval(const std::string &input)
+{
 	eval_done = false;
 	evaluator->begin_eval(); // must be called in same thread as result_poll
 	if (do_async_output)

--- a/opencog/shell/GenericShell.cc
+++ b/opencog/shell/GenericShell.cc
@@ -195,7 +195,8 @@ void GenericShell::line_discipline(const std::string &expr)
 {
 	size_t len = expr.length();
 
-	logger().info("[GenericShell] line disc: expr, len of %zd ='%s'", len, expr.c_str());
+	logger().debug("[GenericShell] line disc: expr, len of %zd ='%s'",
+		len, expr.c_str());
 
 	// Make sure there is at least one character if we are checking
 	// for abort, interrrupt, escape, etc.

--- a/opencog/shell/GenericShell.h
+++ b/opencog/shell/GenericShell.h
@@ -69,6 +69,7 @@ class GenericShell
 		virtual const std::string& get_prompt(void);
 
 		virtual void thread_init(void);
+		virtual void line_discipline(const std::string &expr);
 		virtual void do_eval(const std::string &expr);
 
 		// Async output handling.

--- a/opencog/shell/PythonShell.cc
+++ b/opencog/shell/PythonShell.cc
@@ -77,7 +77,7 @@ void PythonShell::eval(const std::string &expr, ConsoleSocket *s)
         // to flush pending input in the python sehll, as otherwise,
         // there is no way to know that no more python input will
         // arrive!
-        GenericShell::eval("", s);
+        GenericShell::do_eval("");
     }
 }
 
@@ -87,7 +87,7 @@ void PythonShell::socketClosed(void)
     // to flush pending input in the python sehll, as otherwise,
     // there is no way to know that no more python input will
     // arrive!
-    GenericShell::eval("", NULL);
+    GenericShell::do_eval("");
     GenericShell::socketClosed();
 }
 


### PR DESCRIPTION
Split the python shell into two parts, a line-disciple part, and an evaluator part.  
This is needed to corectly handle end-of-file in python.