### PR TITLE
Pass SentenceNode instead of the actual sentence to get-answers

### DIFF
--- a/opencog/nlp/chatbot/nlp-chat-interface.scm
+++ b/opencog/nlp/chatbot/nlp-chat-interface.scm
@@ -35,7 +35,7 @@
         (display "I can't process truth query for now"))
         ((equal? (check_query_type querySentence) "InterrogativeSpeechAct")
             (display "You made an Interrogative SpeechAct ")
-        (wh_query_process query))
+        (wh_query_process querySentence))
         ((equal? (check_query_type querySentence) "DeclarativeSpeechAct")
             (display "You made a Declarative SpeechAct "))
         (else (display "Sorry,I don't know the type"))


### PR DESCRIPTION
Passing the SentenceNode so that the same sentence won't be parsed again.