### PR TITLE
Fix unbound variable problem in definite.scm

### DIFF
--- a/opencog/nlp/relex2logic/definite.scm
+++ b/opencog/nlp/relex2logic/definite.scm
@@ -36,7 +36,7 @@
 
 ; This is function is not needed. It is added so as not to break the existing
 ; r2l pipeline.
-(define (pre-definite-rule pred)
+(define (pre-definite-rule noun)
   (ListLink
     	(definite-rule (word-inst-get-word-str noun) (cog-name noun)
     )


### PR DESCRIPTION
Happened to get an "unbound variable: noun" error while testing something else, this should fix it.