### PR TITLE
Fix for atomspace bug #120

### DIFF
--- a/opencog/modules/CMakeLists.txt
+++ b/opencog/modules/CMakeLists.txt
@@ -70,7 +70,7 @@ ADD_LIBRARY (PersistModule SHARED
 )
 
 TARGET_LINK_LIBRARIES(PersistModule
-	server  # needed for definition of _ZTIN7opencog7RequestE
+	# server  # needed for definition of _ZTIN7opencog7RequestE
 	${ATOMSPACE_LIBRARIES}
 )
 

--- a/opencog/server/CMakeLists.txt
+++ b/opencog/server/CMakeLists.txt
@@ -38,6 +38,7 @@ ADD_LIBRARY (server SHARED
 )
 
 TARGET_LINK_LIBRARIES(server
+	PersistModule
 	nlp-types
 	${ATOMSPACE_LIBRARY}
 	${Boost_FILESYSTEM_LIBRARY}

--- a/opencog/server/CogServer.cc
+++ b/opencog/server/CogServer.cc
@@ -53,9 +53,7 @@
 #include <opencog/util/misc.h>
 #include <opencog/util/platform.h>
 
-#ifdef HAVE_SQL_STORAGE
 #include <opencog/modules/PersistModule.h>
-#endif /* HAVE_SQL_STORAGE */
 
 #include "CogServer.h"
 #include "BaseServer.h"
@@ -744,7 +742,6 @@ void CogServer::openDatabase(void)
         return;
     }
 
-#ifdef HAVE_SQL_STORAGE
     const std::string &dbname = config()["STORAGE"];
     const std::string &username = config()["STORAGE_USERNAME"];
     const std::string &passwd = config()["STORAGE_PASSWD"];
@@ -769,11 +766,6 @@ void CogServer::openDatabase(void)
 
     logger().info("Preload %s as user %s msg: %s",
         dbname.c_str(), username.c_str(), resp.c_str());
-
-#else /* HAVE_SQL_STORAGE */
-    logger().warn(
-        "Server compiled without database support");
-#endif /* HAVE_SQL_STORAGE */
 }
 
 Logger &CogServer::logger()


### PR DESCRIPTION
Specifically, this bug:
https://github.com/opencog/atomspace/issues/120

Note, by the way, that opencog modules appear to be broken;
dlsym is not correctly externalized, and thus, a direct link is
required.