### PR TITLE
Updates for sentence-matching

### DIFF
--- a/opencog/nlp/chatbot/nlp-chat-interface.scm
+++ b/opencog/nlp/chatbot/nlp-chat-interface.scm
@@ -59,7 +59,7 @@
 ;--------------------------------------------------------------------
 (define (wh_query_process query)
     (define temp)
-    (set! temp  (get-similar-sentences query))
+    (set! temp  (get-answers query))
     (cond
         ((equal? #f (car temp)) "Sorry, I don't know the answer")
         (else (car temp))

--- a/opencog/nlp/scm/sentence-matching.scm
+++ b/opencog/nlp/scm/sentence-matching.scm
@@ -1,13 +1,7 @@
-; The get-similar-sentences interface
-(define get-similar-sentences
-	(case-lambda
-		((s) (main-search s '()))
-		((s rl) (main-search s rl))
-	)
-)
-
-; The main get-similar-sentences function.
-; Returns one or more sentences that are structurally similar to the input one.
+; Calls the fuzzy pattern matcher to find similar sentences from the Atomspace.
+;
+; Accepts either an actual sentence or a SentenceNode as the input.
+; Returns one or more similar sentences.
 ;
 ; For example:
 ;    (get-similar-sentences "What did Pete eat?")
@@ -17,21 +11,38 @@
 ; Possible result: 
 ;    (Pete ate apples .)
 ;
-(define (main-search input-sentence rej-list)
+(define (get-similar-sentences input-sentence)
+    (main-ss (sentence-node input-sentence) '())
+)
+
+; Similar to get-similar-sentence but it's mainly for question answering purpose.
+;
+; Find answers (i.e., similar sentences that share some keyword) from the
+; Atomspace by using the fuzzy pattern matcher. By default, it excludes
+; sentences with TruthQuerySpeechAct and InterrogativeSpeechAct.
+;
+; Accepts either an actual sentence or a SentenceNode as the input. Also accepts
+; an optional argument "exclude" which is a list of atoms that we don't want
+; them to exist in the hypergraphs of the answers. By default they are
+; (ConceptNode "TruthQuerySpeechAct") and (ConceptNode "InterrogativeSpeechAct").
+;
+; Returns one or more sentences -- the answers.
+;
+(define get-answers
+    (case-lambda
+        ((question) (main-ss (sentence-node question) (list (ConceptNode "TruthQuerySpeechAct")
+                                                            (ConceptNode "InterrogativeSpeechAct"))))
+        ((question excludes) (main-ss (sentence-node question) excludes))
+    )
+)
+
+; The main function for finding similar sentences
+; Returns one or more sentences that are similar to the input one and
+; contains no atoms
+;
+(define (main-ss sentence-node excludes)
     ; Generate sentences from each of the R2L-SetLinks
     (define (generate-sentences r2l-setlinks) (if (> (length r2l-setlinks) 0) (map sureal r2l-setlinks) '()))
-
-    ; Check if the input-sentence is an actual sentence or a SentenceNode,
-    ; parse and return the corresponding SentenceNode if it is a sentence
-    (define (sentence-node)
-        (if (cog-atom? input-sentence)
-            (if (equal? 'SentenceNode (cog-type input-sentence))
-                input-sentence
-                (display "Please input a SentenceNode only")
-            )
-            (car (nlp-parse input-sentence))
-        )
-    )
 
     (begin
         ; Delete identical sentences from the return set
@@ -43,16 +54,26 @@
                     ; Get the R2L SetLink of the input sentence
                     (car (cog-chase-link 'ReferenceLink 'SetLink
                         (car (cog-chase-link 'InterpretationLink 'InterpretationNode
-                            (car (cog-chase-link 'ParseLink 'ParseNode
-                                (sentence-node)
-                            ))
+                            (car (cog-chase-link 'ParseLink 'ParseNode sentence-node))
                         ))
                     ))
                     'SetLink
-                    rej-list
+                    excludes
                 ))
             )
         )
+    )
+)
+
+; Check if the input-sentence is an actual sentence or a SentenceNode,
+; parse and return the corresponding SentenceNode if it is a sentence
+(define (sentence-node input)
+    (if (cog-atom? input)
+        (if (equal? 'SentenceNode (cog-type input))
+            input
+            (display "Please input a SentenceNode only")
+        )
+        (car (nlp-parse input))
     )
 )
 

--- a/opencog/nlp/scm/sentence-matching.scm
+++ b/opencog/nlp/scm/sentence-matching.scm
@@ -1,3 +1,12 @@
+; The get-similar-sentences interface
+(define get-similar-sentences
+	(case-lambda
+		((s) (main-search s '()))
+		((s rl) (main-search s rl))
+	)
+)
+
+; The main get-similar-sentences function.
 ; Returns one or more sentences that are structurally similar to the input one.
 ;
 ; For example:
@@ -8,7 +17,7 @@
 ; Possible result: 
 ;    (Pete ate apples .)
 ;
-(define (get-similar-sentences input-sentence)
+(define (main-search input-sentence reject-list)
     ; Make sure it is at least a SetLink before sending it to sureal for sentence generation
     (define (to-sureal a-link) (if (equal? 'SetLink (cog-type a-link)) (sureal a-link) #f))
 
@@ -42,6 +51,7 @@
                             ))
                         ))
                     ))
+                    reject-list
                 ))
             )
         )

--- a/opencog/nlp/scm/sentence-matching.scm
+++ b/opencog/nlp/scm/sentence-matching.scm
@@ -17,12 +17,9 @@
 ; Possible result: 
 ;    (Pete ate apples .)
 ;
-(define (main-search input-sentence reject-list)
-    ; Make sure it is at least a SetLink before sending it to sureal for sentence generation
-    (define (to-sureal a-link) (if (equal? 'SetLink (cog-type a-link)) (sureal a-link) #f))
-
+(define (main-search input-sentence rej-list)
     ; Generate sentences from each of the R2L-SetLinks
-    (define (generate-sentences r2l-setlinks) (if (> (length r2l-setlinks) 0) (map to-sureal r2l-setlinks) '()))
+    (define (generate-sentences r2l-setlinks) (if (> (length r2l-setlinks) 0) (map sureal r2l-setlinks) '()))
 
     ; Check if the input-sentence is an actual sentence or a SentenceNode,
     ; parse and return the corresponding SentenceNode if it is a sentence
@@ -51,7 +48,8 @@
                             ))
                         ))
                     ))
-                    reject-list
+                    'SetLink
+                    rej-list
                 ))
             )
         )

--- a/opencog/nlp/scm/sentence-matching.scm
+++ b/opencog/nlp/scm/sentence-matching.scm
@@ -1,3 +1,16 @@
+; Check if the input is an actual sentence or a SentenceNode,
+; parse and return the corresponding SentenceNode if it is a sentence
+;
+(define (sentence-node input)
+    (if (cog-atom? input)
+        (if (equal? 'SentenceNode (cog-type input))
+            input
+            (display "Please input a SentenceNode only")
+        )
+        (car (nlp-parse input))
+    )
+)
+
 ; Calls the fuzzy pattern matcher to find similar sentences from the Atomspace.
 ;
 ; Accepts either an actual sentence or a SentenceNode as the input.
@@ -22,7 +35,7 @@
 ; sentences with TruthQuerySpeechAct and InterrogativeSpeechAct.
 ;
 ; Accepts either an actual sentence or a SentenceNode as the input. Also accepts
-; an optional argument "exclude" which is a list of atoms that we don't want
+; an optional argument "exclude-list" which is a list of atoms that we don't want
 ; them to exist in the hypergraphs of the answers. By default they are
 ; (ConceptNode "TruthQuerySpeechAct") and (ConceptNode "InterrogativeSpeechAct").
 ;
@@ -32,15 +45,15 @@
     (case-lambda
         ((question) (main-ss (sentence-node question) (list (ConceptNode "TruthQuerySpeechAct")
                                                             (ConceptNode "InterrogativeSpeechAct"))))
-        ((question excludes) (main-ss (sentence-node question) excludes))
+        ((question exclude-list) (main-ss (sentence-node question) exclude-list))
     )
 )
 
 ; The main function for finding similar sentences
-; Returns one or more sentences that are similar to the input one and
-; contains no atoms
+; Returns one or more sentences that are similar to the input one but
+; contains no atoms that are listed in the exclude-list
 ;
-(define (main-ss sentence-node excludes)
+(define (main-ss sentence-node exclude-list)
     ; Generate sentences from each of the R2L-SetLinks
     (define (generate-sentences r2l-setlinks) (if (> (length r2l-setlinks) 0) (map sureal r2l-setlinks) '()))
 
@@ -58,22 +71,10 @@
                         ))
                     ))
                     'SetLink
-                    excludes
+                    exclude-list
                 ))
             )
         )
-    )
-)
-
-; Check if the input-sentence is an actual sentence or a SentenceNode,
-; parse and return the corresponding SentenceNode if it is a sentence
-(define (sentence-node input)
-    (if (cog-atom? input)
-        (if (equal? 'SentenceNode (cog-type input))
-            input
-            (display "Please input a SentenceNode only")
-        )
-        (car (nlp-parse input))
     )
 )
 


### PR DESCRIPTION
- Add get-answers scheme function for question answering
- Make sure it always send SetLinks to SuReal by restricting the return type
- Some refactoring

UTest results:
88% tests passed, 4 tests failed out of 34

The following tests FAILED:
	 12 - AnaphoraTest (Failed)
	 17 - PLNRulesUTest (Failed)
	 18 - PythonModuleUTest (Failed)
	 21 - RestApiTest (OTHER_FAULT)
