### PR TITLE
Remove anchor from parse-get-relex-outputs

### DIFF
--- a/opencog/nlp/scm/nlp-utils.scm
+++ b/opencog/nlp/scm/nlp-utils.scm
@@ -231,8 +231,7 @@
   Given a parse, returns a list of RelEx outputs associated with the ParseNode.
 "
     (let* ((sent-node (car (cog-chase-link 'ParseLink 'SentenceNode parse-node)))
-           (anchor (car (cog-get-link 'ListLink 'AnchorNode sent-node)))
-           (sent-incoming-set (remove (lambda (x) (equal? anchor x)) (cog-incoming-set sent-node)))
+           (sent-incoming-set (cog-incoming-set sent-node))
            (word-inst-nodes (parse-get-words parse-node))
            (relex-relations (concatenate (map word-inst-get-relations word-inst-nodes)))
            (word-incoming-set (concatenate (map cog-incoming-set word-inst-nodes)))


### PR DESCRIPTION
Since nlp-parse will release the SentenceNode from the AnchorNode after parsing the sentence, this code will fail to find the SentenceNode from the AnchorNode, and the return an error when doing a `car` to an empty list. The anchor here is not/no longer needed anyway.