### PR TITLE
Time stamp r2l outputs from nlp-fc

### DIFF
--- a/opencog/nlp/scm/nlp-fc.scm
+++ b/opencog/nlp/scm/nlp-fc.scm
@@ -16,7 +16,6 @@
         (parse-name (cog-name parse-node))
         )
 
-
      (for-each (lambda (x)
                  (let* ((t1 (cog-outgoing-set x));t1 contains ListLink List of results
                        )
@@ -35,7 +34,6 @@
                )
       result2)
 
-
   (ReferenceLink
     (InterpretationNode (string-append parse-name "_interpretation_$X"))
     ; The function in the SetLink returns a list of outputs that
@@ -47,6 +45,14 @@
   (InterpretationLink
     (InterpretationNode (string-append parse-name "_interpretation_$X"))
     parse-node
+  )
+
+  (AtTimeLink
+      ; FIXME: maybe opencog's internal time octime should be used. Will do for
+      ; now assuming a single instance deals with a single conversation.
+      (TimeNode (number->string (current-time)))
+      (InterpretationNode (string-append parse-name "_interpretation_$X"))
+      (TimeDomainNode "Dialogue-System")
   )
  )
 #t

--- a/opencog/nlp/scm/nlp-fc.scm
+++ b/opencog/nlp/scm/nlp-fc.scm
@@ -1,13 +1,13 @@
-;recomended way
-;1.
-(define (load-r2l-rules rules-file)
-    (load-scm-from-file rules-file)
+; This loads all the rules into the cogserver shell. This assumes that the
+; cogserver is started from in-source build directory.
+(define (load-r2l-rulebase)
+    (load-scm-from-file "../opencog/nlp/relex2logic/loader/load-rules.scm")
+    (load-scm-from-file
+        "../opencog/nlp/relex2logic/loader/gen-r2l-en-rulebase.scm")
 )
-;then call nlp-fc
+
 (define (nlp-fc sent)
   (define mylist '())
-;load rules
-;  (load-scm-from-file rules-file)
 ; run forward chaining on sentence
   (let* ((temp (run-fc sent)); temp contains list of cog-fc results and parse node
         (result1 (car temp));result1 contains Listlink nested 3 times

--- a/opencog/nlp/scm/nlp-fc.scm
+++ b/opencog/nlp/scm/nlp-fc.scm
@@ -52,56 +52,6 @@
 #t
 )
 
-;below function is not recomended for normal use
-(define (nlp-parse-fc sent rules-file)
-  (define mylist '())
-;load rules
-  (load-scm-from-file rules-file)
-; run forward chaining on sentence
-  (let* ((temp (run-fc sent)); temp contains list of cog-fc results and parse node
-        (result1 (car temp));result1 contains Listlink nested 3 times
-        (parse-node (cadr temp))
-        (result2 (cog-outgoing-set result1));result2 contains ListLink nested 2 times
-        (parse-name (cog-name parse-node))
-        )
-
-
-     (for-each (lambda (x)
-                 (let* ((t1 (cog-outgoing-set x));t1 contains ListLink List of results
-                       )
-                       (for-each (lambda (b)
-                                   (let* ((t2 (cog-outgoing-set b)));t2 contains atoms contained in ListLink
-                                    (for-each (lambda(c)
-                                             ;  (display c)
-                                                (set! mylist (append mylist (list c)))
-                                              )
-                                     t2)
-                                   )
-                                 )
-                       t1
-                       )
-                 )
-               )
-      result2)
-
-
-  (ReferenceLink
-    (InterpretationNode (string-append parse-name "_interpretation_$X"))
-    ; The function in the SetLink returns a list of outputs that
-    ; are the results of the evaluation of the relex-to-logic functions,
-    ; on the relex-opencog-outputs.
-  (SetLink (delete-duplicates mylist))
-  )
-
-  (InterpretationLink
-    (InterpretationNode (string-append parse-name "_interpretation_$X"))
-    parse-node
-  )
- )
-#t
-)
-
-
 (define (run-fc sent)
   (define parse-node (car (sentence-get-parses (nlp-parse sent))))
   (list (cog-fc


### PR DESCRIPTION
The  `(TimeDomainNode "Dialogue-System")` is used as the time stamping is needed for pruning the searchspace used by sureal & microplanning. The time stamping doesn't use the time-server for now, but will be required for sureal & microplanner optimization.
