### PR TITLE
Remove unneeded str variable

### DIFF
--- a/opencog/nlp/relex2logic/definite.scm
+++ b/opencog/nlp/relex2logic/definite.scm
@@ -38,7 +38,7 @@
 ; r2l pipeline.
 (define (pre-definite-rule noun)
   (ListLink
-    	(definite-rule (cog-name (word-inst-get-lemma str noun)) (cog-name noun)
+    	(definite-rule (cog-name (word-inst-get-lemma noun)) (cog-name noun)
     )
   )
 )


### PR DESCRIPTION
Got an unbound variable error while running it, looks like "str" is not needed here anyway.