### PR TITLE
nlp-utils: Fix unable to get NumberNode Lemma

### DIFF
--- a/opencog/nlp/scm/nlp-utils.scm
+++ b/opencog/nlp/scm/nlp-utils.scm
@@ -339,7 +339,13 @@
 "
 	(let ((wlist (cog-chase-link 'LemmaLink 'WordNode word-inst)))
 		(if (null? wlist)
-			'()
+			; FIXME: this is a dumb way to get other type
+			(let ((nlist (cog-chase-link 'LemmaLink 'NumberNode word-inst)))
+				(if (null? nlist)
+					'()
+					(car nlist)
+				)
+			)
 			(car wlist)
 		)
 	)


### PR DESCRIPTION
Why is the ReferenceLink link to WordNode but for Lemma it is NumberNode?