### PR TITLE
spatial code cython binding fix

### DIFF
--- a/opencog/cython/opencog/spacetime.pxd
+++ b/opencog/cython/opencog/spacetime.pxd
@@ -3,7 +3,7 @@ from libcpp cimport bool
 from libcpp.string cimport string
 
 from opencog.atomspace cimport cAtomSpace, cHandle, tv_ptr
-from opencog.spatial cimport cOctomapOcTree
+from opencog.spatial cimport cOctomapOcTree, cEntityRecorder
 
 cdef extern from "opencog/spacetime/Temporal.h":
     ctypedef uint64_t octime_t
@@ -21,6 +21,7 @@ cdef extern from "opencog/spacetime/SpaceServer.h" namespace "opencog":
     cdef cppclass cSpaceServer "opencog::SpaceServer":
         cSpaceServer(cAtomSpace&)
         const cSpaceMap& getMap(cHandle)
+        const cEntityRecorder& getEntityRecorder(cHandle)
         cHandle addOrGetSpaceMap(octime_t, string, double, string)
         bool addSpaceInfo(cHandle, cHandle, bool, bool, octime_t, double, double, double, string)
         void removeSpaceInfo(cHandle, cHandle, octime_t, string)

--- a/opencog/cython/opencog/spacetime.pyx
+++ b/opencog/cython/opencog/spacetime.pyx
@@ -2,6 +2,7 @@ from cython.operator cimport dereference as deref
 
 from opencog.atomspace cimport AtomSpace, Handle, TruthValue
 from opencog.spatial import OctomapOcTree as SpaceMap
+from opencog.spatial import EntityRecorder
 
 cdef class TimeServer:
     cdef cTimeServer* c_time_server
@@ -39,6 +40,11 @@ cdef class SpaceServer:
         cdef cHandle c_handle = deref((<Handle>handle).h)
         map_instance = SpaceMap(<long>(&(self.c_space_server.getMap(c_handle))))
         return map_instance
+
+    def get_entity_recorder(self,Handle handle):
+        cdef cHandle c_handle = deref((<Handle>handle).h)
+        er_instance = EntityRecorder(<long>(&(self.c_space_server.getEntityRecorder(c_handle))))
+        return er_instance
 
     def add_map(self, timestamp, map_name, resolution, time_domain = None):
         cdef string c_map_name = map_name.encode('UTF-8')

--- a/opencog/cython/opencog/spatial.pyx
+++ b/opencog/cython/opencog/spatial.pyx
@@ -107,6 +107,12 @@ cdef class EntityRecorder:
         #SpaceServer will handle this
         pass
 
+    @classmethod
+    def init_new_entity_recorder(cls):
+        cdef cEntityRecorder* cer = new cEntityRecorder()
+        newer = cls(PyLong_FromVoidPtr(cer))
+        return newer
+
     def get_self_agent_entity(self):
         return Handle(self.c_entity_recorder.getSelfAgentEntity().value())
 

--- a/opencog/cython/opencog/spatial.pyx
+++ b/opencog/cython/opencog/spatial.pyx
@@ -100,15 +100,15 @@ cdef class EntityRecorder:
     def __cinit__(self):
         pass
 
-    def __init__(self):
-        self.c_entity_recorder = new cEntityRecorder()
+    def __init__(self, long addr):
+        self.c_entity_recorder = <cEntityRecorder*> PyLong_AsVoidPtr(addr)
 
     def __dealloc__(self):
         #SpaceServer will handle this
         pass
 
     def get_self_agent_entity(self):
-        return Handle(self.c_octree_map.getSelfAgentEntity().value())
+        return Handle(self.c_entity_recorder.getSelfAgentEntity().value())
 
     def add_none_block_entity(self, Handle handle, pos, isSelfObject, isAvatarEntity, timestamp):
         assert len(pos) == 3

--- a/tests/cython/spatial/test_EntityRecorder.py
+++ b/tests/cython/spatial/test_EntityRecorder.py
@@ -7,7 +7,7 @@ class TestEntityRecorder(unittest.TestCase):
 
     def setUp(self):
         self.atomspace = AtomSpace()
-        self.test_entity_recorder = EntityRecorder()
+        self.test_entity_recorder = EntityRecorder.init_new_entity_recorder()
 
     def tearDown(self):
         del self.test_entity_recorder

--- a/tests/cython/spatial/test_Octree3DMap.py
+++ b/tests/cython/spatial/test_Octree3DMap.py
@@ -25,8 +25,8 @@ class TestMap(unittest.TestCase):
         self.assertTrue(test_handle.is_undefined())
 
     def testBinaryAddandRemove_NormalUnitBlock_AllGetFunctionWork(self):
-        test_pos1 = (7, 8, 9)
-        test_handle1 = Handle(100)
+        test_pos1 = (7.0, 8.0, 9.0)
+        test_handle1 = self.atomspace.add_node(types.Node,"bogus").h
 
         self.testmap.add_solid_unit_block(test_handle1, test_pos1)
         test_handle2 = self.testmap.get_block(test_pos1)
@@ -41,7 +41,7 @@ class TestMap(unittest.TestCase):
     def testAddSolidUnitBlock__PositionOverBorder__GetBlockFailed(self):
         border = 32768
         test_pos1 = (border, 8, 9)
-        test_handle1 = Handle(100)
+        test_handle1 = self.atomspace.add_node(types.Node,"bogus").h
 
         self.testmap.add_solid_unit_block(test_handle1, test_pos1)
         test_handle2 = self.testmap.get_block(test_pos1)
@@ -49,8 +49,8 @@ class TestMap(unittest.TestCase):
         self.assertTrue(test_handle2.is_undefined())
 
     def testSetBlock_AddBlockWithProbabilityControl_GetFunctionsWorkWithProb(self):
-        test_pos1 = (7, 8, 9)
-        test_handle1 = Handle(100)
+        test_pos1 = (7.0, 8.0, 9.0)
+        test_handle1 = self.atomspace.add_node(types.Node,"bogus").h
         log_odds_threshold = self.testmap.get_occupancy_thres_log()
 
         self.testmap.set_unit_block(test_handle1, test_pos1, log_odds_threshold)


### PR DESCRIPTION
Some fix for EntityRecorder and cython test of OctomapOcTree.
After this fix we passed the cython unit test of EntityRecorder and OctomapOcTree. Also it fixed the functionality in Minecraft embodiment, which needs to get entity recorder from SpaceServer in python.
