### PR TITLE
Support load pln-config.scm from any location

### DIFF
--- a/opencog/reasoning/pln/pln-config.scm
+++ b/opencog/reasoning/pln/pln-config.scm
@@ -42,9 +42,11 @@
 ;;;;;;;;;;;;;;;;
 
 ; Load the rules (use load for relative path w.r.t. to that file)
+(define config-dir (dirname (current-filename)))
+(define (prepend-config-dir fp) (string-append config-dir "/" fp))
 (define rule-files (list "rules/deduction.scm"
                          "rules/modus-ponens.scm"))
-(for-each load rule-files)
+(for-each (lambda (fp) (load (prepend-config-dir fp))) rule-files)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Associate rules to PLN ;;


### PR DESCRIPTION
Loading only worked when doing (load "pln-config.scm") from the current directory. Now you can do (load "../pln-config.scm"), etc.