### PR TITLE
PythonModuleUTest fix

### DIFF
--- a/tests/cython/pymodule.conf
+++ b/tests/cython/pymodule.conf
@@ -2,4 +2,4 @@
 # cmake replaces this variable
 PYTHON_EXTENSION_DIRS = @CMAKE_SOURCE_DIR@/tests/cython,@CMAKE_SOURCE_DIR@/tests/cython/agents
 
-# PYTHON_PRELOAD = preload_test
+PYTHON_PRELOAD = preload_test

--- a/tests/nlp/CMakeLists.txt
+++ b/tests/nlp/CMakeLists.txt
@@ -16,6 +16,6 @@ IF (HAVE_NOSETESTS)
 		${CMAKE_SOURCE_DIR}/tests/nlp/anaphora)
 	SET_TESTS_PROPERTIES(AnaphoraTest
 		PROPERTIES ENVIRONMENT
-		"PYTHONPATH=/usr/local/share/opencog/python:${PROJECT_SOURCE_DIR}/opencog/nlp:${PROJECT_SOURCE_DIR}/opencog/python")
+	"PYTHONPATH=/usr/local/share/opencog/python:${PROJECT_SOURCE_DIR}/opencog/nlp/anaphora:${PROJECT_SOURCE_DIR}/opencog/python:${PROJECT_BINARY_DIR}/opencog/cython")
 
 ENDIF (HAVE_NOSETESTS)

--- a/tests/nlp/anaphora/test_anaphora.py
+++ b/tests/nlp/anaphora/test_anaphora.py
@@ -5,8 +5,12 @@ import unittest
 from opencog.atomspace import AtomSpace, TruthValue, Atom, Handle
 from opencog.atomspace import types, is_a, get_type, get_type_name
 from opencog.scheme_wrapper import load_scm, scheme_eval, scheme_eval_h, __init__
-from anaphora.agents.hobbs import HobbsAgent
-#from agents.hobbs import HobbsAgent
+# The path is commented out b/c there is no __init__.py in
+# https://github.com/opencog/opencog/tree/master/opencog/nlp don't think it
+# would make sense to add it there as the directory contains code from other
+# languages.
+#from anaphora.agents.hobbs import HobbsAgent
+from agents.hobbs import HobbsAgent
 from unittest import TestCase
 
 


### PR DESCRIPTION
it also partially resolves the path related causes of failure to the AnaphoraTest