### PR TITLE
Fix for sentence matching

### DIFF
--- a/opencog/nlp/scm/sentence-matching.scm
+++ b/opencog/nlp/scm/sentence-matching.scm
@@ -20,7 +20,7 @@
     (define (sentence-node)
         (if (cog-atom? input-sentence)
             (if (equal? 'SentenceNode (cog-type input-sentence))
-                (input-sentence)
+                input-sentence
                 (display "Please input a SentenceNode only")
             )
             (car (nlp-parse input-sentence))


### PR DESCRIPTION
The parenthesis should be removed in order to return the SentenceNode