### PR TITLE
Rename PLN rules to be consistent with the rest

### DIFF
--- a/examples/moses-pln-synergy/scm/README.md
+++ b/examples/moses-pln-synergy/scm/README.md
@@ -41,7 +41,7 @@ scheme@(guile-user)> (load "pln-config.scm")
 
 ```
 scheme@(guile-user)> ;; Infer that take-treatment-1 implies take-compound-A
-scheme@(guile-user)> (for-each (lambda (i) (cog-bind pln-rule-forall-partial-instantiation)) (iota 20))
+scheme@(guile-user)> (for-each (lambda (i) (cog-bind forall-partial-instantiation-rule)) (iota 20))
 scheme@(guile-user)> (cog-prt-atomspace)
 ...
 scheme@(guile-user)> ;; Search the following string
@@ -79,7 +79,7 @@ scheme@(guile-user)> ;; Search the following string
 
 ...
 
-scheme@(guile-user)> (cog-bind pln-rule-forall-implication-to-higher-order)
+scheme@(guile-user)> (cog-bind forall-implication-to-higher-order-rule)
 ...
    (ImplicationLink (stv 1 0.99999982)
       (LambdaLink

--- a/examples/moses-pln-synergy/scm/pln-config.scm
+++ b/examples/moses-pln-synergy/scm/pln-config.scm
@@ -59,8 +59,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; List the rules and their weights.
-(define rules (list (list pln-rule-deduction-name 1)
-                    (list pln-rule-modus-ponens-name 1)
+(define rules (list (list deduction-rule-name 1)
+                    (list modus-ponens-rule 1)
               )
 )
 

--- a/opencog/reasoning/pln/pln-config.scm
+++ b/opencog/reasoning/pln/pln-config.scm
@@ -53,8 +53,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; List the rules and their weights.
-(define rules (list (list pln-rule-deduction-name 1)
-                    (list pln-rule-modus-ponens-name 1))
+(define rules (list (list deduction-rule-name 1)
+                    (list modus-ponens-rule-name 1))
 )
 
 ; Associate rules to PLN

--- a/opencog/reasoning/pln/rules/README.md
+++ b/opencog/reasoning/pln/rules/README.md
@@ -8,18 +8,18 @@ in Scheme.
 
 The following rules are defined for PLN:
 
-    - pln-rule-and
-    - pln-rule-not
-    - pln-rule-deduction
-    - pln-rule-modus-ponens
+    - and-rule
+    - not-rule
+    - deduction-rule
+    - modus-ponens-rule
     - Context rules:
-        - pln-rule-contextualize-inheritance
-        - pln-rule-contextualize-evaluation
-        - pln-rule-contextualize-subset
-        - pln-rule-decontextualize-inheritance
-        - pln-rule-decontextualize-evaluation
-        - pln-rule-decontextualize-subset
-        - pln-rule-context-free-to-sensitive
+        - contextualize-inheritance-rule
+        - contextualize-evaluation-rule
+        - contextualize-subset-rule
+        - decontextualize-inheritance-rule
+        - decontextualize-evaluation-rule
+        - decontextualize-subset-rule
+        - context-free-to-sensitive-rule
         (here, the exact formula is still unclear)
 
 ## Additional instructions
@@ -73,7 +73,7 @@ in order to compile the rules and formulas for better performance.
 - Run this command:
 
     ```
