### PR TITLE
Avoid passing a ReferenceLink as a variable in det-rule

### DIFF
--- a/opencog/nlp/relex2logic/rule-helpers.scm
+++ b/opencog/nlp/relex2logic/rule-helpers.scm
@@ -599,9 +599,9 @@
 (define (det-rule concept instance var_name determiner)
 	(cond ((or (string=? determiner "those") (string=? determiner "these"))
 		(list (ImplicationLink
-			(r2l-wordinst-concept instance)
 			(MemberLink (VariableNode var_name) (ConceptNode instance))
 			(InheritanceLink (VariableNode var_name) (ConceptNode concept))))
+			(r2l-wordinst-concept instance)
 		)
 		((or (string=? determiner "this") (string=? determiner "that"))
 		(list


### PR DESCRIPTION
Repositioning the ReferenceLink generated by r2l-wordinst-concept in det-rule, otherwise an error `Expected a VariableNode or a TypedVariableLink, got: ReferenceLink` occurred when parsing sentences like "These people are crazy." etc