### PR TITLE
Microplanning: Added imperative sentence form

### DIFF
--- a/opencog/nlp/microplanning/sentence-forms.scm
+++ b/opencog/nlp/microplanning/sentence-forms.scm
@@ -42,5 +42,15 @@
 			)
 		)
 	)
+	
+	(InheritanceLink
+		(ConceptNode "ImperativeUtterance")
+		(OrLink
+			(EvaluationLink
+				(PredicateNode "MicroplanningVerbMarker")
+				(VariableNode "MicroplanningWildcardMarker")
+			)
+		)
+	)
 )
 


### PR DESCRIPTION
Assuming "imperative" uses the structure of using "you" as the subject, than imperative is just like declarative and can be microplanned by looking for subject-verb combo.