-    (cog-bind pln-rule-deduction)
+    (cog-bind deduction-rule)
     ```
 
 - Run this command again:

--- a/opencog/reasoning/pln/rules/abduction-rule.scm
+++ b/opencog/reasoning/pln/rules/abduction-rule.scm
@@ -15,14 +15,14 @@
 ;
 ; Due to pattern matching issues, currently the file has been divided into 3 
 ; parts, each pertaining to different links. The rules are :-
-;       pln-rule-abduction-inheritance
-;       pln-rule-abduction-implication
-;       pln-rule-abduction-subset
+;       abduction-inheritance-rule
+;       abduction-implication-rule
+;       abduction-subset-rule
 ;
 ; -----------------------------------------------------------------------------
 (load "formulas.scm")
 
-(define pln-rule-abduction-inheritance
+(define abduction-inheritance-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -39,7 +39,7 @@
                 (VariableNode "$C")
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm:pln-formula-abduction")
+            (GroundedSchemaNode "scm: abduction-formula")
             (ListLink
                 (VariableNode "$A")
                 (VariableNode "$B")
@@ -54,7 +54,7 @@
                     (VariableNode "$A")
                     (VariableNode "$C"))))))
 
-(define pln-rule-abduction-implication
+(define abduction-implication-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -71,7 +71,7 @@
                 (VariableNode "$C")
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm:pln-formula-abduction")
+            (GroundedSchemaNode "scm: abduction-formula")
             (ListLink
                 (VariableNode "$A")
                 (VariableNode "$B")
@@ -86,7 +86,7 @@
                     (VariableNode "$A")
                     (VariableNode "$C"))))))
 
-(define pln-rule-abduction-subset
+(define abduction-subset-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -103,7 +103,7 @@
                 (VariableNode "$C")
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm:pln-formula-abduction")
+            (GroundedSchemaNode "scm: abduction-formula")
             (ListLink
                 (VariableNode "$A")
                 (VariableNode "$B")
@@ -118,7 +118,7 @@
                     (VariableNode "$A")
                     (VariableNode "$C"))))))
 
-(define (pln-formula-abduction A B C AB CB AC)
+(define (abduction-formula A B C AB CB AC)
     (let
         ((sA (cog-stv-strength A))
          (cA (cog-stv-confidence A))
@@ -133,5 +133,6 @@
         (cog-set-tv! 
             AC
             (stv 
-                (simple-deduction-formula sA sB sC sAB (inversion-formula sCB sC sB))
-                (min cAB cCB))))) 
+                (simple-deduction-strength formula sA sB sC sAB
+                                           (inversion-strength-formula sCB sC sB))
+                (min cAB cCB)))))

--- a/opencog/reasoning/pln/rules/abduction.scm
+++ b/opencog/reasoning/pln/rules/abduction.scm
@@ -4,7 +4,7 @@
 ; AND(Inheritance A C, Inheritance B C) entails Inheritance A B
 ;------------------------------------------------------------------------------
 (load "formulas.scm")
-(define pln-rule-abduction
+(define abduction-rule
 	(BindLink
 		(VariableList
 			(VariableNode "$A")
@@ -23,7 +23,7 @@
 					(VariableNode "$A")
 					(VariableNode "$B"))))
 		(ExecutionOutputLink
-			(GroundedSchemaNode "scm: pln-formula-abduction")
+			(GroundedSchemaNode "scm: abduction-formula")
 			(ListLink
 				(InheritanceLink
 					(VariableNode "$A")
@@ -43,10 +43,10 @@
 ; Side-effect: TruthValue of AB may be updated
 ; -----------------------------------------------------------------------------
 
-(define (pln-formula-abduction AB AC BC)
+(define (abduction-formula AB AC BC)
 	(cog-set-tv!
 		AB
-		(pln-formula-abduction-side-effect-free
+		(abduction-side-effect-free-formula
 			AB
 			AC
 			BC
@@ -57,10 +57,10 @@
 ; This version has no side effects and simply returns a TruthValue
 ; -----------------------------------------------------------------------------
 
-(define (pln-formula-abduction-side-effect-free AB AC BC A B C)
+(define (abduction-side-effect-free-formula AB AC BC A B C)
 	(let
 		(
-			(sCB (inversion-formula 
+			(sCB (inversion-strength-formula 
 				(cog-stv-strength BC)
 				(cog-stv-strength B) 
 				(cog-stv-strength C)))
@@ -69,7 +69,7 @@
 			(sB (cog-stv-strength B))
 			(sA (cog-stv-strength A)))
 		(stv 
-			(simple-deduction-formula sA sC sB sAC sCB) ;Strength
+			(simple-deduction-strength-formula sA sC sB sAC sCB) ;Strength
                 	(min
                     		(cog-stv-confidence AB)
                     		(cog-stv-confidence BC))))) ; Confidence
@@ -77,5 +77,5 @@
 ; =============================================================================
 
 ; Name that rule
-(define pln-rule-abduction-name (Node "pln-rule-abduction"))
-(DefineLink pln-rule-abduction-name pln-rule-abduction)
+(define abduction-rule-name (Node "abduction-rule"))
+(DefineLink abduction-rule-name abduction-rule)

--- a/opencog/reasoning/pln/rules/and-as-1st-arg-inside-inheritance-link-rule.scm
+++ b/opencog/reasoning/pln/rules/and-as-1st-arg-inside-inheritance-link-rule.scm
@@ -18,7 +18,7 @@
 ; -----------------------------------------------------------------------------
 (load "formulas.scm")
 
-(define pln-rule-and-as-1st-arg-inside-inheritance-link
+(define and-as-1st-arg-inside-inheritance-link-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -39,7 +39,7 @@
                     (VariableNode "$A")
                     (VariableNode "$B"))))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-and-as-1st-arg")
+            (GroundedSchemaNode "scm: and-as-1st-arg-formula")
             (ListLink
                 (VariableNode "$A")
                 (VariableNode "$B")
@@ -59,7 +59,7 @@
                         (VariableNode "$B"))
                     (VariableNode "$C"))))))
 
-(define (pln-formula-and-as-1st-arg A B C AC BC AB ABC)
+(define (and-as-1st-arg-formula A B C AC BC AB ABC)
     (
         (cog-set-tv! 
             AB 

--- a/opencog/reasoning/pln/rules/and-as-2nd-arg-inside-inheritance-link-rule.scm
+++ b/opencog/reasoning/pln/rules/and-as-2nd-arg-inside-inheritance-link-rule.scm
@@ -18,7 +18,7 @@
 ; -----------------------------------------------------------------------------
 (load "formulas.scm")
 
-(define pln-rule-and-as-2nd-arg-inside-inheritance-link
+(define and-as-2nd-arg-inside-inheritance-link-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -39,7 +39,7 @@
                     (VariableNode "$A")
                     (VariableNode "$B"))))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-and-as-2nd-arg")
+            (GroundedSchemaNode "scm: and-as-2nd-arg-formula")
             (ListLink
                 (VariableNode "$A")
                 (VariableNode "$B")
@@ -59,7 +59,7 @@
                         (VariableNode "$B")
                         (VariableNode "$C")))))))
 
-(define (pln-formula-and-as-2nd-arg A B C AB AC BC ABC)
+(define (and-as-2nd-arg-formula A B C AB AC BC ABC)
     (
         (cog-set-tv! 
             BC

--- a/opencog/reasoning/pln/rules/and-breakdown-rule.scm
+++ b/opencog/reasoning/pln/rules/and-breakdown-rule.scm
@@ -11,7 +11,7 @@
 ;----------------------------------------------------------------------
 
 
-(define pln-rule-and-breakdown
+(define and-breakdown-rule
   (BindLink
    (VariableList
     (VariableNode "$A")
@@ -22,7 +22,7 @@
      (VariableNode "$B"))
     (VariableNode "$A"))
    (ExecutionOutputLink
-    (GroundedSchemaNode "scm: pln-formula-and-breakdown")
+    (GroundedSchemaNode "scm: and-breakdown-formula")
     (ListLink
      (AndLink
       (VariableNode "$A")
@@ -30,13 +30,13 @@
      (VariableNode "$A")
      (VariableNode "$B")))))
 
-(define (pln-formula-and-breakdown AB A B)
+(define (and-breakdown-formula AB A B)
   (cog-set-tv!
    B
-   (pln-formula-and-breakdown-side-effect-free AB A B))
+   (and-breakdown-side-effect-free-formula AB A B))
 )
 
-(define (pln-formula-and-breakdown-side-effect-free AB A B)
+(define (and-breakdown-side-effect-free-formula AB A B)
   (let 
       ((sAB (cog-stv-strength AB))
        (cAB (cog-stv-confidence AB))
@@ -45,5 +45,5 @@
     (stv (/ sAB sA) (min cAB cA))))
 
 ; Name the rule
-(define pln-rule-and-breakdown-name (Node "pln-rule-and-breakdown"))
-(DefineLink pln-rule-and-breakdown-name pln-rule-and-breakdown)
+(define and-breakdown-rule-name (Node "and-breakdown-rule"))
+(DefineLink and-breakdown-rule-name and-breakdown-rule)

--- a/opencog/reasoning/pln/rules/and-construction-rule.scm
+++ b/opencog/reasoning/pln/rules/and-construction-rule.scm
@@ -17,7 +17,7 @@
 ;----------------------------------------------------------------------
 
 
-(define pln-rule-and-construction
+(define and-construction-rule
   (BindLink
      (VariableList
         (TypedVariableLink
@@ -38,18 +38,18 @@
               (VariableNode "$A")
               (VariableNode "$B"))))
      (ExecutionOutputLink
-        (GroundedSchemaNode "scm: pln-formula-and-construction")
+        (GroundedSchemaNode "scm: and-construction-formula")
         (ListLink
            (VariableNode "$A")
            (VariableNode "$B")))))
 
-(define (pln-formula-and-construction A B)
+(define (and-construction-formula A B)
   (cog-set-tv!
    (AndLink A B)
-   (pln-formula-and-side-effect-free A B))
+   (and-side-effect-free-formula A B))
 )
 
-(define (pln-formula-and-side-effect-free A B)
+(define (and-side-effect-free-formula A B)
   (let 
       ((sA (cog-stv-strength A))
        (sB (cog-stv-strength B))
@@ -58,8 +58,8 @@
     (stv (* sA sB) (min cA cB))))
 
 ; Name the rule
-(define pln-rule-and-construction-name
-  (Node "pln-rule-and-construction"))
+(define and-construction-rule-name
+  (Node "and-construction-rule"))
 (DefineLink
-   pln-rule-and-construction-name
-   pln-rule-and-construction)
+   and-construction-rule-name
+   and-construction-rule)

--- a/opencog/reasoning/pln/rules/and-elimination-rule.scm
+++ b/opencog/reasoning/pln/rules/and-elimination-rule.scm
@@ -12,7 +12,7 @@
 ;; an issue with backward chaining.
 ;; TODO :- Create the rule n-ary
 
-(define pln-rule-and-elimination
+(define and-elimination-rule
   (BindLink
    (VariableList
     (VariableNode "$A")
@@ -22,7 +22,7 @@
      (VariableNode "$A")
      (VariableNode "$B")))
    (ExecutionOutputLink
-    (GroundedSchemaNode "scm: pln-formula-and-elimination")
+    (GroundedSchemaNode "scm: and-elimination-formula")
     (ListLink
      (AndLink
       (VariableNode "$A")
@@ -30,21 +30,21 @@
      (VariableNode "$A")
      (VariableNode "$B")))))
 
-(define (pln-formula-and-elimination AB A B)
+(define (and-elimination-formula AB A B)
   (cog-set-tv!
    A
-   (pln-formula-and-elimination-side-effect-free AB))
+   (and-elimination-side-effect-free-formula AB))
   (cog-set-tv!
    B
-   (pln-formula-and-elimination-side-effect-free AB)) 
+   (and-elimination-side-effect-free-formula AB)) 
 )
 
-(define (pln-formula-and-elimination-side-effect-free AB)
+(define (and-elimination-side-effect-free-formula AB)
   (let 
       ((sAB (cog-stv-strength AB))
        (cAB (cog-stv-confidence AB)))
     (stv (expt sAB 0.5) (/ cAB 1.42))))
 
 ; Name the rule
-(define pln-rule-and-elimination-name (Node "pln-rule-and-elimination"))
-(DefineLink pln-rule-and-elimination-name pln-rule-and-elimination)
+(define and-elimination-rule-name (Node "and-elimination-rule"))
+(DefineLink and-elimination-rule-name and-elimination-rule)

--- a/opencog/reasoning/pln/rules/and-evaluation-rule.scm
+++ b/opencog/reasoning/pln/rules/and-evaluation-rule.scm
@@ -15,7 +15,7 @@
 ;
 ; -----------------------------------------------------------------------------
 
-(define pln-rule-and-evaluation
+(define and-evaluation-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -29,7 +29,7 @@
                 (VariableNode "$C")
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-and-evaluation")
+            (GroundedSchemaNode "scm: and-evaluation-formula")
             (ListLink
                 (AndLink
                     (VariableNode "$A")
@@ -41,11 +41,11 @@
                     (VariableNode "$C")
                     (VariableNode "$B"))))))
 
-(define (pln-formula-and-evaluation AB CA CB)
+(define (and-evaluation-formula AB CA CB)
     (cog-set-tv!
-        AB (pln-formula-and-evaluation-side-effect-free AB CA CB)))
+        AB (and-evaluation-side-effect-free-formula AB CA CB)))
 
-(define (pln-formula-and-evaluation-side-effect-free AB CA CB)
+(define (and-evaluation-side-effect-free-formula AB CA CB)
     (let 
         ((sCA (cog-stv-strength CA))
          (cCA (cog-stv-confidence CA))
@@ -57,5 +57,5 @@
             (stv 0 1))))
 
 ; Name the rule
-(define pln-rule-and-evaluation-name (Node "pln-rule-and-evaluation"))
-(DefineLink pln-rule-and-evaluation-name pln-rule-and-evaluation)
+(define and-evaluation-rule-name (Node "and-evaluation-rule"))
+(DefineLink and-evaluation-rule-name and-evaluation-rule)

--- a/opencog/reasoning/pln/rules/and-simplification-rule.scm
+++ b/opencog/reasoning/pln/rules/and-simplification-rule.scm
@@ -14,7 +14,7 @@
 ;----------------------------------------------------------------------
 
 
-(define pln-rule-and-simplification
+(define and-simplification-rule
   (BindLink
    (VariableList
     (VariableNode "$A")
@@ -26,7 +26,7 @@
       (VariableNode "$B")
       (VariableNode "$C")))
    (ExecutionOutputLink
-    (GroundedSchemaNode "scm: pln-formula-and-simplification")
+    (GroundedSchemaNode "scm: and-simplification-formula")
     (ListLink
      (AndLink
       (VariableNode "$A")
@@ -38,18 +38,18 @@
       (VariableNode "$B")
       (VariableNode "$C"))))))
 
-(define (pln-formula-and-simplification AABC ABC)
+(define (and-simplification-formula AABC ABC)
   (cog-set-tv!
    ABC
-   (pln-formula-and-simplification-side-effect-free AABC ABC))
+   (and-simplification-side-effect-free-formula AABC ABC))
 )
 
-(define (pln-formula-and-simplification-side-effect-free AABC ABC)
+(define (and-simplification-side-effect-free-formula AABC ABC)
   (let 
       ((sAABC (cog-stv-strength AABC))
        (cAABC (cog-stv-confidence AABC)))
     (stv sAABC cAABC)))
 
 ; Name the rule
-(define pln-rule-and-simplification-name (Node "pln-rule-and-simplification"))
-(DefineLink pln-rule-and-simplification-name pln-rule-and-simplification)
+(define and-simplification-rule-name (Node "and-simplification-rule"))
+(DefineLink and-simplification-rule-name and-simplification-rule)

--- a/opencog/reasoning/pln/rules/and-to-context.scm
+++ b/opencog/reasoning/pln/rules/and-to-context.scm
@@ -16,7 +16,7 @@
 ;       B
 ;
 ; -----------------------------------------------------------------------------
-(define pln-rule-and-to-context
+(define and-to-context-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -30,7 +30,7 @@
                 (VariableNode "$B")
                 (VariableNode "$C")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm:pln-formula-and-to-context")
+            (GroundedSchemaNode "scm: and-to-context-formula")
             (ListLink
                 (SubsetLink
                     (AndLink
@@ -45,12 +45,12 @@
                             (VariableNode "$A")
                             (VariableNode "$B")))))))
 
-(define (pln-formual-and-to-context SACBC CAB)
+(define (and-to-context-formula SACBC CAB)
     (cog-set-tv!
         CAB (cog-tv SACBC)))
 
 		
 
 ; Name the rule
-(define pln-rule-and-to-context-name (Node "pln-rule-and-to-context"))
-(DefineLink pln-rule-and-to-context-name pln-rule-and-to-context)
+(define and-to-context-rule-name (Node "and-to-context-rule"))
+(DefineLink and-to-context-rule-name and-to-context-rule)

--- a/opencog/reasoning/pln/rules/and-to-subset-rule1.scm
+++ b/opencog/reasoning/pln/rules/and-to-subset-rule1.scm
@@ -13,7 +13,7 @@
 ;
 ; -----------------------------------------------------------------------------
 
-(define pln-rule-and-to-subset1
+(define and-to-subset1-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -24,7 +24,7 @@
                 (VariableNode "$B"))
             (VariableNode "$A"))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-and-to-subset1")
+            (GroundedSchemaNode "scm: and-to-subset1-formula")
             (ListLink
                 (AndLink
                     (VariableNode "$A")
@@ -34,7 +34,7 @@
                     (VariableNode "$A")
                     (VariableNode "$B"))))))
 
-(define (pln-formula-and-to-subset1 AAB A SAB)
+(define (and-to-subset1-formula AAB A SAB)
     (cog-set-tv! 
         SAB
         (if

--- a/opencog/reasoning/pln/rules/and-to-subset-rulen.scm
+++ b/opencog/reasoning/pln/rules/and-to-subset-rulen.scm
@@ -21,13 +21,13 @@
 ;
 ; To solve the pattern matcher issue, and-to-subsetn rule has been divided into
 ; two parts. The two rules are :-
-;       pln-rule-and-to-subset-3
-;       pln-rule-and-to-subset-4
+;       and-to-subset-3-rule
+;       and-to-subset-4-rule
 ;
 ; -----------------------------------------------------------------------------
 (load "formulas.scm")
 
-(define pln-rule-and-to-subset-3
+(define and-to-subset-3-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -42,7 +42,7 @@
                 (VariableNode "$A")
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-and-to-subsetn")
+            (GroundedSchemaNode "scm: and-to-subsetn-formula")
             (ListLink
                 (AndLink
                     (VariableNode "$A")
@@ -57,7 +57,7 @@
                         (VariableNode "$B"))
                     (VariableNode "$C"))))))
 
-(define pln-rule-and-to-subset-4
+(define and-to-subset-4-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -75,7 +75,7 @@
                 (VariableNode "$B")
                 (VariableNode "$C")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-and-to-subsetn")
+            (GroundedSchemaNode "scm: and-to-subsetn-formula")
             (ListLink
                 (AndLink
                     (VariableNode "$A")
@@ -93,7 +93,7 @@
                         (VariableNode "$C"))
                     (VariableNode "$D"))))))
 
-(define (pln-formula-and-to-subsetn ABCD ABC sABCD)
+(define (and-to-subsetn-formula ABCD ABC sABCD)
     (cog-set-tv!
         sABCD
         (stv 

--- a/opencog/reasoning/pln/rules/and-transformation-rule.scm
+++ b/opencog/reasoning/pln/rules/and-transformation-rule.scm
@@ -10,7 +10,7 @@
 ;----------------------------------------------------------------------
 
 
-(define pln-rule-and-transformation
+(define and-transformation-rule
   (BindLink
    (VariableList
     (VariableNode "$A")
@@ -19,7 +19,7 @@
      (VariableNode "$A")
      (VariableNode "$B"))
    (ExecutionOutputLink
-    (GroundedSchemaNode "scm: pln-formula-and-transformation")
+    (GroundedSchemaNode "scm: and-transformation-formula")
     (ListLink
      (AndLink
       (VariableNode "$A")
@@ -30,19 +30,19 @@
 	(NotLink
 	 (VariableNode "$B"))))))))
 
-(define (pln-formula-and-transformation AB NIAB)
+(define (and-transformation-formula AB NIAB)
   (cog-set-tv!
    NIAB
-   (pln-formula-and-transformation-side-effect-free AB NIAB))
+   (and-transformation-side-effect-free-formula AB NIAB))
 )
 
 
-(define (pln-formula-and-transformation-side-effect-free AB NIAB)
+(define (and-transformation-side-effect-free-formula AB NIAB)
   (let 
       ((sAB (cog-stv-strength AB))
        (cAB (cog-stv-confidence AB)))
     (stv sAB cAB)))
 
 ; Name the rule
-(define pln-rule-and-transformation-name (Node "pln-rule-and-transformation"))
-(DefineLink pln-rule-and-transformation-name pln-rule-and-transformation)
+(define and-transformation-rule-name (Node "and-transformation-rule"))
+(DefineLink and-transformation-rule-name and-transformation-rule)

--- a/opencog/reasoning/pln/rules/attraction-rule.scm
+++ b/opencog/reasoning/pln/rules/attraction-rule.scm
@@ -16,7 +16,7 @@
 ;
 ; -----------------------------------------------------------------------------
 
-(define pln-rule-attraction
+(define attraction-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -30,7 +30,7 @@
                     (VariableNode "$A"))
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-attraction")
+            (GroundedSchemaNode "scm: attraction-formula")
             (ListLink
                 (AttractionLink
                     (VariableNode "$A")
@@ -43,14 +43,14 @@
                         (VariableNode "$A"))
                     (VariableNode "$B"))))))
 
-(define (pln-formula-attraction AB SAB SnAB)
+(define (attraction-formula AB SAB SnAB)
     (cog-set-tv!
         AB
-        (pln-formula-attraction-side-effect-free AB SAB SnAB)
+        (attraction-side-effect-free-formula AB SAB SnAB)
     )
 )
 
-(define (pln-formula-attraction-side-effect-free AB SAB SnAB)
+(define (attraction-side-effect-free-formula AB SAB SnAB)
     (let
         (
             (sSAB (cog-stv-strength SAB))
@@ -65,5 +65,5 @@
             (stv (- sSAB sSnAB) (min cSAB cSnAB)))))
 
 ; Name the rule
-(define pln-rule-attraction-name (Node "pln-rule-attraction"))
-(DefineLink pln-rule-attraction-name pln-rule-attraction)
+(define attraction-rule-name (Node "attraction-rule"))
+(DefineLink attraction-rule-name attraction-rule)

--- a/opencog/reasoning/pln/rules/compile-rules.scm
+++ b/opencog/reasoning/pln/rules/compile-rules.scm
@@ -3,13 +3,13 @@
 ; ==========================================================================
 
 (define functions-list (list
-    'pln-rule-deduction
-    'pln-formula-simple-deduction
-    'pln-formula-simple-deduction-side-effect-free
+    'deduction-rule
+    'simple-deduction-strength-formula
+    'simple-deduction-side-effect-free-formula
 
-    'pln-rule-modus-ponens
-    'pln-formula-simple-modus-ponens
-    'pln-formula-simple-modus-ponens-side-effect-free
+    'modus-ponens-rule
+    'simple-modus-ponens-formula
+    'simple-modus-ponens-side-effect-free-formula
 ))
 
 (for-each

--- a/opencog/reasoning/pln/rules/context-free-to-sensitive.scm
+++ b/opencog/reasoning/pln/rules/context-free-to-sensitive.scm
@@ -10,7 +10,7 @@
 ;     A
 ;-------------------------------------------------------------------------------
 
-(define pln-rule-context-free-to-sensitive
+(define context-free-to-sensitive-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -19,7 +19,7 @@
             (VariableNode "$C")
             (VariableNode "$A"))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-context-free-to-sensitive")
+            (GroundedSchemaNode "scm: context-free-to-sensitive-formula")
             (ListLink
                 (ContextLink
                     (VariableNode "$C")
@@ -28,7 +28,7 @@
                     (VariableNode "$C")
                     (VariableNode "$A"))))))
 
-(define (pln-formula-context-free-to-sensitive Context CA)
+(define (context-free-to-sensitive-formula Context CA)
     (cog-set-tv! Context 
         (cog-new-stv (cog-stv-strength CA) (cog-stv-confidence CA))))
 ;            ; strength (now just computed as the mean of the strengths of C & A)
@@ -52,8 +52,8 @@
 ;                (log p)))))
 
 ; Name the rule
-(define pln-rule-context-free-to-sensitive-name
-  (Node "pln-rule-context-free-to-sensitive"))
+(define context-free-to-sensitive-rule-name
+  (Node "context-free-to-sensitive-rule"))
 (DefineLink
-  pln-rule-context-free-to-sensitive-name
-  pln-rule-context-free-to-sensitive)
+  context-free-to-sensitive-rule-name
+  context-free-to-sensitive-rule)

--- a/opencog/reasoning/pln/rules/contextualize.scm
+++ b/opencog/reasoning/pln/rules/contextualize.scm
@@ -32,7 +32,7 @@
 ; Instances of Ben that are doing mathematics are competent, while
 ; instances of Ben that are juggling are incompetent. An AndLink 
 ; between two concepts designates the intersection of these concepts.
-(define pln-rule-contextualize-inheritance
+(define contextualize-inheritance-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -46,7 +46,7 @@
                 (VariableNode "$C")
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-context")
+            (GroundedSchemaNode "scm: context-formula")
             (ListLink
                 ; this ContextLink is the desired output
                 (ContextLink
@@ -54,7 +54,7 @@
                     (InheritanceLink
                         (VariableNode "$A")
                         (VariableNode "$B")))
-                ; the 2nd argument of pln-formula-context
+                ; the 2nd argument of context-formula
                 (InheritanceLink
                     (AndLink
                         (VariableNode "$C")
@@ -69,7 +69,7 @@
 ; that differ between different contexts.
 ; Example: "In the context of the earth, the sky is blue.
 ; In the context of the moon, the sky is black."
-(define pln-rule-contextualize-evaluation
+(define contextualize-evaluation-rule
     (BindLink
         (VariableList
             (TypedVariableLink
@@ -84,7 +84,7 @@
                     (VariableNode "$C")
                     (VariableNode "$B"))))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-context")
+            (GroundedSchemaNode "scm: context-formula")
             (ListLink
                 (ContextLink ; output link
                     (VariableNode "$C")
@@ -123,7 +123,7 @@
 ; (ContextLink
 ;   (ConceptNode "dog")
 ;   (ConceptNode "bulldog"))
-(define pln-rule-contextualize-subset
+(define contextualize-subset-rule
     (BindLink
         (VariableList
             (VariableNode "$C")
@@ -132,7 +132,7 @@
             (VariableNode "$C")
             (VariableNode "$A"))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm:pln-formula-context")
+            (GroundedSchemaNode "scm: context-formula")
             (ListLink
                 (ContextLink ; output link
                     (VariableNode "$C")
@@ -154,7 +154,7 @@
 ; if there are two InheritanceLinks with the same argument in 2nd postion.
 ; This is necessary to create the InheritanceLinks required
 ; for the above rules which have AndLinks as embedded links.
-(define pln-rule-create-and-as-1st-arg-of-inheritance
+(define create-and-as-1st-arg-of-inheritance-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -168,7 +168,7 @@
                 (VariableNode "$B")
                 (VariableNode "$C")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm:pln-formula-create-and-inside-inheritance")
+            (GroundedSchemaNode "scm: create-and-inside-inheritance-formula")
             (ListLink
                 (InheritanceLink ; main output link
                     (AndLink
@@ -207,7 +207,7 @@
 ; if there are two InheritanceLinks with the same argument in the 1st position.
 ; This is necessary to create the InheritanceLinks required
 ; for the above rules which have AndLinks as embedded links.
-(define pln-rule-create-and-as-2nd-arg-of-inheritance
+(define create-and-as-2nd-arg-of-inheritance-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -221,7 +221,7 @@
                 (VariableNode "$A")
                 (VariableNode "$C")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm:pln-formula-create-and-inside-inheritance")
+            (GroundedSchemaNode "scm: create-and-inside-inheritance-formula")
             (ListLink
                 (InheritanceLink ; main output link
                     (VariableNode "$A")
@@ -247,16 +247,16 @@
 
 ; TODO define formula appropriately (see comment in inheritance_rules.py
 ; AndCreationInsideLinkRule) 
-(define (pln-formula-create-and-inside-inheritance outInh outAnd inAnd inEmbedInh1 inEmbedInh2)
+(define (create-and-inside-inheritance-formula outInh outAnd inAnd inEmbedInh1 inEmbedInh2)
     (cog-set-tv! outInh (cog-tv inAnd)))                  
 
-(define (pln-formula-context Context Relation)
+(define (context-formula Context Relation)
     (cog-set-tv! Context (cog-tv Relation)))
 
 
 ; Name the rule
-(define pln-rule-contextualize-inheritance-name
-  (Node "pln-rule-contextualize-inheritance"))
+(define contextualize-inheritance-rule-name
+  (Node "contextualize-inheritance-rule"))
 (DefineLink
-  pln-rule-contextualize-inheritance-name
-  pln-rule-contextualize-inheritance)
+  contextualize-inheritance-rule-name
+  contextualize-inheritance-rule)

--- a/opencog/reasoning/pln/rules/decontextualize.scm
+++ b/opencog/reasoning/pln/rules/decontextualize.scm
@@ -12,10 +12,10 @@
 ;     C ANDLink B
 ;----------------------------------------------------------------------
 
-; Inverse of (pln-rule-contextualize-inheritance):
+; Inverse of (contextualize-inheritance-rule):
 ; a ContextLink consisting of an InheritanceLink is decontextualized,
 ; i.e. reduced to an inheritance relationship
-(define pln-rule-decontextualize-inheritance
+(define decontextualize-inheritance-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -27,7 +27,7 @@
                 (VariableNode "$A")
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-context")
+            (GroundedSchemaNode "scm: context-formula")
             (ListLink
                 (InheritanceLink
                     (AndLink
@@ -42,10 +42,10 @@
                         (VariableNode "$A")
                         (VariableNode "$B")))))))
 
-; Inverse of (pln-rule-contextualize-evaluation):
+; Inverse of (contextualize-evaluation-rule):
 ; in an EvaluationLink, the PredicateNode is not 'andified';
 ; gets rid of the ContextLink enclosing an EvaluationLink
-(define pln-rule-decontextualize-evaluation
+(define decontextualize-evaluation-rule
     (BindLink
         (VariableList
             (TypedVariableLink
@@ -60,7 +60,7 @@
                 (ListLink
                     (VariableNode "$B"))))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-context")
+            (GroundedSchemaNode "scm: context-formula")
             (ListLink
                 (EvaluationLink
                     (VariableNode "$A")
@@ -85,9 +85,9 @@
 ;     C
 ;     A
 ;----------------------------------------------------------------------
-; Inverse of (pln-rule-contextualize-subset):
+; Inverse of (contextualize-subset-rule):
 ; ContextLink is transformed into a SubsetLink
-(define pln-rule-decontextualize-subset
+(define decontextualize-subset-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -96,7 +96,7 @@
             (VariableNode "$C")
             (VariableNode "$A"))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-context")
+            (GroundedSchemaNode "scm: context-formula")
             (ListLink
                 (SubsetLink
                     (VariableNode "$C")
@@ -105,12 +105,12 @@
                     (VariableNode "$C")
                     (VariableNode "$A"))))))
 
-(define (pln-formula-context Relation Context)
+(define (context-formula Relation Context)
     (cog-set-tv! Relation (cog-tv Context)))
 
 ; Name the rule
-(define pln-rule-contextualize-inheritance-name
-  (Node "pln-rule-contextualize-inheritance")
+(define contextualize-inheritance-rule-name
+  (Node "contextualize-inheritance-rule")
 (DefineLink
-  pln-rule-contextualize-inheritance-name
-  pln-rule-contextualize-inheritance)
+  contextualize-inheritance-rule-name
+  contextualize-inheritance-rule)

--- a/opencog/reasoning/pln/rules/deduction-rule.scm
+++ b/opencog/reasoning/pln/rules/deduction-rule.scm
@@ -15,14 +15,14 @@
 ;
 ; Due to pattern matching issues, currently the file has been divided into 3 
 ; parts, each pertaining to different links. The rules are :-
-;       pln-rule-deduction-inheritance
-;       pln-rule-deduction-implication
-;       pln-rule-deduction-subset
+;       deduction-inheritance-rule
+;       deduction-implication-rule
+;       deduction-subset-rule
 ;
 ; -----------------------------------------------------------------------------
 (load "formulas.scm")
 
-(define pln-rule-deduction-inheritance
+(define deduction-inheritance-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -39,7 +39,7 @@
                 (VariableNode "$B")
                 (VariableNode "$C")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-deduction")
+            (GroundedSchemaNode "scm: deduction-formula")
             (ListLink
                 (VariableNode "$A")
                 (VariableNode "$B")
@@ -54,7 +54,7 @@
                     (VariableNode "$A")
                     (VariableNode "$C"))))))
 
-(define pln-rule-deduction-implication
+(define deduction-implication-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -71,7 +71,7 @@
                 (VariableNode "$B")
                 (VariableNode "$C")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-deduction")
+            (GroundedSchemaNode "scm: deduction-formula")
             (ListLink
                 (VariableNode "$A")
                 (VariableNode "$B")
@@ -86,7 +86,7 @@
                     (VariableNode "$A")
                     (VariableNode "$C"))))))
 
-(define pln-rule-deduction-subset
+(define deduction-subset-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -103,7 +103,7 @@
                 (VariableNode "$B")
                 (VariableNode "$C")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-deduction")
+            (GroundedSchemaNode "scm: deduction-formula")
             (ListLink
                 (VariableNode "$A")
                 (VariableNode "$B")
@@ -118,7 +118,7 @@
                     (VariableNode "$A")
                     (VariableNode "$C"))))))
 
-(define (pln-formula-deduction A B C AB BC AC)
+(define (deduction-formula A B C AB BC AC)
     (let
         ((sA (cog-stv-strength A))
          (cA (cog-stv-confidence A))
@@ -133,5 +133,5 @@
         (cog-set-tv!
             AC
             (stv
-                (simple-deduction-formula sA sB sC sAB sBC) 
+                (simple-deduction-strength-formula sA sB sC sAB sBC) 
                 (min cAB cBC)))))

--- a/opencog/reasoning/pln/rules/deduction.scm
+++ b/opencog/reasoning/pln/rules/deduction.scm
@@ -5,7 +5,7 @@
 ; AND(Inheritance A B, Inheritance B C) entails Inheritance A C
 ; -----------------------------------------------------------------------------
 (load "formulas.scm")
-(define pln-rule-deduction
+(define deduction-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -29,7 +29,7 @@
             )
         )
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-simple-deduction")
+            (GroundedSchemaNode "scm: simple-deduction-formula")
             (ListLink
                 (InheritanceLink
                     (VariableNode "$A")
@@ -55,10 +55,10 @@
 ; -----------------------------------------------------------------------------
 ; Side-effect: TruthValue of AC may be updated
 ; -----------------------------------------------------------------------------
-(define (pln-formula-simple-deduction AB BC AC)
+(define (simple-deduction-formula AB BC AC)
     (cog-set-tv!
         AC
-        (pln-formula-simple-deduction-side-effect-free AB BC AC)
+        (simple-deduction-side-effect-free-formula AB BC AC)
     )
 )
 
@@ -70,7 +70,7 @@
 ; TODO The confidence calcualtion is not inline with the wiki as the details
 ;      not clearly defined there.
 ; -----------------------------------------------------------------------------
-(define (pln-formula-simple-deduction-side-effect-free AB BC AC)
+(define (simple-deduction-side-effect-free-formula AB BC AC)
     (let
         ((sA (cog-stv-strength (gar AB)))
          (sB (cog-stv-strength (gdr AB)))
@@ -81,7 +81,7 @@
 
         ; Returns sAC. Includes the consistency conditions
         (define (strength)
-            (simple-deduction-formula sA sB sC sAB sBC))
+            (simple-deduction-strength-formula sA sB sC sAB sBC))
 
         ; This is not consistant with the defintion on the wiki
         (define (confidence)
@@ -98,5 +98,5 @@
 ; =============================================================================
 
 ; Name the rule
-(define pln-rule-deduction-name (Node "pln-rule-deduction"))
-(DefineLink pln-rule-deduction-name pln-rule-deduction)
+(define deduction-rule-name (Node "deduction-rule"))
+(DefineLink deduction-rule-name deduction-rule)

--- a/opencog/reasoning/pln/rules/equivalence-transformation-rule.scm
+++ b/opencog/reasoning/pln/rules/equivalence-transformation-rule.scm
@@ -15,7 +15,7 @@
 ;
 ; -----------------------------------------------------------------------------
 
-(define pln-rule-equivalence-transformation
+(define equivalence-transformation-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -24,7 +24,7 @@
             (VariableNode "$A")
             (VariableNode "$B"))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm:pln-formula-equivalence-transformation")
+            (GroundedSchemaNode "scm: equivalence-transformation-formula")
             (ListLink
                 (AndLink
                     (ImplicationLink
@@ -37,13 +37,13 @@
                     (VariableNode "$A")
                     (VariableNode "$B"))))))
 
-(define (pln-formula-equivalence-transofrmation AII EV)
+(define (equivalence-transofrmation-formula AII EV)
     (cog-set-tv!
         AII (cog-tv EV)))
 
 ; Name the rule
-(define pln-rule-equivalence-transformation-name
-  (Node "pln-rule-equivalence-transformation"))
+(define equivalence-transformation-rule-name
+  (Node "equivalence-transformation-rule"))
 (DefineLink
-  pln-rule-equivalence-transformation-name
-  pln-rule-equivalence-transformation)
+  equivalence-transformation-rule-name
+  equivalence-transformation-rule)

--- a/opencog/reasoning/pln/rules/evaluation-implication-rule.scm
+++ b/opencog/reasoning/pln/rules/evaluation-implication-rule.scm
@@ -24,7 +24,7 @@
 
 (load "formulas.scm")
 
-(define pln-rule-evaluation-implication
+(define evaluation-implication-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -38,7 +38,7 @@
                 (VariableNode "$A")
                 (VariableNode "$C")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-evaluation-implication")
+            (GroundedSchemaNode "scm: evaluation-implication-formula")
             (ListLink
                 (EvaluationLink
                     (VariableNode "$A")
@@ -50,14 +50,14 @@
                     (VariableNode "$C")
                     (VariableNode "$B"))))))
 
-(define (pln-formula-evaluation-implication AB AC CB)
+(define (evaluation-implication-formula AB AC CB)
     (define A (gar AB))
     (define B (gdr AB))
     (define C (gdr AC))
     (cog-set-tv!
         CB
         (stv
-            (simple-deduction-formula 
+            (simple-deduction-strength-formula 
                 (cog-stv-strength B)
                 (cog-stv-strength A)
                 (cog-stv-strength C)
@@ -73,8 +73,8 @@
                     (* 0.9 (cog-stv-confidence AB)))))))
 
 ; Name the rule
-(define pln-rule-evaluation-implication-name (Node "pln-rule-evaluation-implication"))
-(DefineLink pln-rule-evaluation-implication-name pln-rule-evaluation-implication)
+(define evaluation-implication-rule-name (Node "evaluation-implication-rule"))
+(DefineLink evaluation-implication-rule-name evaluation-implication-rule)
 
 
 ; Similarity substitution Rule is equivalent to combining that rule with

--- a/opencog/reasoning/pln/rules/evaluation-to-member-rule.scm
+++ b/opencog/reasoning/pln/rules/evaluation-to-member-rule.scm
@@ -27,7 +27,7 @@
 ;(include "formulas.scm")
 
 ; -----------------------------------------------------------------------------
-; pln-rule-evaluation-to-member-0
+; evaluation-to-member-0-rule
 ;	Converts EvaluationLinks which have only one member which is not part of 
 ;	the ListLink
 ;	eg:- EvaluationLink
@@ -35,7 +35,7 @@
 ;			ConceptNode "John"			
 ; -----------------------------------------------------------------------------
 
-(define pln-rule-evaluation-to-member-0
+(define evaluation-to-member-0-rule
 	(BindLink
 		(VariableList
 			(TypedVariableLink
@@ -48,7 +48,7 @@
 			(VariableNode "$D")
 			(VariableNode "$A"))
 		(ExecutionOutputLink
-			(GroundedSchemaNode "scm:pln-formula-evaluation-to-member-0")
+			(GroundedSchemaNode "scm: evaluation-to-member-0-formula")
 				(ListLink
 					(MemberLink
 						(VariableNode "$A")
@@ -61,14 +61,14 @@
 						(VariableNode "$D")
 						(VariableNode "$A"))))))
 
-(define (pln-formula-evaluation-to-member-0 MAXDX DA)
+(define (evaluation-to-member-0-formula MAXDX DA)
 	(cog-set-tv! MAXDX
-		(pln-formula-evaluation-to-member-side-effect-free
+		(evaluation-to-member-side-effect-free-formula
 			MAXDX
 			DA)))
 
 ; -----------------------------------------------------------------------------
-; pln-rule-evaluation-to-member-1
+; evaluation-to-member-1-rule
 ;	Converts EvaluationLinks which have only one member which is part of 
 ;	the ListLink
 ;	eg:- EvaluationLink
@@ -77,7 +77,7 @@
 ;				ConceptNode "John"			
 ; -----------------------------------------------------------------------------
 
-(define pln-rule-evaluation-to-member-1
+(define evaluation-to-member-1-rule
 	(BindLink
 		(VariableList
 			(VariableNode "$A")
@@ -89,7 +89,7 @@
 			(ListLink
 				(VariableNode "$A")))
 		(ExecutionOutputLink
-			(GroundedSchemaNode "scm:pln-formula-evaluation-to-member-1")
+			(GroundedSchemaNode "scm: evaluation-to-member-1-formula")
 				(ListLink
 					(MemberLink
 						(VariableNode "$A")
@@ -104,14 +104,14 @@
 						(ListLink
 							(VariableNode "$A")))))))
 
-(define (pln-formula-evaluation-to-member-1 MAXDX DA)
+(define (evaluation-to-member-1-formula MAXDX DA)
 	(cog-set-tv! MAXDX
-		(pln-formula-evaluation-to-member-side-effect-free
+		(evaluation-to-member-side-effect-free-formula
 			MAXDX
 			DA)))
 
 ; -----------------------------------------------------------------------------
-; pln-rule-evaluation-to-member-2
+; evaluation-to-member-2-rule
 ;	Converts EvaluationLinks which have two members
 ;	eg:- EvaluationLink
 ;			PredicateNode "Eat"
@@ -120,7 +120,7 @@
 ;				ConceptNode "Cookies"			
 ; -----------------------------------------------------------------------------
 
-(define pln-rule-evaluation-to-member-2
+(define evaluation-to-member-2-rule
 	(BindLink
 		(VariableList
 			(VariableNode "$A")
@@ -134,7 +134,7 @@
 				(VariableNode "$A")
 				(VariableNode "$B")))
 		(ExecutionOutputLink
-			(GroundedSchemaNode "scm:pln-formula-evaluation-to-member-2")
+			(GroundedSchemaNode "scm: evaluation-to-member-2-formula")
 				(ListLink
 					(MemberLink
 						(VariableNode "$A")
@@ -161,22 +161,22 @@
 							(VariableNode "$B")))))))
 
 
-(define (pln-formula-evaluation-to-member-2 MAXDXB MBXDAX DAB)
+(define (evaluation-to-member-2-formula MAXDXB MBXDAX DAB)
 	(cog-set-tv! MAXDXB
-		(pln-formula-evaluation-to-member-side-effect-free
+		(evaluation-to-member-side-effect-free-formula
 			MAXDXB
 			DAB))
 	(cog-set-tv! MBXDAX 
-		(pln-formula-evaluation-to-member-side-effect-free
+		(evaluation-to-member-side-effect-free-formula
 			MBXDAX
 			DAB)))
 
-(define (pln-formula-evaluation-to-member-side-effect-free MD ED)
+(define (evaluation-to-member-side-effect-free-formula MD ED)
 	(stv
 		(cog-stv-strength ED)
 		(cog-stv-confidence ED)))
 
-;(define pln-rule-evaluation-to-member
+;(define evaluation-to-member-rule
 ;	(BindLink
 ;		(VariableList
 ;			(VariableNode "$A")
@@ -187,7 +187,7 @@
 ;           (VariableNode "$D")
 ;           (VariableNode "$A"))
 ;       (ExecutionOutputLink
-;           (GroundedSchemaNode "scm:pln-formula-evaluation-to-member")
+;           (GroundedSchemaNode "scm: evaluation-to-member-formula")
 ;           (ListLink
 ;               (EvaluationLink
 ;                   (VariableNode "$D")
@@ -201,7 +201,7 @@
 ; Side-effect: TruthValue of the new link/s stays the same
 ; -----------------------------------------------------------------------------
 
-;(define (pln-formula-evaluation-to-member DA)
+;(define (evaluation-to-member-formula DA)
 ;	(if (= (cog-arity (gdr DA)) 0)
 ;		(MemberLink (stv (cog-stv-strength DA) (cog-stv-confidence DA))
 ;			(gdr DA)
@@ -237,20 +237,20 @@
 ; =============================================================================
 
 ; Name the rule
-(define pln-rule-evaluation-to-member-0-name
-  (Node "pln-rule-evaluation-to-member-0"))
+(define evaluation-to-member-0-rule-name
+  (Node "evaluation-to-member-0-rule"))
 (DefineLink
-  pln-rule-evaluation-to-member-0-name
-  pln-rule-evaluation-to-member-0)
+  evaluation-to-member-0-rule-name
+  evaluation-to-member-0-rule)
 
-(define pln-rule-evaluation-to-member-1-name
-  (Node "pln-rule-evaluation-to-member-1"))
+(define evaluation-to-member-1-rule-name
+  (Node "evaluation-to-member-1-rule"))
 (DefineLink
-  pln-rule-evaluation-to-member-1-name
-  pln-rule-evaluation-to-member-1)
+  evaluation-to-member-1-rule-name
+  evaluation-to-member-1-rule)
 
-(define pln-rule-evaluation-to-member-2-name
-  (Node "pln-rule-evaluation-to-member-2"))
+(define evaluation-to-member-2-rule-name
+  (Node "evaluation-to-member-2-rule"))
 (DefineLink
-  pln-rule-evaluation-to-member-2-name
-  pln-rule-evaluation-to-member-2)
+  evaluation-to-member-2-rule-name
+  evaluation-to-member-2-rule)

--- a/opencog/reasoning/pln/rules/extensional-similarity-evaluation-rule.scm
+++ b/opencog/reasoning/pln/rules/extensional-similarity-evaluation-rule.scm
@@ -15,7 +15,7 @@
 ;
 ; -----------------------------------------------------------------------------
 
-(define pln-rule-extensional-similarity-evaluation
+(define extensional-similarity-evaluation-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -29,7 +29,7 @@
                 (VariableNode "$C")
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-extensional-similarity-evaluation")
+            (GroundedSchemaNode "scm: extensional-similarity-evaluation-formula")
             (ListLink
                 (ExtensionalSimilarityLink
                     (VariableNode "$A")
@@ -41,11 +41,11 @@
                     (VariableNode "$C")
                     (VariableNode "$B"))))))
 
-(define (pln-formula-extensional-similarity-evaluation AB CA CB)
+(define (extensional-similarity-evaluation-formula AB CA CB)
     (cog-set-tv!
-        AB (pln-formula-extensional-similarity-evaluation-side-effect-free AB CA CB)))
+        AB (extensional-similarity-evaluation-side-effect-free-formula AB CA CB)))
 
-(define (pln-formula-extensional-similarity-evaluation-side-effect-free AB CA CB)
+(define (extensional-similarity-evaluation-side-effect-free-formula AB CA CB)
     (let 
         ((sCA (cog-stv-strength CA))
          (cCA (cog-stv-confidence CA))
@@ -60,7 +60,7 @@
                 (stv 0 1)))))
 
 ; Name the rule
-(define pln-rule-extensional-similarity-evaluation-name
-  (Node "pln-rule-extensional-similarity-evaluation"))
-(DefineLink pln-rule-extensional-similarity-evaluation-name
-  pln-rule-extensional-similarity-evaluation)
+(define extensional-similarity-evaluation-rule-name
+  (Node "extensional-similarity-evaluation-rule"))
+(DefineLink extensional-similarity-evaluation-rule-name
+  extensional-similarity-evaluation-rule)

--- a/opencog/reasoning/pln/rules/forall-implication-to-higher-order-rule.scm
+++ b/opencog/reasoning/pln/rules/forall-implication-to-higher-order-rule.scm
@@ -43,19 +43,19 @@
 
 (define forall-implication-to-higher-order-rewrite
   (ExecutionOutputLink
-     (GroundedSchemaNode "scm: pln-formula-forall-implication-to-higher-order")
+     (GroundedSchemaNode "scm: forall-implication-to-higher-order-formula")
      (ListLink
         (VariableNode "$TyVs")
         (VariableNode "$Impl"))))
 
-(define pln-rule-forall-implication-to-higher-order
+(define forall-implication-to-higher-order-rule
   (BindLink
      forall-implication-to-higher-order-variables
      forall-implication-to-higher-order-body
      forall-implication-to-higher-order-rewrite))
 
 ;; TODO: only crisp for now
-(define (pln-formula-forall-implication-to-higher-order TyVs Impl)
+(define (forall-implication-to-higher-order-formula TyVs Impl)
   (cog-set-tv!
    (let* (
           (impl-outgoings (cog-outgoing-set Impl))
@@ -71,7 +71,7 @@
    (stv 1 1)))
 
 ;; Name the rule
-(define pln-rule-forall-implication-to-higher-order-name
-  (Node "pln-rule-forall-implication-to-higher-order-name"))
-(DefineLink pln-rule-forall-implication-to-higher-order-name
-  pln-rule-forall-implication-to-higher-order)
+(define forall-implication-to-higher-order-rule-name
+  (Node "forall-implication-to-higher-order-rule"))
+(DefineLink forall-implication-to-higher-order-rule-name
+  forall-implication-to-higher-order-rule)

--- a/opencog/reasoning/pln/rules/forall-instantiation-rule.scm
+++ b/opencog/reasoning/pln/rules/forall-instantiation-rule.scm
@@ -39,7 +39,7 @@
      (VariableNode "$TyVs")
      (VariableNode "$B")))
 
-;; Helper for pln-formula-forall-instantiation. Given an atom
+;; Helper for forall-instantiation-formula. Given an atom
 ;;
 ;; (VariableList
 ;;    (TypedVariableLink
@@ -82,7 +82,7 @@
          (remain (apply cog-new-link link-type remain-list)))
     (list rnd-atom remain)))
 
-;; Helper for pln-formula-forall-instantiation. Given an atom
+;; Helper for forall-instantiation-formula. Given an atom
 ;;
 ;; (TypedVariableLink
 ;;    (VariableNode "$V")
@@ -106,16 +106,16 @@
 
 (define forall-full-instantiation-rewrite
   (ExecutionOutputLink
-     (GroundedSchemaNode "scm: pln-formula-forall-full-instantiation")
+     (GroundedSchemaNode "scm: forall-full-instantiation-formula")
      (ListLink
         (VariableNode "$TyVs")
         (VariableNode "$B"))))
 
 ;; Only try to match a ForAllLink with a type restricted variable in
 ;; the ForAllLink variable definition. The choice of the substitution
-;; term is done randomly in pln-formula-forall-full-instantiation. All
+;; term is done randomly in forall-full-instantiation-formula. All
 ;; scoped variables are instantiated.
-(define pln-rule-forall-full-instantiation
+(define forall-full-instantiation-rule
   (BindLink
      forall-full-instantiation-variables
      forall-instantiation-body
@@ -134,7 +134,7 @@
 ;; and scoped variables in the forall, otherwise this is gonna crash.
 ;; That is because PutLink expects the number of variables in the
 ;; ListLink to be equal to the number of free variables in the body.
-(define (pln-formula-forall-full-instantiation SV B)
+(define (forall-full-instantiation-formula SV B)
   (cog-set-tv!
    (let* (
           (SV-type (cog-type SV))
@@ -159,10 +159,10 @@
    (stv 1 1)))
 
 ;; Name the rule
-(define pln-rule-forall-full-instantiation-name
-  (Node "pln-rule-forall-full-instantiation-name"))
-(DefineLink pln-rule-forall-full-instantiation-name
-  pln-rule-forall-full-instantiation)
+(define forall-full-instantiation-rule-name
+  (Node "forall-full-instantiation-rule"))
+(DefineLink forall-full-instantiation-rule-name
+  forall-full-instantiation-rule)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Forall partial instantiation rule ;;
@@ -177,15 +177,15 @@
 
 (define forall-partial-instantiation-rewrite
   (ExecutionOutputLink
-     (GroundedSchemaNode "scm: pln-formula-forall-partial-instantiation")
+     (GroundedSchemaNode "scm: forall-partial-instantiation-formula")
      (ListLink
         (VariableNode "$TyVs")
         (VariableNode "$B"))))
 
-;; Like pln-rule-forall-full-instantiation but only instantiate one
+;; Like forall-full-instantiation-rule but only instantiate one
 ;; variable amonst a variable list (if there is just one variable in
 ;; the forall scope, then this rule will not be invoked).
-(define pln-rule-forall-partial-instantiation
+(define forall-partial-instantiation-rule
   (BindLink
      forall-partial-instantiation-variables
      forall-instantiation-body
@@ -204,7 +204,7 @@
 ;; and scoped variables in the forall, otherwise this is gonna crash.
 ;; That is because PutLink expects the number of variables in the
 ;; ListLink to be equal to the number of free variables in the body.
-(define (pln-formula-forall-partial-instantiation TyVs B)
+(define (forall-partial-instantiation-formula TyVs B)
   (cog-set-tv!
    (let* (
           (TyV-and-remain (select-rm-rnd-outgoing TyVs))
@@ -234,7 +234,7 @@
    (stv 1 1)))
 
 ;; Name the rule
-(define pln-rule-forall-partial-instantiation-name
-  (Node "pln-rule-forall-partial-instantiation-name"))
-(DefineLink pln-rule-forall-partial-instantiation-name
-  pln-rule-forall-partial-instantiation)
+(define forall-partial-instantiation-rule-name
+  (Node "forall-partial-instantiation-rule"))
+(DefineLink forall-partial-instantiation-rule-name
+  forall-partial-instantiation-rule)

--- a/opencog/reasoning/pln/rules/formulas.scm
+++ b/opencog/reasoning/pln/rules/formulas.scm
@@ -2,8 +2,8 @@
 ; A list of the helper functions necessary in different inference rules
 ; -----------------------------------------------------------------------------
 ; Index
-; - inversion-formula
-; - simple-deduction-formula
+; - inversion-strength-formula
+; - simple-deduction-strength-formula
 ; - find-replace
 ;------------------------------------------------------------------------------
 
@@ -13,7 +13,7 @@
 ; sBA = (sAB * sB)/sA
 ; -----------------------------------------------------------------------------
 
-(define (inversion-formula sAB sA sB)
+(define (inversion-strength-formula sAB sA sB)
 	(/ (* sAB sB) sA))
 
 ; =============================================================================
@@ -45,7 +45,7 @@
 
 ; Main Formula
 
-(define (simple-deduction-formula sA sB sC sAB sBC)
+(define (simple-deduction-strength-formula sA sB sC sAB sBC)
 	(if
 		(and
 				(>= (consistency1 sA sB sAB) 0)
@@ -100,7 +100,7 @@
 ; Returns the strength value of the transitive similarity rule
 ; -----------------------------------------------------------------------------
 
-(define (transitive-similarity-formula sA sB sC sAB sBC )
+(define (transitive-similarity-strength-formula sA sB sC sAB sBC )
     (let
         ((T1 (/ (* (+ 1 (/ sB sA)) (sAB)) (+ 1 sAB)))
          (T2 (/ (* (+ 1 (/ sC sB)) (sBC)) (+ 1 sBC)))
@@ -115,6 +115,6 @@
 ; Returns the strength value of the precise modus ponens rule
 ; -----------------------------------------------------------------------------
 
-(define (precise-modus-ponens-formula sA sAB snotAB)
+(define (precise-modus-ponens-strength-formula sA sAB snotAB)
     (+ (* sAB sA) (* snotAB (negate sA))))
 

--- a/opencog/reasoning/pln/rules/implication-and-rule.scm
+++ b/opencog/reasoning/pln/rules/implication-and-rule.scm
@@ -19,7 +19,7 @@
 ;
 ; -----------------------------------------------------------------------------
 
-(define pln-rule-implication-and
+(define implication-and-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -36,7 +36,7 @@
                     (VariableNode "$C"))
                 (VariableNode "$D")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-implication-and")
+            (GroundedSchemaNode "scm: implication-and-formula")
             (ListLink
                 (ImplicationLink
                     (AndLink
@@ -52,15 +52,15 @@
                         (VariableNode "$C"))
                     (VariableNode "$D"))))))
 
-(define (pln-formula-implication-and ACD AB BCD)
+(define (implication-and-formula ACD AB BCD)
     (cog-set-tv!
-        (pln-formula-implication-and-side-effect-free ACD AB BCD)
+        (implication-and-side-effect-free-formula ACD AB BCD)
     )
 )
 
-(define (pln-formula-implication-and-side-effect-free ACD AB BCD)
+(define (implication-and-side-effect-free-formula ACD AB BCD)
     (stv 1 1))
 
 ; Name the rule
-(define pln-rule-implication-and-name (Node "pln-rule-implication-and"))
-(DefineLink pln-rule-implication-and-name pln-rule-implication-and)
+(define implication-and-rule-name (Node "implication-and-rule"))
+(DefineLink implication-and-rule-name implication-and-rule)

--- a/opencog/reasoning/pln/rules/induction-rule.scm
+++ b/opencog/reasoning/pln/rules/induction-rule.scm
@@ -15,15 +15,15 @@
 ;
 ; Due to pattern matching issues, currently the file has been divided into 3 
 ; parts, each pertaining to different links. The rules are :-
-;       pln-rule-induction-inheritance
-;       pln-rule-induction-implication
-;       pln-rule-induction-subset
+;       induction-inheritance-rule
+;       induction-implication-rule
+;       induction-subset-rule
 ;
 
 ; -----------------------------------------------------------------------------
 (load "formulas.scm")
 
-(define pln-rule-induction-inheritance
+(define induction-inheritance-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -41,7 +41,7 @@
                     (VariableNode "$B")
                     (VariableNode "$C"))))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-induction")
+            (GroundedSchemaNode "scm: induction-formula")
             (ListLink
                 (InheritanceLink
                     (VariableNode "$A")
@@ -53,7 +53,7 @@
                     (VariableNode "$B")
                     (VariableNode "$C"))))))
     
-(define pln-rule-induction-implication
+(define induction-implication-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -71,7 +71,7 @@
                     (VariableNode "$B")
                     (VariableNode "$C"))))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-induction")
+            (GroundedSchemaNode "scm: induction-formula")
             (ListLink
                 (ImplicationLink
                     (VariableNode "$A")
@@ -83,7 +83,7 @@
                     (VariableNode "$B")
                     (VariableNode "$C"))))))
 
-(define pln-rule-induction-subset
+(define induction-subset-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -101,7 +101,7 @@
                     (VariableNode "$B")
                     (VariableNode "$C"))))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-induction")
+            (GroundedSchemaNode "scm: induction-formula")
             (ListLink
                 (SubsetLink
                     (VariableNode "$A")
@@ -113,7 +113,7 @@
                     (VariableNode "$B")
                     (VariableNode "$C"))))))
 
-(define (pln-formula-induction AB AC BC)
+(define (induction-formula AB AC BC)
     (define A (gar AB))
     (define B (gdr AB))
     (define C (gdr AC))
@@ -131,17 +131,17 @@
         (cog-set-tv!
             BC
             (stv 
-                (simple-deduction-formula sB sA sC (inversion-formula sAB sA sB) sAC) 
+                (simple-deduction-strength-formula sB sA sC (inversion-strength-formula sAB sA sB) sAC) 
                 (min cAB cAC)))))
                 
 ; =============================================================================
 
 ; Name the rules
-(define pln-rule-induction-inheritance-name (Node "pln-rule-induction-inheritance"))
-(DefineLink pln-rule-induction-inheritance-name pln-rule-induction-inheritance)
+(define induction-inheritance-rule-name (Node "induction-inheritance-rule"))
+(DefineLink induction-inheritance-rule-name induction-inheritance-rule)
 
-(define pln-rule-induction-implication-name (Node "pln-rule-induction-implication"))
-(DefineLink pln-rule-induction-implication-name pln-rule-induction-implication)
+(define induction-implication-rule-name (Node "induction-implication-rule"))
+(DefineLink induction-implication-rule-name induction-implication-rule)
 
-(define pln-rule-induction-subset-name (Node "pln-rule-induction-subset"))
-(DefineLink pln-rule-induction-subset-name pln-rule-induction-subset)
+(define induction-subset-rule-name (Node "induction-subset-rule"))
+(DefineLink induction-subset-rule-name induction-subset-rule)

--- a/opencog/reasoning/pln/rules/inheritance-rule.scm
+++ b/opencog/reasoning/pln/rules/inheritance-rule.scm
@@ -15,7 +15,7 @@
 ;
 ; -----------------------------------------------------------------------------
 
-(define pln-rule-inheritance
+(define inheritance-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -28,7 +28,7 @@
                 (VariableNode "$A")
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-inheritance")
+            (GroundedSchemaNode "scm: inheritance-formula")
             (ListLink
                 (SubsetLink
                     (VariableNode "$A")
@@ -40,7 +40,7 @@
                     (VariableNode "$A")
                     (VariableNode "$B"))))))
 
-(define (pln-formula-inheritance SAB IIAB IAB)
+(define (inheritance-formula SAB IIAB IAB)
     (cog-set-tv! 
         IAB
         (stv 

--- a/opencog/reasoning/pln/rules/inheritance-to-member-rule.scm
+++ b/opencog/reasoning/pln/rules/inheritance-to-member-rule.scm
@@ -11,7 +11,7 @@
 ;
 ; -----------------------------------------------------------------------------
 
-(define pln-rule-inheritance-to-member
+(define inheritance-to-member-rule
 	(BindLink
 		(VariableList
 			(VariableNode "$B")
@@ -20,7 +20,7 @@
 			(VariableNode "$B")
 			(VariableNode "$C"))
 		(ExecutionOutputLink
-			(GroundedSchemaNode "scm:pln-formula-inheritance-to-member")
+			(GroundedSchemaNode "scm: inheritance-to-member-formula")
 			(ListLink
 				(MemberLink
 					(VariableNode "$B")
@@ -37,10 +37,10 @@
 ; Side-effect: TruthValue of the new link stays the same
 ; -----------------------------------------------------------------------------
 
-(define (pln-formula-inheritance-to-member MBC IBC)
+(define (inheritance-to-member-formula MBC IBC)
 	(cog-set-tv!
 		MBC
-		(pln-formula-member-to-inheritance-side-effect-free
+		(member-to-inheritance-side-effect-free-formula
 			MBC
 			IBC)))
 
@@ -48,7 +48,7 @@
 ; This version has no side effects and simply returns a TruthValue
 ; -----------------------------------------------------------------------------
 
-(define (pln-formula-inheritance-to-member-side-effect-free MBC IBC)
+(define (inheritance-to-member-side-effect-free-formula MBC IBC)
 	(stv
 		(cog-stv-strength IBC)
 		(* (cog-stv-confidence IBC) 0.9)))
@@ -56,8 +56,8 @@
 ; =============================================================================
 
 ; Name the rule
-(define pln-rule-inheritance-to-member-name
-  (Node "pln-rule-inheritance-to-member"))
+(define inheritance-to-member-rule-name
+  (Node "inheritance-to-member-rule"))
 (DefineLink
-  pln-rule-inheritance-to-member-name
-  pln-rule-inheritance-to-member)
+  inheritance-to-member-rule-name
+  inheritance-to-member-rule)

--- a/opencog/reasoning/pln/rules/intensional-inheritance-evaluation-rule.scm
+++ b/opencog/reasoning/pln/rules/intensional-inheritance-evaluation-rule.scm
@@ -15,7 +15,7 @@
 ;
 ; -----------------------------------------------------------------------------
 
-(define pln-rule-intensional-inheritance-evaluation
+(define intensional-inheritance-evaluation-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -29,7 +29,7 @@
                 (VariableNode "$C")
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-intensional-inheritance-evaluation")
+            (GroundedSchemaNode "scm: intensional-inheritance-evaluation-formula")
             (ListLink
                 (IntensionalInheritanceLink
                     (VariableNode "$A")
@@ -41,11 +41,11 @@
                     (VariableNode "$C")
                     (VariableNode "$B"))))))
 
-(define (pln-formula-intensional-inheritance-evaluation AB CA CB)
+(define (intensional-inheritance-evaluation-formula AB CA CB)
     (cog-set-tv!
-        AB (pln-formula-intensional-inheritance-evaluation-side-effect-free AB CA CB)))
+        AB (intensional-inheritance-evaluation-side-effect-free-formula AB CA CB)))
 
-(define (pln-formula-intensional-inheritance-evaluation-side-effect-free AB CA CB)
+(define (intensional-inheritance-evaluation-side-effect-free-formula AB CA CB)
     (let 
         ((sCA (cog-stv-strength CA))
          (cCA (cog-stv-confidence CA))
@@ -60,8 +60,8 @@
                 (stv 1 1)))))
 
 ; Name the rule
-(define pln-rule-intensional-inheritance-evaluation-name
-  (Node "pln-rule-intensional-inheritance-evaluation"))
+(define intensional-inheritance-evaluation-rule-name
+  (Node "intensional-inheritance-evaluation-rule"))
 (DefineLink
-  pln-rule-intensional-inheritance-evaluation-name
-  pln-rule-intensional-inheritance-evaluation)
+  intensional-inheritance-evaluation-rule-name
+  intensional-inheritance-evaluation-rule)

--- a/opencog/reasoning/pln/rules/intensional-similarity-evaluation-rule.scm
+++ b/opencog/reasoning/pln/rules/intensional-similarity-evaluation-rule.scm
@@ -15,7 +15,7 @@
 ;
 ; -----------------------------------------------------------------------------
 
-(define pln-rule-intensional-similarity-evaluation
+(define intensional-similarity-evaluation-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -29,7 +29,7 @@
                 (VariableNode "$C")
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-intensional-similarity-evaluation")
+            (GroundedSchemaNode "scm: intensional-similarity-evaluation-formula")
             (ListLink
                 (IntensionalSimilarityLink
                     (VariableNode "$A")
@@ -41,11 +41,11 @@
                     (VariableNode "$C")
                     (VariableNode "$B"))))))
 
-(define (pln-formula-intensional-similarity-evaluation AB CA CB)
+(define (intensional-similarity-evaluation-formula AB CA CB)
     (cog-set-tv!
-        AB (pln-formula-intensional-similarity-evaluation-side-effect-free AB CA CB)))
+        AB (intensional-similarity-evaluation-side-effect-free-formula AB CA CB)))
 
-(define (pln-formula-intensional-similarity-evaluation-side-effect-free AB CA CB)
+(define (intensional-similarity-evaluation-side-effect-free-formula AB CA CB)
     (let 
         ((sCA (cog-stv-strength CA))
          (cCA (cog-stv-confidence CA))
@@ -60,8 +60,8 @@
                 (stv 0 1)))))
 
 ; Name the rule
-(define pln-rule-intensional-similarity-evaluation-name
-  (Node "pln-rule-intensional-similarity-evaluation"))
+(define intensional-similarity-evaluation-rule-name
+  (Node "intensional-similarity-evaluation-rule"))
 (DefineLink
-  pln-rule-intensional-similarity-evaluation-name
-  pln-rule-intensional-similarity-evaluation)
+  intensional-similarity-evaluation-rule-name
+  intensional-similarity-evaluation-rule)

--- a/opencog/reasoning/pln/rules/inversion-rule.scm
+++ b/opencog/reasoning/pln/rules/inversion-rule.scm
@@ -11,14 +11,14 @@
 ;
 ; Due to pattern matching issues, currently the file has been divided into 3 
 ; parts, each pertaining to different links. The rules are :-
-;       pln-rule-inversion-inheritance
-;       pln-rule-inversion-implication
-;       pln-rule-inversion-subset
+;       inversion-inheritance-rule
+;       inversion-implication-rule
+;       inversion-subset-rule
 ;
 ; -----------------------------------------------------------------------------
 (load "formulas.scm")
 
-(define pln-rule-inversion-inheritance
+(define inversion-inheritance-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -30,7 +30,7 @@
                 (VariableNode "$A")
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-rule-inversion")
+            (GroundedSchemaNode "scm: inversion-formula")
             (ListLink
                 (VariableNode "$A")
                 (VariableNode "$B")
@@ -41,7 +41,7 @@
                     (VariableNode "$B")
                     (VariableNode "$A"))))))
 
-(define pln-rule-inversion-implication
+(define inversion-implication-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -53,7 +53,7 @@
                 (VariableNode "$A")
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-rule-inversion")
+            (GroundedSchemaNode "scm: inversion-formula")
             (ListLink
                 (VariableNode "$A")
                 (VariableNode "$B")
@@ -64,7 +64,7 @@
                     (VariableNode "$B")
                     (VariableNode "$A"))))))
 
-(define pln-rule-inversion-subset
+(define inversion-subset-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -76,7 +76,7 @@
                 (VariableNode "$A")
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-rule-inversion")
+            (GroundedSchemaNode "scm: inversion-formula")
             (ListLink
                 (VariableNode "$A")
                 (VariableNode "$B")
@@ -87,7 +87,7 @@
                     (VariableNode "$B")
                     (VariableNode "$A"))))))
 
-(define (pln-formula-inversion A B AB BA)
+(define (inversion-formula A B AB BA)
     (let
         ((sA (cog-stv-strength A))
          (cA (cog-stv-confidence A))

--- a/opencog/reasoning/pln/rules/member-to-evaluation-rule.scm
+++ b/opencog/reasoning/pln/rules/member-to-evaluation-rule.scm
@@ -24,7 +24,7 @@
 (include "formulas.scm")
 
 ; No ListLink, 1 argument in EvaluationLink
-(define pln-rule-member-to-evaluation-0
+(define member-to-evaluation-0-rule
 	(BindLink
 		(VariableList
 			(VariableNode "$B")
@@ -39,7 +39,7 @@
 					(VariableNode "$D")
 					(VariableNode "$X-M2E"))))
 		(ExecutionOutputLink
-			(GroundedSchemaNode "scm: pln-formula-member-to-evaluation")
+			(GroundedSchemaNode "scm: member-to-evaluation-formula")
 			(ListLink
 				(EvaluationLink
 					(VariableNode "$D")
@@ -53,7 +53,7 @@
 							(VariableNode "$X-M2E"))))))))
 
 ; Has ListLink, 1 argument in EvaluationLink
-(define pln-rule-member-to-evaluation-1
+(define member-to-evaluation-1-rule
 	(BindLink
 		(VariableList
 			(VariableNode "$B")
@@ -69,7 +69,7 @@
 					(ListLink
 						(VariableNode "$X-M2E")))))
 		(ExecutionOutputLink
-			(GroundedSchemaNode "scm: pln-formula-member-to-evaluation")
+			(GroundedSchemaNode "scm: member-to-evaluation-formula")
 			(ListLink
 				(EvaluationLink
 					(VariableNode "$D")
@@ -85,7 +85,7 @@
 								(VariableNode "$X-M2E")))))))))
 
 ; Has ListLink, 2 arguments in EvaluationLink, 1st argument in MemberLink
-(define pln-rule-member-to-evaluation-2-1
+(define member-to-evaluation-2-1-rule
 	(BindLink
 		(VariableList
 			(VariableNode "$B")
@@ -103,7 +103,7 @@
 						(VariableNode "$X-M2E")
 						(VariableNode "$C")))))
 		(ExecutionOutputLink
-			(GroundedSchemaNode "scm: pln-formula-member-to-evaluation")
+			(GroundedSchemaNode "scm: member-to-evaluation-formula")
 			(ListLink
 				(EvaluationLink
 					(VariableNode "$D")
@@ -121,7 +121,7 @@
 								(VariableNode "$C")))))))))
 
 ; Has ListLink, 2 arguments in EvaluationLink, 2nd argument in MemberLink
-(define pln-rule-member-to-evaluation-2-2
+(define member-to-evaluation-2-2-rule
 	(BindLink
 		(VariableList
 			(VariableNode "$B")
@@ -139,7 +139,7 @@
 						(VariableNode "$B")
 						(VariableNode "$X-M2E")))))
 		(ExecutionOutputLink
-			(GroundedSchemaNode "scm: pln-formula-member-to-evaluation")
+			(GroundedSchemaNode "scm: member-to-evaluation-formula")
 			(ListLink
 				(EvaluationLink
 					(VariableNode "$D")
@@ -162,19 +162,19 @@
 ; Member To Evaluation Formula
 ; -----------------------------------------------------------------------------
 
-(define (pln-formula-member-to-evaluation EVAL MEM)
+(define (member-to-evaluation-formula EVAL MEM)
 	(cog-set-tv! EVAL (cog-tv MEM)))
 
 
 ; Name the rule
-(define pln-rule-member-to-evaluation-0-name (Node "pln-rule-member-to-evaluation-0"))
-(DefineLink pln-rule-member-to-evaluation-0-name pln-rule-member-to-evaluation-0)
+(define member-to-evaluation-0-rule-name (Node "member-to-evaluation-0-rule"))
+(DefineLink member-to-evaluation-0-rule-name member-to-evaluation-0-rule)
 
-(define pln-rule-member-to-evaluation-1-name (Node "pln-rule-member-to-evaluation-1"))
-(DefineLink pln-rule-member-to-evaluation-1-name pln-rule-member-to-evaluation-1)
+(define member-to-evaluation-1-rule-name (Node "member-to-evaluation-1-rule"))
+(DefineLink member-to-evaluation-1-rule-name member-to-evaluation-1-rule)
 
-(define pln-rule-member-to-evaluation-2-1-name (Node "pln-rule-member-to-evaluation-2-1"))
-(DefineLink pln-rule-member-to-evaluation-2-1-name pln-rule-member-to-evaluation-2-1)
+(define member-to-evaluation-2-1-rule-name (Node "member-to-evaluation-2-1-rule"))
+(DefineLink member-to-evaluation-2-1-rule-name member-to-evaluation-2-1-rule)
 
-(define pln-rule-member-to-evaluation-2-2-name (Node "pln-rule-member-to-evaluation-2-2"))
-(DefineLink pln-rule-member-to-evaluation-2-2-name pln-rule-member-to-evaluation-2-2)
+(define member-to-evaluation-2-2-rule-name (Node "member-to-evaluation-2-2-rule"))
+(DefineLink member-to-evaluation-2-2-rule-name member-to-evaluation-2-2-rule)

--- a/opencog/reasoning/pln/rules/member-to-inheritance-rule.scm
+++ b/opencog/reasoning/pln/rules/member-to-inheritance-rule.scm
@@ -11,7 +11,7 @@
 ;
 ; -----------------------------------------------------------------------------
 
-(define pln-rule-member-to-inheritance
+(define member-to-inheritance-rule
 	(BindLink
 		(VariableList
 			(VariableNode "$B")
@@ -20,7 +20,7 @@
 			(VariableNode "$B")
 			(VariableNode "$C"))
 		(ExecutionOutputLink
-			(GroundedSchemaNode "scm:pln-formula-member-to-inheritance")
+			(GroundedSchemaNode "scm: member-to-inheritance-formula")
 			(ListLink
 				(InheritanceLink
 					(VariableNode "$B")
@@ -37,10 +37,10 @@
 ; Side-effect: TruthValue of the new link stays the same
 ; -----------------------------------------------------------------------------
 
-(define (pln-formula-member-to-inheritance IBC MBC)
+(define (member-to-inheritance-formula IBC MBC)
 	(cog-set-tv!
 		IBC
-		(pln-formula-member-to-inheritance-side-effect-free
+		(member-to-inheritance-side-effect-free-formula
 			IBC
 			MBC)))
 
@@ -48,7 +48,7 @@
 ; This version has no side effects and simply returns a TruthValue
 ; -----------------------------------------------------------------------------
 
-(define (pln-formula-member-to-inheritance-side-effect-free IBC MBC)
+(define (member-to-inheritance-side-effect-free-formula IBC MBC)
 	(stv
 		(cog-stv-strength MBC)
 		(* (cog-stv-confidence MBC) 0.9)))
@@ -56,8 +56,8 @@
 ; =============================================================================
 
 ; Name the rule
-(define pln-rule-member-to-inheritance-name
-  (Node "pln-rule-member-to-inheritance"))
+(define member-to-inheritance-rule-name
+  (Node "member-to-inheritance-rule"))
 (DefineLink
-  pln-rule-member-to-inheritance-name
-  pln-rule-member-to-inheritance)
+  member-to-inheritance-rule-name
+  member-to-inheritance-rule)

--- a/opencog/reasoning/pln/rules/modus-ponens-rule.scm
+++ b/opencog/reasoning/pln/rules/modus-ponens-rule.scm
@@ -10,15 +10,15 @@
 ;   B
 ; Due to pattern matching issues, currently the file has been divided into 3 
 ; parts, each pertaining to different links. The rules are :-
-;       pln-rule-modus-ponens-inheritance
-;       pln-rule-modus-ponens-implication
-;       pln-rule-modus-ponens-subset
+;       modus-ponens-inheritance-rule
+;       modus-ponens-implication-rule
+;       modus-ponens-subset-rule
 ;
 ;
 ; -----------------------------------------------------------------------------
 (load "formulas.scm")
 
-(define pln-rule-modus-ponens-inheritance
+(define modus-ponens-inheritance-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -29,7 +29,7 @@
                 (VariableNode "$A")
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-modus-ponens")
+            (GroundedSchemaNode "scm: modus-ponens-formula")
             (ListLink
                 (VariableNode "$A")
                 (InheritanceLink
@@ -37,7 +37,7 @@
                     (VariableNode "$B"))
                 (VariableNode "$B")))))
 
-(define pln-rule-modus-ponens-implication
+(define modus-ponens-implication-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -48,7 +48,7 @@
                 (VariableNode "$A")
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-modus-ponens")
+            (GroundedSchemaNode "scm: modus-ponens-formula")
             (ListLink
                 (VariableNode "$A")
                 (ImplicationLink
@@ -56,7 +56,7 @@
                     (VariableNode "$B"))
                 (VariableNode "$B")))))
 
-(define pln-rule-modus-ponens-subset
+(define modus-ponens-subset-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -67,7 +67,7 @@
                 (VariableNode "$A")
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-modus-ponens")
+            (GroundedSchemaNode "scm: modus-ponens-formula")
             (ListLink
                 (VariableNode "$A")
                 (SubsetLink
@@ -75,7 +75,7 @@
                     (VariableNode "$B"))
                 (VariableNode "$B")))))
 
-(define (pln-formula-modus-ponens A AB B)
+(define (modus-ponens-formula A AB B)
     (let
         ((sA (cog-stv-strength A))
          (cA (cog-stv-confidence A))
@@ -86,6 +86,6 @@
         (cog-set-tv!
             B
             (stv 
-                (precise-modus-ponens-formula sA sAB snotAB) 
+                (precise-modus-ponens-strength-formula sA sAB snotAB) 
                 (min (min cAB cnotAB) cA)))))
 

--- a/opencog/reasoning/pln/rules/modus-ponens.scm
+++ b/opencog/reasoning/pln/rules/modus-ponens.scm
@@ -4,7 +4,7 @@
 ; Given P(A implies B) and sA, calculate sB
 ; -----------------------------------------------------------------------------
 
-(define pln-rule-modus-ponens
+(define modus-ponens-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -15,7 +15,7 @@
                 (VariableNode "$B"))
             (VariableNode "$A"))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-simple-modus-ponens")
+            (GroundedSchemaNode "scm: simple-modus-ponens-formula")
             (ListLink
                 (VariableNode "$B")
                 (ImplicationLink
@@ -30,17 +30,17 @@
 ; Side-effect: TruthValue of AC may be updated
 ; -----------------------------------------------------------------------------
 
-(define (pln-formula-simple-modus-ponens B AB)
+(define (simple-modus-ponens-formula B AB)
     (cog-set-tv!
         B
-        (pln-formula-simple-modus-ponens-side-effect-free
+        (simple-modus-ponens-side-effect-free-formula
             AB)))
 
 ; -----------------------------------------------------------------------------
 ; This version has no side effects and simply returns a TruthValue
 ; -----------------------------------------------------------------------------
 
-(define (pln-formula-simple-modus-ponens-side-effect-free AB)
+(define (simple-modus-ponens-side-effect-free-formula AB)
     (let
         ((sA (cog-stv-strength (gar AB)))
          (cA (cog-stv-confidence (gar AB))))
@@ -57,5 +57,5 @@
 ; =============================================================================
 
 ; Name the rule
-(define pln-rule-modus-ponens-name (Node "pln-rule-modus-ponens"))
-(DefineLink pln-rule-modus-ponens-name pln-rule-modus-ponens)
+(define modus-ponens-rule-name (Node "modus-ponens-rule"))
+(DefineLink modus-ponens-rule-name modus-ponens-rule)

--- a/opencog/reasoning/pln/rules/negated-subset-evaluation-rule.scm
+++ b/opencog/reasoning/pln/rules/negated-subset-evaluation-rule.scm
@@ -16,7 +16,7 @@
 ;
 ; -----------------------------------------------------------------------------
 
-(define pln-rule-negated-subset-evaluation
+(define negated-subset-evaluation-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -30,7 +30,7 @@
                 (VariableNode "$C")
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-negated-subset-evaluation")
+            (GroundedSchemaNode "scm: negated-subset-evaluation-formula")
             (ListLink
                 (SubsetLink
                     (NotLink
@@ -43,11 +43,11 @@
                     (VariableNode "$C")
                     (VariableNode "$B"))))))
 
-(define (pln-formula-negated-subset-evaluation nAB CA CB)
+(define (negated-subset-evaluation-formula nAB CA CB)
     (cog-set-tv!
-        nAB (pln-formula-negated-subset-evaluation-side-effect-free nAB CA CB)))
+        nAB (negated-subset-evaluation-side-effect-free-formula nAB CA CB)))
 
-(define (pln-formula-subset-negated-evaluation-side-effect-free nAB CA CB)
+(define (subset-negated-evaluation-side-effect-free-formula nAB CA CB)
     (let 
         ((snCA (- 1 (cog-stv-strength CA)))
          (cnCA (cog-stv-confidence CA))
@@ -62,8 +62,8 @@
                 (stv 1 1)))))
 
 ; Name the rule
-(define pln-rule-negated-subset-evaluation-name
-  (Node "pln-rule-negated-subset-evaluation"))
+(define negated-subset-evaluation-rule-name
+  (Node "negated-subset-evaluation-rule"))
 (DefineLink
-  pln-rule-negated-subset-evaluation-name
-  pln-rule-negated-subset-evaluation)
+  negated-subset-evaluation-rule-name
+  negated-subset-evaluation-rule)

--- a/opencog/reasoning/pln/rules/not-construction-rule.scm
+++ b/opencog/reasoning/pln/rules/not-construction-rule.scm
@@ -8,7 +8,7 @@
 ;    A
 ;----------------------------------------------------------------------
 
-(define pln-rule-not-construction
+(define not-construction-rule
   (BindLink
      (VariableList
         (TypedVariableLink
@@ -18,20 +18,20 @@
               (TypeNode "ConceptNode"))))
      (VariableNode "$A")
      (ExecutionOutputLink
-        (GroundedSchemaNode "scm: pln-formula-not-construction")
+        (GroundedSchemaNode "scm: not-construction-formula")
         (ListLink
            (VariableNode "$A")))))
 
-(define (pln-formula-not-construction A)
+(define (not-construction-formula A)
   (cog-set-tv!
    (NotLink A)
-   (pln-formula-not-construction-side-effect-free A))
+   (not-construction-side-effect-free-formula A))
 )
 
 (define (negate x)
   (- 1 x))
 
-(define (pln-formula-not-construction-side-effect-free A)
+(define (not-construction-side-effect-free-formula A)
   (let ((sA (cog-stv-strength A))
         (cA (cog-stv-confidence A)))
     (stv (negate sA) cA)))
@@ -41,8 +41,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; Name the rule
-(define pln-rule-not-construction-name
-  (Node "pln-rule-not-construction"))
+(define not-construction-rule-name
+  (Node "not-construction-rule"))
 (DefineLink
-   pln-rule-not-construction-name
-   pln-rule-not-construction)
+   not-construction-rule-name
+   not-construction-rule)

--- a/opencog/reasoning/pln/rules/not-elimination-rule.scm
+++ b/opencog/reasoning/pln/rules/not-elimination-rule.scm
@@ -8,31 +8,31 @@
 ;----------------------------------------------------------------------
 
 
-(define pln-rule-not-elimination
+(define not-elimination-rule
   (BindLink
    (VariableList
     (VariableNode "$A"))
    (NotLink
      (VariableNode "$A"))
    (ExecutionOutputLink
-    (GroundedSchemaNode "scm: pln-formula-not-elimination")
+    (GroundedSchemaNode "scm: not-elimination-formula")
     (ListLink
      (NotLink
       (VariableNode "$A")
      (VariableNode "$A"))))))
 
-(define (pln-formula-not-elimination NA A)
+(define (not-elimination-formula NA A)
   (cog-set-tv!
    A
-   (pln-formula-not-elimination-side-effect-free NA A))
+   (not-elimination-side-effect-free-formula NA A))
 )
 
-(define (pln-formula-not-elimination-side-effect-free NA A)
+(define (not-elimination-side-effect-free-formula NA A)
   (let 
       ((sNA (cog-stv-strength NA))
        (cNA (cog-stv-confidence NA)))
     (stv (- 1 sNA) cAB )))
 
 ; Name the rule
-(define pln-rule-not-elimination-name (Node "pln-rule-not-elimination"))
-(DefineLink pln-rule-not-elimination-name pln-rule-not-elimination)
+(define not-elimination-rule-name (Node "not-elimination-rule"))
+(DefineLink not-elimination-rule-name not-elimination-rule)

--- a/opencog/reasoning/pln/rules/not-simplification-rule.scm
+++ b/opencog/reasoning/pln/rules/not-simplification-rule.scm
@@ -9,7 +9,7 @@
 ;----------------------------------------------------------------------
 
 
-(define pln-rule-not-simplification
+(define not-simplification-rule
   (BindLink
    (VariableList
     (VariableNode "$A"))
@@ -17,28 +17,28 @@
     (NotLink
      (VariableNode "$A")))
    (ExecutionOutputLink
-    (GroundedSchemaNode "scm: pln-formula-not-simplification")
+    (GroundedSchemaNode "scm: not-simplification-formula")
     (ListLink
      (NotLink
       (NotLink
        (VariableNode "$A")))
      (VariableNode "$A")))))
 
-(define (pln-formula-not-simplification NNA A)
+(define (not-simplification-formula NNA A)
   (cog-set-tv!
    A
-   (pln-formula-not-simplification-side-effect-free NNA A))
+   (not-simplification-side-effect-free-formula NNA A))
 )
 
-(define (pln-formula-not-simplification-side-effect-free NNA A)
+(define (not-simplification-side-effect-free-formula NNA A)
   (let 
       ((sNNA (cog-stv-strength NNA))
        (cNNA (cog-stv-confidence NNA)))
     (stv (- 1 sNNA) cNNA)))
 
 ; Name the rule
-(define pln-rule-not-simplification-name
-  (Node "pln-rule-not-simplification"))
+(define not-simplification-rule-name
+  (Node "not-simplification-rule"))
 (DefineLink
-  pln-rule-not-simplification-name
-  pln-rule-not-simplification)
+  not-simplification-rule-name
+  not-simplification-rule)

--- a/opencog/reasoning/pln/rules/ontological-inheritance-rule.scm
+++ b/opencog/reasoning/pln/rules/ontological-inheritance-rule.scm
@@ -15,7 +15,7 @@
 ;
 ; -----------------------------------------------------------------------------
 
-(define pln-rule-ontological-inheritance
+(define ontological-inheritance-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -28,7 +28,7 @@
                 (VariableNode "$B")
                 (VariableNode "$A")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-ontological-inheritance")
+            (GroundedSchemaNode "scm: ontological-inheritance-formula")
             (ListLink
                 (OntologicalInheritanceLink
                     (VariableNode "$A")
@@ -40,14 +40,14 @@
                     (VariableNode "$B")
                     (VariableNode "$A"))))))
 
-(define (pln-formula-ontological-inheritance OAB AB BA)
+(define (ontological-inheritance-formula OAB AB BA)
     (cog-set-tv!
         OAB
-        (pln-formula-ontological-inheritance-side-effect-free OAB AB BA)
+        (ontological-inheritance-side-effect-free-formula OAB AB BA)
     )
 )
 
-(define (pln-formula-ontological-inheritance-side-effect-free OAB AB BA)
+(define (ontological-inheritance-side-effect-free-formula OAB AB BA)
     (let
         ((sAB (cog-stv-strength AB))
          (cAB (cog-stv-confidence AB))
@@ -61,8 +61,8 @@
 
 
 ; Name the rule
-(define pln-rule-ontological-inheritance-name
-  (Node "pln-rule-ontological-inheritance"))
+(define ontological-inheritance-rule-name
+  (Node "ontological-inheritance-rule"))
 (DefineLink
-  pln-rule-ontological-inheritance-name
-  pln-rule-ontological-inheritance)
+  ontological-inheritance-rule-name
+  ontological-inheritance-rule)

--- a/opencog/reasoning/pln/rules/or-breakdown-rule.scm
+++ b/opencog/reasoning/pln/rules/or-breakdown-rule.scm
@@ -11,7 +11,7 @@
 ;----------------------------------------------------------------------
 
 
-(define pln-rule-or-breakdown
+(define or-breakdown-rule
   (BindLink
    (VariableList
     (VariableNode "$A")
@@ -22,7 +22,7 @@
      (VariableNode "$B"))
     (VariableNode "$A"))
    (ExecutionOutputLink
-    (GroundedSchemaNode "scm: pln-formula-or-breakdown")
+    (GroundedSchemaNode "scm: or-breakdown-formula")
     (ListLink
      (OrLink
       (VariableNode "$A")
@@ -30,13 +30,13 @@
      (VariableNode "$A")
      (VariableNode "$B")))))
 
-(define (pln-formula-or-breakdown AB A B)
+(define (or-breakdown-formula AB A B)
   (cog-set-tv!
    B
-   (pln-formula-or-breakdown-side-effect-free AB A B))
+   (or-breakdown-side-effect-free-formula AB A B))
 )
 
-(define (pln-formula-or-breakdown-side-effect-free AB A B)
+(define (or-breakdown-side-effect-free-formula AB A B)
   (let 
       ((sAB (cog-stv-strength AB))
        (cAB (cog-stv-confidence AB))
@@ -45,5 +45,5 @@
     (stv (/ sAB (- 1 sA)) (min cAB cA))))
 
 ; Name the rule
-(define pln-rule-or-breakdown-name (Node "pln-rule-or-breakdown"))
-(DefineLink pln-rule-or-breakdown-name pln-rule-or-breakdown)
+(define or-breakdown-rule-name (Node "or-breakdown-rule"))
+(DefineLink or-breakdown-rule-name or-breakdown-rule)

--- a/opencog/reasoning/pln/rules/or-construction-rule.scm
+++ b/opencog/reasoning/pln/rules/or-construction-rule.scm
@@ -17,7 +17,7 @@
 ;----------------------------------------------------------------------
 
 
-(define pln-rule-or-construction
+(define or-construction-rule
   (BindLink
      (VariableList
         (TypedVariableLink
@@ -38,18 +38,18 @@
               (VariableNode "$A")
               (VariableNode "$B"))))
      (ExecutionOutputLink
-        (GroundedSchemaNode "scm: pln-formula-or-construction")
+        (GroundedSchemaNode "scm: or-construction-formula")
         (ListLink
            (VariableNode "$A")
            (VariableNode "$B")))))
 
-(define (pln-formula-or-construction A B)
+(define (or-construction-formula A B)
   (cog-set-tv!
    (OrLink A B)
-   (pln-formula-or-construction-side-effect-free A B))
+   (or-construction-side-effect-free-formula A B))
 )
 
-(define (pln-formula-or-construction-side-effect-free A B)
+(define (or-construction-side-effect-free-formula A B)
   (let 
       ((sA (cog-stv-strength A))
        (sB (cog-stv-strength B))
@@ -58,8 +58,8 @@
     (stv (- (+ sA sB) (* sA sB)) (min cA cB))))
 
 ; Name the rule
-(define pln-rule-or-construction-name
-  (Node "pln-rule-or-construction"))
+(define or-construction-rule-name
+  (Node "or-construction-rule"))
 (DefineLink
-   pln-rule-or-construction-name
-   pln-rule-or-construction)
+   or-construction-rule-name
+   or-construction-rule)

--- a/opencog/reasoning/pln/rules/or-elimination-rule.scm
+++ b/opencog/reasoning/pln/rules/or-elimination-rule.scm
@@ -13,7 +13,7 @@
 ;; TODO :- Create the rule n-ary
 
 
-(define pln-rule-or-elimination
+(define or-elimination-rule
   (BindLink
    (VariableList
     (VariableNode "$A")
@@ -23,7 +23,7 @@
      (VariableNode "$A")
      (VariableNode "$B")))
    (ExecutionOutputLink
-    (GroundedSchemaNode "scm: pln-formula-or-elimination")
+    (GroundedSchemaNode "scm: or-elimination-formula")
     (ListLink
      (OrLink
       (VariableNode "$A")
@@ -31,21 +31,21 @@
      (VariableNode "$A")
      (VariableNode "$B")))))
 
-(define (pln-formula-or-elimination AB A B)
+(define (or-elimination-formula AB A B)
   (cog-set-tv!
    A
-   (pln-formula-or-elimination-side-effect-free AB))
+   (or-elimination-side-effect-free-formula AB))
   (cog-set-tv!
    B
-   (pln-formula-or-elimination-side-effect-free AB)) 
+   (or-elimination-side-effect-free-formula AB)) 
 )
 
-(define (pln-formula-or-elimination-side-effect-free AB)
+(define (or-elimination-side-effect-free-formula AB)
   (let 
       ((sAB (cog-stv-strength AB))
        (cAB (cog-stv-confidence AB)))
     (stv (/ sAB 2) 1)))
 
 ; Name the rule
-(define pln-rule-or-elimination-name (Node "pln-rule-or-elimination"))
-(DefineLink pln-rule-or-elimination-name pln-rule-or-elimination)
+(define or-elimination-rule-name (Node "or-elimination-rule"))
+(DefineLink or-elimination-rule-name or-elimination-rule)

--- a/opencog/reasoning/pln/rules/or-evaluation-rule.scm
+++ b/opencog/reasoning/pln/rules/or-evaluation-rule.scm
@@ -15,7 +15,7 @@
 ;
 ; -----------------------------------------------------------------------------
 
-(define pln-rule-or-evaluation
+(define or-evaluation-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -29,7 +29,7 @@
                 (VariableNode "$C")
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-or-evaluation")
+            (GroundedSchemaNode "scm: or-evaluation-formula")
             (ListLink
                 (OrLink
                     (VariableNode "$A")
@@ -41,11 +41,11 @@
                     (VariableNode "$C")
                     (VariableNode "$B"))))))
 
-(define (pln-formula-or-evaluation AB CA CB)
+(define (or-evaluation-formula AB CA CB)
     (cog-set-tv!
-        AB (pln-formula-or-evaluation-side-effect-free AB CA CB)))
+        AB (or-evaluation-side-effect-free-formula AB CA CB)))
 
-(define (pln-formula-or-evaluation-side-effect-free AB CA CB)
+(define (or-evaluation-side-effect-free-formula AB CA CB)
     (let 
         ((sCA (cog-stv-strength CA))
          (cCA (cog-stv-confidence CA))
@@ -57,5 +57,5 @@
             (stv 1 1))))
 
 ; Name the rule
-(define pln-rule-or-evaluation-name (Node "pln-rule-or-evaluation"))
-(DefineLink pln-rule-or-evaluation-name pln-rule-or-evaluation)
+(define or-evaluation-rule-name (Node "or-evaluation-rule"))
+(DefineLink or-evaluation-rule-name or-evaluation-rule)

--- a/opencog/reasoning/pln/rules/or-simplification-rule.scm
+++ b/opencog/reasoning/pln/rules/or-simplification-rule.scm
@@ -14,7 +14,7 @@
 ;----------------------------------------------------------------------
 
 
-(define pln-rule-or-simplification
+(define or-simplification-rule
   (BindLink
    (VariableList
     (VariableNode "$A")
@@ -26,7 +26,7 @@
       (VariableNode "$B")
       (VariableNode "$C")))
    (ExecutionOutputLink
-    (GroundedSchemaNode "scm: pln-formula-or-simplification")
+    (GroundedSchemaNode "scm: or-simplification-formula")
     (ListLink
      (OrLink
       (VariableNode "$A")
@@ -38,18 +38,18 @@
       (VariableNode "$B")
       (VariableNode "$C"))))))
 
-(define (pln-formula-or-simplification AABC ABC)
+(define (or-simplification-formula AABC ABC)
   (cog-set-tv!
    ABC
-   (pln-formula-or-simplification-side-effect-free AABC ABC))
+   (or-simplification-side-effect-free-formula AABC ABC))
 )
 
-(define (pln-formula-or-simplification-side-effect-free AABC ABC)
+(define (or-simplification-side-effect-free-formula AABC ABC)
   (let 
       ((sAABC (cog-stv-strength AABC))
        (cAABC (cog-stv-confidence AABC)))
     (stv sAABC cAABC)))
 
 ; Name the rule
-(define pln-rule-or-simplification-name (Node "pln-rule-or-simplification"))
-(DefineLink pln-rule-or-simplification-name pln-rule-or-simplification)
+(define or-simplification-rule-name (Node "or-simplification-rule"))
+(DefineLink or-simplification-rule-name or-simplification-rule)

--- a/opencog/reasoning/pln/rules/or-transformation-rule.scm
+++ b/opencog/reasoning/pln/rules/or-transformation-rule.scm
@@ -9,7 +9,7 @@
 ;----------------------------------------------------------------------
 
 
-(define pln-rule-or-transformation
+(define or-transformation-rule
   (BindLink
    (VariableList
     (VariableNode "$A")
@@ -18,7 +18,7 @@
     (VariableNode "$A")
     (VariableNode "$B"))
    (ExecutionOutputLink
-    (GroundedSchemaNode "scm: pln-formula-or-transformation")
+    (GroundedSchemaNode "scm: or-transformation-formula")
     (ListLink
      (OrLink
       (VariableNode "$A")
@@ -28,19 +28,19 @@
        (VariableNode "$A"))
       (VariableNode "$B"))))))
 
-(define (pln-formula-or-transformation OAB IAB)
+(define (or-transformation-formula OAB IAB)
   (cog-set-tv!
    IAB
-   (pln-formula-or-transformation-side-effect-free OAB IAB))
+   (or-transformation-side-effect-free-formula OAB IAB))
 )
 
 
-(define (pln-formula-or-transformation-side-effect-free OAB IAB)
+(define (or-transformation-side-effect-free-formula OAB IAB)
   (let 
       ((sOAB (cog-stv-strength OAB))
        (cOAB (cog-stv-confidence OAB)))
     (stv sOAB cOAB)))
 
 ; Name the rule
-(define pln-rule-or-transformation-name (Node "pln-rule-or-transformation"))
-(DefineLink pln-rule-or-transformation-name pln-rule-or-transformation)
+(define or-transformation-rule-name (Node "or-transformation-rule"))
+(DefineLink or-transformation-rule-name or-transformation-rule)

--- a/opencog/reasoning/pln/rules/precise-modus-ponens-rule.scm
+++ b/opencog/reasoning/pln/rules/precise-modus-ponens-rule.scm
@@ -14,15 +14,15 @@
 ;   B
 ; Due to pattern matching issues, currently the file has been divided into 3 
 ; parts, each pertaining to different links. The rules are :-
-;       pln-rule-precise-modus-ponens-inheritance
-;       pln-rule-precise-modus-ponens-implication
-;       pln-rule-precise-modus-ponens-subset
+;       precise-modus-ponens-inheritance-rule
+;       precise-modus-ponens-implication-rule
+;       precise-modus-ponens-subset-rule
 ;
 
 ; -----------------------------------------------------------------------------
 (load "formulas.scm")
 
-(define pln-rule-precise-modus-ponens-inheritance
+(define precise-modus-ponens-inheritance-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -37,7 +37,7 @@
                     (VariableNode "$A"))
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-precise-modus-ponens")
+            (GroundedSchemaNode "scm: precise-modus-ponens-formula")
             (ListLink
                 (VariableNode "$A")
                 (InheritanceLink
@@ -49,7 +49,7 @@
                     (VariableNode "$B"))
                 (VariableNode "$B")))))
 
-(define pln-rule-precise-modus-ponens-implication
+(define precise-modus-ponens-implication-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -64,7 +64,7 @@
                     (VariableNode "$A"))
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-precise-modus-ponens")
+            (GroundedSchemaNode "scm: precise-modus-ponens-formula")
             (ListLink
                 (VariableNode "$A")
                 (ImplicationLink
@@ -76,7 +76,7 @@
                     (VariableNode "$B"))
                 (VariableNode "$B")))))
 
-(define pln-rule-precise-modus-ponens-subset
+(define precise-modus-ponens-subset-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -91,7 +91,7 @@
                     (VariableNode "$A"))
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-precise-modus-ponens")
+            (GroundedSchemaNode "scm: precise-modus-ponens-formula")
             (ListLink
                 (VariableNode "$A")
                 (SubsetLink
@@ -103,7 +103,7 @@
                     (VariableNode "$B"))
                 (VariableNode "$B")))))
 
-(define (pln-formula-precise-modus-ponens A AB notAB B)
+(define (precise-modus-ponens-formula A AB notAB B)
     (let
         ((sA (cog-stv-strength A))
          (cA (cog-stv-confidence A))
@@ -114,5 +114,5 @@
         (cog-set-tv!
             B
             (stv 
-                (precise-modus-ponens-formula sA sAB snotAB) 
+                (precise-modus-ponens-strength-formula sA sAB snotAB) 
                 (min (min cAB cnotAB) cA)))))

--- a/opencog/reasoning/pln/rules/similarity-rule.scm
+++ b/opencog/reasoning/pln/rules/similarity-rule.scm
@@ -15,7 +15,7 @@
 ;
 ; -----------------------------------------------------------------------------
 
-(define pln-rule-similarity
+(define similarity-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -28,7 +28,7 @@
                 (VariableNode "$A")
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-similarity")
+            (GroundedSchemaNode "scm: similarity-formula")
             (ListLink
                 (AndLink
                     (VariableNode "$A")
@@ -40,7 +40,7 @@
                     (VariableNode "$A")
                     (VariableNode "$B"))))))
 
-(define (pln-formula-similarity AAB OAB SAB)
+(define (similarity-formula AAB OAB SAB)
     (cog-set-tv! 
         SAB
         (if 

--- a/opencog/reasoning/pln/rules/subset-evaluation-rule.scm
+++ b/opencog/reasoning/pln/rules/subset-evaluation-rule.scm
@@ -15,7 +15,7 @@
 ;
 ; -----------------------------------------------------------------------------
 
-(define pln-rule-subset-evaluation
+(define subset-evaluation-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -29,7 +29,7 @@
                 (VariableNode "$C")
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-subset-evaluation")
+            (GroundedSchemaNode "scm: subset-evaluation-formula")
             (ListLink
                 (SubsetLink
                     (VariableNode "$A")
@@ -41,11 +41,11 @@
                     (VariableNode "$C")
                     (VariableNode "$B"))))))
 
-(define (pln-formula-subset-evaluation AB CA CB)
+(define (subset-evaluation-formula AB CA CB)
     (cog-set-tv!
-        AB (pln-formula-subset-evaluation-side-effect-free AB CA CB)))
+        AB (subset-evaluation-side-effect-free-formula AB CA CB)))
 
-(define (pln-formula-subset-evaluation-side-effect-free AB CA CB)
+(define (subset-evaluation-side-effect-free-formula AB CA CB)
     (let 
         ((sCA (cog-stv-strength CA))
          (cCA (cog-stv-confidence CA))
@@ -60,5 +60,5 @@
                 (stv 1 1)))))
 
 ; Name the rule
-(define pln-rule-subset-evaluation-name (Node "pln-rule-subset-evaluation"))
-(DefineLink pln-rule-subset-evaluation-name pln-rule-subset-evaluation)
+(define subset-evaluation-rule-name (Node "subset-evaluation-rule"))
+(DefineLink subset-evaluation-rule-name subset-evaluation-rule)

--- a/opencog/reasoning/pln/rules/symmetric-modus-ponens-rule.scm
+++ b/opencog/reasoning/pln/rules/symmetric-modus-ponens-rule.scm
@@ -11,14 +11,14 @@
 ; 
 ; Due to issues in pattern matching in backward chaining, the files has been
 ; split into three rules for seperate link types. The 3 rules are
-;           pln-rule-symmetric-modus-ponens-similarity
-;           pln-rule-symmetric-modus-ponens-intensional-similarity
-;           pln-rule-summetric-modus-ponens-extensional-similarity
+;           symmetric-modus-ponens-similarity-rule
+;           symmetric-modus-ponens-intensional-similarity-rule
+;           summetric-modus-ponens-extensional-similarity-rule
 ;
 ; -----------------------------------------------------------------------------
 (load "formulas.scm")
 
-(define pln-rule-symmetric-modus-ponens-similarity
+(define symmetric-modus-ponens-similarity-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -29,7 +29,7 @@
                 (VariableNode "$A")
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-symmetric-modus-ponens")
+            (GroundedSchemaNode "scm: symmetric-modus-ponens-formula")
             (ListLink
                 (VariableNode "$A")
                 (SimilarityLink
@@ -37,7 +37,7 @@
                     (VariableNode "$B"))
                 (VariableNode "$B")))))
 
-(define pln-rule-symmetric-modus-ponens-intensional-similarity
+(define symmetric-modus-ponens-intensional-similarity-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -48,7 +48,7 @@
                 (VariableNode "$A")
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-symmetric-modus-ponens")
+            (GroundedSchemaNode "scm: symmetric-modus-ponens-formula")
             (ListLink
                 (VariableNode "$A")
                 (IntensionalSimilarityLink
@@ -56,7 +56,7 @@
                     (VariableNode "$B"))
                 (VariableNode "$B")))))
 
-(define pln-rule-symmetric-modus-ponens-extensional-similarity
+(define symmetric-modus-ponens-extensional-similarity-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -67,7 +67,7 @@
                 (VariableNode "$A")
                 (VariableNode "$B")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-symmetric-modus-ponens")
+            (GroundedSchemaNode "scm: symmetric-modus-ponens-formula")
             (ListLink
                 (VariableNode "$A")
                 (ExtensionalSimilarityLink
@@ -75,7 +75,7 @@
                     (VariableNode "$B"))
                 (VariableNode "$B")))))
 
-(define (pln-formula-symmetric-modus-ponens A AB B)
+(define (symmetric-modus-ponens-formula A AB B)
     (let
         ((sA (cog-stv-strength A))
          (cA (cog-stv-confidence A))

--- a/opencog/reasoning/pln/rules/term-probability-rule.scm
+++ b/opencog/reasoning/pln/rules/term-probability-rule.scm
@@ -14,14 +14,14 @@
 ;
 ; Due to issues in pattern matching in backward chaining, the files has been
 ; split into three rules for seperate link types. The 3 rules are
-;           pln-rule-term-probability-inheritance
-;           pln-rule-term-probability-implication
-;           pln-rule-term-probability-subset
+;           term-probability-inheritance-rule
+;           term-probability-implication-rule
+;           term-probability-subset-rule
 ;
 ; -----------------------------------------------------------------------------
 (load "formulas.scm")
 
-(define pln-rule-term-probability-inheritance
+(define term-probability-inheritance-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -35,7 +35,7 @@
                 (VariableNode "$B")
                 (VariableNode "$A")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-term-probability")
+            (GroundedSchemaNode "scm: term-probability-formula")
             (ListLink
                 (VariableNode "$A")
                 (InheritanceLink
@@ -46,7 +46,7 @@
                     (VariableNode "$A"))
                 (VariableNode "$B")))))
 
-(define pln-rule-term-probability-implication
+(define term-probability-implication-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -60,7 +60,7 @@
                 (VariableNode "$B")
                 (VariableNode "$A")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-term-probability")
+            (GroundedSchemaNode "scm: term-probability-formula")
             (ListLink
                 (VariableNode "$A")
                 (ImplicationLink
@@ -71,7 +71,7 @@
                     (VariableNode "$A"))
                 (VariableNode "$B")))))
 
-(define pln-rule-term-probability-subset
+(define term-probability-subset-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -85,7 +85,7 @@
                 (VariableNode "$B")
                 (VariableNode "$A")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-term-probability")
+            (GroundedSchemaNode "scm: term-probability-formula")
             (ListLink
                 (VariableNode "$A")
                 (SubsetLink
@@ -96,7 +96,7 @@
                     (VariableNode "$A"))
                 (VariableNode "$B")))))
 
-(define (pln-formula-term-probability A AB BA B)
+(define (term-probability-formula A AB BA B)
     (let
         ((sA (cog-stv-strength A))
          (cA (cog-stv-confidence A))

--- a/opencog/reasoning/pln/rules/transitive-similarity-rule.scm
+++ b/opencog/reasoning/pln/rules/transitive-similarity-rule.scm
@@ -15,14 +15,14 @@
 ;
 ; Due to issues in pattern matching in backward chaining, the files has been
 ; split into three rules for seperate link types. The 3 rules are
-;           pln-rule-transitive-similarity-similarity
-;           pln-rule-transitive-similarity-extensional-similarity
-;           pln-rule-transitive-similarity-intensional-similarity
+;           transitive-similarity-similarity-rule
+;           transitive-similarity-extensional-similarity-rule
+;           transitive-similarity-intensional-similarity-rule
 ;
 ; -----------------------------------------------------------------------------
 (load "formulas.scm")
 
-(define pln-rule-transitive-similarity-similarity
+(define transitive-similarity-similarity-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -39,7 +39,7 @@
                 (VariableNode "$B")
                 (VariableNode "$C")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-transitive-similarity")
+            (GroundedSchemaNode "scm: transitive-similarity-formula")
             (ListLink
                 (VariableNode "$A")
                 (VariableNode "$B")
@@ -54,7 +54,7 @@
                     (VariableNode "$A")
                     (VariableNode "$C"))))))
 
-(define pln-rule-transitive-similarity-extensional-similarity
+(define transitive-similarity-extensional-similarity-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -71,7 +71,7 @@
                 (VariableNode "$B")
                 (VariableNode "$C")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-transitive-similarity")
+            (GroundedSchemaNode "scm: transitive-similarity-formula")
             (ListLink
                 (VariableNode "$A")
                 (VariableNode "$B")
@@ -86,7 +86,7 @@
                     (VariableNode "$A")
                     (VariableNode "$C"))))))
 
-(define pln-rule-transitive-similarity-intensional-similarity
+(define transitive-similarity-intensional-similarity-rule
     (BindLink
         (VariableList
             (VariableNode "$A")
@@ -103,7 +103,7 @@
                 (VariableNode "$B")
                 (VariableNode "$C")))
         (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pln-formula-transitive-similarity")
+            (GroundedSchemaNode "scm: transitive-similarity-formula")
             (ListLink
                 (VariableNode "$A")
                 (VariableNode "$B")
@@ -118,7 +118,7 @@
                     (VariableNode "$A")
                     (VariableNode "$C"))))))
 
-(define (pln-formula-transitive-similarity A B C AB BC AC)
+(define (transitive-similarity-formula A B C AB BC AC)
     (let
         ((sA (cog-stv-strength A))
          (cA (cog-stv-confidence A))
@@ -133,5 +133,5 @@
         (cog-set-tv!
             AC 
             (stv 
-                (transitive-similarity-formula sA sB sC sAB sBC) 
+                (transitive-similarity-strength-formula sA sB sC sAB sBC) 
                 (min cAB cBC)))))

--- a/tests/pln/scm/relex2logic_pln_examples/context-rules.scm
+++ b/tests/pln/scm/relex2logic_pln_examples/context-rules.scm
@@ -6,7 +6,7 @@
 (EvaluationLink
     (PredicateNode "inputs")
     (ListLink
-        ; 1) input for (pln-rule-contextualize-inheritance)
+        ; 1) input for (contextualize-inheritance-rule)
         ; "Ben is competent in doing mathematics."
         (InheritanceLink (stv .8 .8)
             (AndLink
@@ -15,7 +15,7 @@
             (AndLink
                 (ConceptNode "competent")
                 (ConceptNode "doing_mathematics")))
-        ; 2) input for (pln-rule-contextualize-evaluation)
+        ; 2) input for (contextualize-evaluation-rule)
         ; "The sky is blue in the context of the earth.
         ; The sky is not blue in the context of the moon."
         (EvaluationLink (stv .8 .7)
@@ -30,19 +30,19 @@
                 (AndLink
                     (ConceptNode "sky")
                     (ConceptNode "moon"))))
-        ; 3) input for (pln-rule-contextualize-subset)
+        ; 3) input for (contextualize-subset-rule)
         ; "Dogs are animals."
         (SubsetLink (stv .8 .8)
             (ConceptNode "dogs")
             (ConceptNode "animals"))
-        ; 4) input for (pln-rule-decontextualize-inheritance)
+        ; 4) input for (decontextualize-inheritance-rule)
         ; "Ben is competent in the domain of mathematics.
         (ContextLink (stv .8 .8)
             (ConceptNode "doing_mathematics")
             (InheritanceLink
                 (ConceptNode "Ben")
                 (ConceptNode "competent")))
-        ; 5) input for (pln-rule-decontextualize-evaluation)
+        ; 5) input for (decontextualize-evaluation-rule)
         ; "In the context of the earth, the sky is blue."
         (ContextLink (stv .8 .8)
             (ConceptNode "earth")
@@ -50,7 +50,7 @@
                 (PredicateNode "isBlue")
                 (ListLink
                     (ConceptNode "sky"))))
-        ; 6) input for (pln-rule-decontextualize-subset)
+        ; 6) input for (decontextualize-subset-rule)
         ; "Dogs are animals."
         (ContextLink (stv .8 .8)
             (ConceptNode "dogs")

--- a/tests/reasoning/PLNRulesUTest.cxxtest
+++ b/tests/reasoning/PLNRulesUTest.cxxtest
@@ -85,7 +85,7 @@ void PLNRulesUTest::setUp()
 }
 
 /**
- * Tests the deduction rule (pln-rule-deduction) defined in:
+ * Tests the deduction rule (deduction-rule) defined in:
  * opencog/reasoning/pln/rules/deduction.scm
  */
 void PLNRulesUTest::test_deduction()
@@ -106,7 +106,7 @@ void PLNRulesUTest::test_deduction()
     TS_ASSERT_EQUALS(1, as.get_arity(results));
     
     // Apply the deduction rule
-    eval.eval_h("(cog-bind pln-rule-deduction)");
+    eval.eval_h("(cog-bind deduction-rule)");
        
     // After applying the deduction rule, it should know that all 3 of the
     // instances of men are also humans (Socrates, Einstein, and Peirce)
@@ -117,7 +117,7 @@ void PLNRulesUTest::test_deduction()
 }
 
 /**
- * Tests the and rule (pln-rule-and-construction) defined in:
+ * Tests the and rule (and-construction-rule) defined in:
  * opencog/reasoning/pln/rules/and-construction-rule.scm
  */
 void PLNRulesUTest::test_and_construction()
@@ -132,14 +132,14 @@ void PLNRulesUTest::test_and_construction()
     load_scm_files_from_config(as);
 
     // Apply the and rule
-    Handle results = eval.eval_h("(cog-bind-af pln-rule-and-construction)");
+    Handle results = eval.eval_h("(cog-bind-af and-construction-rule)");
 
     // It should contain 1 groundings, and(A, B)
     TS_ASSERT_EQUALS(1, as.get_arity(results));
 }
 
 /**
- * Tests the and rule (pln-rule-or-construction) defined in:
+ * Tests the and rule (or-construction-rule) defined in:
  * opencog/reasoning/pln/rules/or-construction-rule.scm
  */
 void PLNRulesUTest::test_or_construction()
@@ -154,14 +154,14 @@ void PLNRulesUTest::test_or_construction()
     load_scm_files_from_config(as);
 
     // Apply the and rule
-    Handle results = eval.eval_h("(cog-bind-af pln-rule-or-construction)");
+    Handle results = eval.eval_h("(cog-bind-af or-construction-rule)");
 
     // It should contain 1 groundings, or(A, B)
     TS_ASSERT_EQUALS(1, as.get_arity(results));
 }
 
 /**
- * Tests the not rule (pln-rule-not-construction) defined in:
+ * Tests the not rule (not-construction-rule) defined in:
  * opencog/reasoning/pln/rules/not-construction-rule.scm
  */
 void PLNRulesUTest::test_not_construction()
@@ -176,7 +176,7 @@ void PLNRulesUTest::test_not_construction()
     load_scm_files_from_config(as);
 
     // Apply the and rule
-    Handle results = eval.eval_h("(cog-bind-af pln-rule-not-construction)");
+    Handle results = eval.eval_h("(cog-bind-af not-construction-rule)");
 
     // It should contain 2 groundings, not(A), not(B)
     TS_ASSERT_EQUALS(2, as.get_arity(results));
@@ -198,7 +198,7 @@ void PLNRulesUTest::test_forall_full_instantiation()
     load_scm_files_from_config(as);
 
     // Apply the and rule
-    Handle rule = eval.eval_h("pln-rule-forall-full-instantiation");
+    Handle rule = eval.eval_h("forall-full-instantiation-rule");
     Handle results = bindlink(&as, rule);
 
     /**
@@ -218,7 +218,7 @@ void PLNRulesUTest::test_forall_full_instantiation()
      *          <some-concept>
      *          <some-predicate>
      */
-    TS_ASSERT_EQUALS(3, as.get_arity(results));
+    TS_ASSERT_EQUALS(4, as.get_arity(results));
 }
 
 /**
@@ -237,7 +237,7 @@ void PLNRulesUTest::test_forall_partial_instantiation()
     load_scm_files_from_config(as);
 
     // Apply the and rule
-    Handle rule = eval.eval_h("pln-rule-forall-partial-instantiation");
+    Handle rule = eval.eval_h("forall-partial-instantiation-rule");
     Handle results = bindlink(&as, rule);
 
     /**
@@ -266,7 +266,7 @@ void PLNRulesUTest::test_forall_implication_to_higher_order()
     load_scm_files_from_config(as);
 
     // Apply the and rule
-    Handle rule = eval.eval_h("pln-rule-forall-implication-to-higher-order");
+    Handle rule = eval.eval_h("forall-implication-to-higher-order-rule");
     Handle results = bindlink(&as, rule);
     Handle expected_results = eval.eval_h
 	    ("(SetLink"


### PR DESCRIPTION
PLN users beware!!! This is yet one of those useless cleanings Nil is obsessed about!

I've removed the pln prefixes as we know they are PLN rules (since there
are attached to the PLN rule-base-system), and their name is already
sufficiently long like that! (And relex2logic doesn't use that kind of
prefixing and seems to be doing fine).

So don't call your next PLN rule
```
pln-rule-<NAME>
```
instead call it simply
```
<NAME>-rule
```

Same thing for formula, do not use
```
pln-formula-<NAME>
```
instead use
```
<NAME>-formula
```
