### PR TITLE
Use a shorter, simpler, easier-to-rad syntax for the rules

### DIFF
--- a/opencog/nlp/chatbot/CMakeLists.txt
+++ b/opencog/nlp/chatbot/CMakeLists.txt
@@ -5,6 +5,7 @@ INSTALL (FILES
 
 INSTALL (FILES
 	chat-utils.scm
+	eva.scm
 	process-query.scm
    DESTINATION "${DATADIR}/scm/opencog/nlp/chatbot"
 )

--- a/opencog/nlp/chatbot/DIARY
+++ b/opencog/nlp/chatbot/DIARY
@@ -479,4 +479,9 @@ passive.scm
 imperative.scm
 how-q.scm
 
+declarative borked!
+
+
 PrepositionalRelationshipNode
+PartOfSpeechLink
+InheritanceLink

--- a/opencog/nlp/chatbot/DIARY
+++ b/opencog/nlp/chatbot/DIARY
@@ -473,3 +473,10 @@ bugs:
 
 ====================================================
 (process-query "luser" "Look left")
+
+truthquery.scm
+passive.scm
+imperative.scm
+how-q.scm
+
+PrepositionalRelationshipNode

--- a/opencog/nlp/chatbot/DIARY
+++ b/opencog/nlp/chatbot/DIARY
@@ -390,3 +390,86 @@ bugs:
 * typoes fool the fuzzy matcher... e.g.
   "Linas eats banannas. "Who eats bannanas?"  note variable nn
 
+====================================================
+
+(use-modules (opencog) (opencog nlp chatbot))
+(use-modules (opencog) (opencog nlp) (opencog nlp microplanning))
+
+(nlp-parse "Ronald ate the apple.")
+(nlp-parse "Ronald ate some fruit.")
+(microplanning lap "declarative" *default_chunks_option* #f)
+
+(process-query 'luser "Joe ate a pie.")
+(process-query 'luser "Joe is eating a pie.")
+(process-query 'luser "Who ate a cookie?")
+(process-query "luser" "Joe ate a pear.")
+(process-query "luser" "Who ate a pear?")
+
+(process-query "luser" "Linas ate an apple.")
+(process-query "luser" "Who ate an apple?")
+
+(process-query "luser" "John Kennedy died.")
+(process-query "luser" "Who died?")
+
+(process-query "luser" "What is the color of the ball? ")
+(process-query "luser" "What is the color of the book? ")
+(process-query "luser" "Who died?")
+
+(nlp-parse "My name is Raymond Reddington.")
+(process-query "luser" "What is your name?")
+
+(process-query "luser" "I sent the money to your boss.")
+(process-query "luser" "Who sent money to your boss?")
+(process-query "luser" "Who did you send the money to?")
+
+(process-query "luser" "I sang a song to her")
+
+
+(process-query "luser" "I sang a beautiful song to Mary")
+(process-query "luser" "Who did I sing to?")
+(process-query "luser" "I sang to Joan")
+(process-query "luser" "Who did I sing to?")
+(process-query "luser" "Who did I sing a beautiful song to?")
+
+(process-query "luser" "Who did I sing to?")
+(process-query "luser" "The ball is red")
+(process-query "luser" "The book is blue")
+
+(process-query "luser" "The ball is under the couch")
+
+(process-query "luser" "John threw a green ball.")
+(process-query "luser" "Mike threw a red ball.")
+
+(process-query "luser" "Who threw a red ball?")
+(process-query "luser" "Who threw a green ball?")
+(process-query "luser" "Where is the ball?")
+
+(process-query "luser" "I had two chocolates")
+(process-query "luser" "how many chocolates do I have")
+
+(process-query "luser" "what's your name")
+(process-query "luser" "who is Raymond?")
+
+(EvaluationLink (stv 1.0 1.0)
+   (LinkGrammarRelationshipNode "Wq")
+   (ListLink
+      (WordInstanceNode
+"LEFT-WALL@sentence@b7598d65-e2c7-4f4a-b873-02d548140b40_parse_0")
+      (WordInstanceNode "how@a3499630-bbe8-4802-acbe-8a8f1213c714")
+   )
+)
+
+(ReferenceLink (stv 1.0 1.0)
+   (WordInstanceNode
+"LEFT-WALL@sentence@b7598d65-e2c7-4f4a-b873-02d548140b40_parse_0")
+   (WordNode "###LEFT-WALL###")
+)
+(WordInstanceLink (stv 1.0 1.0)
+   (WordInstanceNode
+"LEFT-WALL@sentence@b7598d65-e2c7-4f4a-b873-02d548140b40_parse_0")
+   (ParseNode "sentence@b7598d65-e2c7-4f4a-b873-02d548140b40_parse_0")
+)
+
+
+====================================================
+(process-query "luser" "Look left")

--- a/opencog/nlp/chatbot/chatbot.scm
+++ b/opencog/nlp/chatbot/chatbot.scm
@@ -4,6 +4,7 @@
 (define-module (opencog nlp chatbot))
 
 (load "chatbot/chat-utils.scm")
+(load "chatbot/eva.scm")
 (load "chatbot/process-query.scm")
 
 ; Temporary debug support

--- a/opencog/nlp/chatbot/eva.scm
+++ b/opencog/nlp/chatbot/eva.scm
@@ -1,0 +1,15 @@
+;
+; eva.scm
+;
+; Hacky scaffolding for talking with Hanson Robotics Eva.
+; Probably does not belong in this directory.
+
+;--------------------------------------------------------------------
+(define (imperative_process imp)
+"
+  Process imperative IMP, which should be a SentenceNode.
+
+"
+	(display imp)
+	(newline)
+)

--- a/opencog/nlp/chatbot/eva.scm
+++ b/opencog/nlp/chatbot/eva.scm
@@ -5,6 +5,18 @@
 ; Probably does not belong in this directory.
 
 ;--------------------------------------------------------------------
+(define (var-decl var type)
+	(TypedVariable (VariableNode var) (TypeNode type)))
+
+;(define look-rule
+;	(BindLink
+;		(VariableList
+;			(var-decl "$a-parse" "ParseNode")
+;		)
+;	)
+;)
+
+;--------------------------------------------------------------------
 (define (imperative_process imp)
 "
   Process imperative IMP, which should be a SentenceNode.

--- a/opencog/nlp/chatbot/process-query.scm
+++ b/opencog/nlp/chatbot/process-query.scm
@@ -11,10 +11,10 @@
 ;--------------------------------------------------------------------
 (define (wh_query_process query)
 "
-  Process wh-question using the fuzzy hyper graph Matcher
-  QUERY should be a SentenceNode
+  Process wh-question using the fuzzy hypergraph Matcher
+  QUERY should be a SentenceNode.
 
-  Wrapper around get-ansers provided by (opencog nlp fuzzy)
+  Wrapper around get-answers provided by (opencog nlp fuzzy)
 "
     (define temp (get-answers query))
     (cond
@@ -32,7 +32,7 @@
   string holding what the user said.
 "
     ; nlp-parse returns (SentenceNode "sentence@45c470a6-29...")
-    (define querySentence (car (nlp-parse query)))
+    (define sent-node (car (nlp-parse query)))
 
     ;; XXX FIXME -- remove the IRC debug response below.
     (display "Hello ")
@@ -44,18 +44,18 @@
     ; Call the `get-utterance-type` function to get the speech act type
     ; of the utterance.  The response processing will be based on the
     ; type of the speech act.
-    (let* ((gutr (sentence-get-utterance-type querySentence))
+    (let* ((gutr (sentence-get-utterance-type sent-node))
            (utr (if (equal? '() gutr) '() (car gutr)))
         )
     (cond
         ((equal? utr (DefinedLinguisticConceptNode "TruthQuerySpeechAct"))
             (display "You asked a Truth Query\n")
-            ; (truth_query_process querySentence)
+            ; (truth_query_process sent-node)
             (display "I can't process truth query for now\n")
         )
         ((equal? utr (DefinedLinguisticConceptNode "InterrogativeSpeechAct"))
             (display "You made an Interrogative SpeechAct\n")
-            (wh_query_process querySentence)
+            (wh_query_process sent-node)
         )
         ((equal? utr (DefinedLinguisticConceptNode "DeclarativeSpeechAct"))
             (display "You made a Declarative SpeechAct\n")
@@ -64,6 +64,7 @@
         ((equal? utr (DefinedLinguisticConceptNode "ImperativeSpeechAct"))
             (display "You made a Imperative SpeechAct\n")
             ; Make the robot do whatever ...
+				(imperative_process sent-node)
             ; XXX Use AIML here to say something snarky.
         )
         (else
@@ -94,7 +95,7 @@
 ; Used by 'truth_query_process' to find the input for the backward
 ; chaining.
 ; XXX FIXME This also definitely requires change after the backward
-; chaning is completed.
+; chaining is completed.
 ;-------------------------------------------------------------------
 (define (fAtom querySentence)
     (define x (cog-filter 'EvaluationLink (cog-outgoing-set

--- a/opencog/nlp/relex2logic/CMakeLists.txt
+++ b/opencog/nlp/relex2logic/CMakeLists.txt
@@ -6,6 +6,7 @@ INSTALL (FILES
 INSTALL (FILES
 	post-processing.scm
 	rule-helpers.scm
+	rule-utils.scm
 	r2l-utilities.scm
 	DESTINATION "${DATADIR}/scm/opencog/nlp/relex2logic"
 )

--- a/opencog/nlp/relex2logic/relex2logic.scm
+++ b/opencog/nlp/relex2logic/relex2logic.scm
@@ -5,6 +5,7 @@
 
 (use-modules (opencog) (opencog atom-types) (opencog nlp))
 
+(load "relex2logic/rule-utils.scm")
 (load "relex2logic/r2l-utilities.scm")
 
 ; -----------------------------------------------------------------------
@@ -13,6 +14,7 @@
 
 	; "." in case the cogserver is started from in-source build directory.
 	(add-to-load-path ".")
+	(load "relex2logic/rule-utils.scm")
 	(load "relex2logic/rule-helpers.scm")
 	(load "relex2logic/loader/load-rules.scm")
 	(load "relex2logic/loader/gen-r2l-en-rulebase.scm")

--- a/opencog/nlp/relex2logic/rule-utils.scm
+++ b/opencog/nlp/relex2logic/rule-utils.scm
@@ -1,0 +1,10 @@
+;
+; rule-tuils.scm
+;
+; Some generic rule utilities, not limited to r2l.
+;
+;--------------------------------------------------------------------
+;
+; Short-hand for declaring a variable.
+(define (var-decl var type)
+   (TypedVariableLink (VariableNode var) (TypeNode type)))

--- a/opencog/nlp/relex2logic/rule-utils.scm
+++ b/opencog/nlp/relex2logic/rule-utils.scm
@@ -11,3 +11,8 @@
 
 (define (word-in-parse word parse)
 	(WordInstanceLink (VariableNode word) (VariableNode parse))
+
+(define (dependency rel head dep)
+	(EvaluationLink
+		(DefinedLinguisticRelationshipNode rel)
+		(ListLink (VariableNode head) (VariableNode dep))))

--- a/opencog/nlp/relex2logic/rule-utils.scm
+++ b/opencog/nlp/relex2logic/rule-utils.scm
@@ -16,3 +16,8 @@
 	(EvaluationLink
 		(DefinedLinguisticRelationshipNode rel)
 		(ListLink (VariableNode head) (VariableNode dep))))
+
+(define (lg-link rel head dep)
+	(EvaluationLink
+		(LinkGrammarRelationshipNode rel)
+		(ListLink (VariableNode head) (VariableNode dep))))

--- a/opencog/nlp/relex2logic/rule-utils.scm
+++ b/opencog/nlp/relex2logic/rule-utils.scm
@@ -9,5 +9,5 @@
 (define (var-decl var type)
    (TypedVariableLink (VariableNode var) (TypeNode type)))
 
-(define (word-inst word parse)
+(define (word-in-parse word parse)
 	(WordInstanceLink (VariableNode word) (VariableNode parse))

--- a/opencog/nlp/relex2logic/rule-utils.scm
+++ b/opencog/nlp/relex2logic/rule-utils.scm
@@ -10,7 +10,7 @@
    (TypedVariableLink (VariableNode var) (TypeNode type)))
 
 (define (word-in-parse word parse)
-	(WordInstanceLink (VariableNode word) (VariableNode parse))
+	(WordInstanceLink (VariableNode word) (VariableNode parse)))
 
 (define (dependency rel head dep)
 	(EvaluationLink

--- a/opencog/nlp/relex2logic/rule-utils.scm
+++ b/opencog/nlp/relex2logic/rule-utils.scm
@@ -8,3 +8,6 @@
 ; Short-hand for declaring a variable.
 (define (var-decl var type)
    (TypedVariableLink (VariableNode var) (TypeNode type)))
+
+(define (word-inst word parse)
+	(WordInstanceLink (VariableNode word) (VariableNode parse))

--- a/opencog/nlp/relex2logic/rules/PREP.scm
+++ b/opencog/nlp/relex2logic/rules/PREP.scm
@@ -14,18 +14,9 @@
 			(var-decl "$obj" "WordInstanceNode")
 		)
 		(AndLink
-			(WordInstanceLink
-				(VariableNode "$subj")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$prep")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$obj")
-				(VariableNode "$a-parse")
-			)
+			(word-in-parse "$subj" "$a-parse")
+			(word-in-parse "$prep" "$a-parse")
+			(word-in-parse "$obj" "$a-parse")
 			(EvaluationLink
 				(DefinedLinguisticRelationshipNode "_psubj")
 				(ListLink

--- a/opencog/nlp/relex2logic/rules/PREP.scm
+++ b/opencog/nlp/relex2logic/rules/PREP.scm
@@ -17,20 +17,8 @@
 			(word-in-parse "$subj" "$a-parse")
 			(word-in-parse "$prep" "$a-parse")
 			(word-in-parse "$obj" "$a-parse")
-			(EvaluationLink
-				(DefinedLinguisticRelationshipNode "_psubj")
-				(ListLink
-					(VariableNode "$prep")
-					(VariableNode "$subj")
-				)
-			)
-			(EvaluationLink
-				(DefinedLinguisticRelationshipNode "_pobj")
-				(ListLink
-					(VariableNode "$prep")
-					(VariableNode "$obj")
-				)
-			)
+			(dependency "_psubj" "$prep" "$subj")
+			(dependency "_pobj" "$prep" "$obj")
 		)
 		(ExecutionOutputLink
 			(GroundedSchemaNode "scm: pre-prep-rule")

--- a/opencog/nlp/relex2logic/rules/PREP.scm
+++ b/opencog/nlp/relex2logic/rules/PREP.scm
@@ -8,22 +8,10 @@
 (define PREP
 	(BindLink
 		(VariableList
-			(TypedVariableLink
-				(VariableNode "$a-parse")
-				(TypeNode "ParseNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$subj")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$prep")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$obj")
-				(TypeNode "WordInstanceNode")
-			)
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$subj" "WordInstanceNode")
+			(var-decl "$prep" "WordInstanceNode")
+			(var-decl "$obj" "WordInstanceNode")
 		)
 		(AndLink
 			(WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/SP.scm
+++ b/opencog/nlp/relex2logic/rules/SP.scm
@@ -6,26 +6,11 @@
 (define SP
 	(BindLink
 		(VariableList
-			(TypedVariableLink
-				(VariableNode "$a-parse")
-				(TypeNode "ParseNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$subj")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$predadj")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$subj-lemma")
-				(TypeNode "WordNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$predadj-lemma")
-				(TypeNode "WordNode")
-			)
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$subj" "WordInstanceNode")
+			(var-decl "$predadj" "WordInstanceNode")
+			(var-decl "$subj-lemma" "WordNode")
+			(var-decl "$predadj-lemma" "WordNode")
 		)
 		(AndLink
 			(WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/SP.scm
+++ b/opencog/nlp/relex2logic/rules/SP.scm
@@ -23,13 +23,7 @@
 				(VariableNode "$predadj")
 				(VariableNode "$predadj-lemma")
 			)
-			(EvaluationLink
-				(DefinedLinguisticRelationshipNode "_predadj")
-				(ListLink
-					(VariableNode "$subj")
-					(VariableNode "$predadj")
-				)
-			)
+			(dependency "_predadj" "$subj" "$predadj")
 		)
 		(ExecutionOutputLink
 			(GroundedSchemaNode "scm: SV-rule")

--- a/opencog/nlp/relex2logic/rules/SP.scm
+++ b/opencog/nlp/relex2logic/rules/SP.scm
@@ -13,14 +13,8 @@
 			(var-decl "$predadj-lemma" "WordNode")
 		)
 		(AndLink
-			(WordInstanceLink
-				(VariableNode "$subj")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$predadj")
-				(VariableNode "$a-parse")
-			)
+			(word-in-parse "$subj" "$a-parse")
+			(word-in-parse "$predadj" "$a-parse")
 			(LemmaLink
 				(VariableNode "$subj")
 				(VariableNode "$subj-lemma")

--- a/opencog/nlp/relex2logic/rules/SV.scm
+++ b/opencog/nlp/relex2logic/rules/SV.scm
@@ -5,26 +5,11 @@
 (define SV
 	(BindLink
 		(VariableList
-			(TypedVariableLink
-				(VariableNode "$a-parse")
-				(TypeNode "ParseNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$subj")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$verb")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$subj-lemma")
-				(TypeNode "WordNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$verb-lemma")
-				(TypeNode "WordNode")
-			)
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$subj" "WordInstanceNode")
+			(var-decl "$verb" "WordInstanceNode")
+			(var-decl "$subj-lemma" "WordNode")
+			(var-decl "$verb-lemma" "WordNode")
 		)
 		(AndLink
 			(WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/SV.scm
+++ b/opencog/nlp/relex2logic/rules/SV.scm
@@ -22,13 +22,7 @@
 				(VariableNode "$verb")
 				(VariableNode "$verb-lemma")
 			)
-			(EvaluationLink
-				(DefinedLinguisticRelationshipNode "_subj")
-				(ListLink
-					(VariableNode "$verb")
-					(VariableNode "$subj")
-				)
-			)
+			(dependency "_subj" "$verb" "$subj")
 		)
 		(ExecutionOutputLink
 			(GroundedSchemaNode "scm: SV-rule")

--- a/opencog/nlp/relex2logic/rules/SV.scm
+++ b/opencog/nlp/relex2logic/rules/SV.scm
@@ -12,14 +12,8 @@
 			(var-decl "$verb-lemma" "WordNode")
 		)
 		(AndLink
-			(WordInstanceLink
-				(VariableNode "$subj")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$verb")
-				(VariableNode "$a-parse")
-			)
+			(word-in-parse "$subj" "$a-parse")
+			(word-in-parse "$verb" "$a-parse")
 			(LemmaLink
 				(VariableNode "$subj")
 				(VariableNode "$subj-lemma")

--- a/opencog/nlp/relex2logic/rules/SVIO1.scm
+++ b/opencog/nlp/relex2logic/rules/SVIO1.scm
@@ -7,42 +7,15 @@
 (define SVIO1
 	(BindLink
 		(VariableList
-			(TypedVariableLink
-				(VariableNode "$a-parse")
-				(TypeNode "ParseNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$subj")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$verb")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$obj")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$iobj")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$subj-lemma")
-				(TypeNode "WordNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$verb-lemma")
-				(TypeNode "WordNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$obj-lemma")
-				(TypeNode "WordNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$iobj-lemma")
-				(TypeNode "WordNode")
-			)
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$subj" "WordInstanceNode")
+			(var-decl "$verb" "WordInstanceNode")
+			(var-decl "$obj" "WordInstanceNode")
+			(var-decl "$iobj" "WordInstanceNode")
+			(var-decl "$subj-lemma" "WordNode")
+			(var-decl "$verb-lemma" "WordNode")
+			(var-decl "$obj-lemma" "WordNode")
+			(var-decl "$iobj-lemma" "WordNode")
 		)
 		(AndLink
 			(WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/SVIO1.scm
+++ b/opencog/nlp/relex2logic/rules/SVIO1.scm
@@ -18,22 +18,10 @@
 			(var-decl "$iobj-lemma" "WordNode")
 		)
 		(AndLink
-			(WordInstanceLink
-				(VariableNode "$subj")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$verb")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$obj")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$iobj")
-				(VariableNode "$a-parse")
-			)
+			(word-in-parse "$subj" "$a-parse")
+			(word-in-parse "$verb" "$a-parse")
+			(word-in-parse "$obj" "$a-parse")
+			(word-in-parse "$iobj" "$a-parse")
 			(EvaluationLink
 				(DefinedLinguisticRelationshipNode "_subj")
 				(ListLink

--- a/opencog/nlp/relex2logic/rules/SVIO1.scm
+++ b/opencog/nlp/relex2logic/rules/SVIO1.scm
@@ -22,27 +22,9 @@
 			(word-in-parse "$verb" "$a-parse")
 			(word-in-parse "$obj" "$a-parse")
 			(word-in-parse "$iobj" "$a-parse")
-			(EvaluationLink
-				(DefinedLinguisticRelationshipNode "_subj")
-				(ListLink
-					(VariableNode "$verb")
-					(VariableNode "$subj")
-				)
-			)
-			(EvaluationLink
-				(DefinedLinguisticRelationshipNode "_obj")
-				(ListLink
-					(VariableNode "$verb")
-					(VariableNode "$obj")
-				)
-			)
-			(EvaluationLink
-				(DefinedLinguisticRelationshipNode "_iobj")
-				(ListLink
-					(VariableNode "$verb")
-					(VariableNode "$iobj")
-				)
-			)
+			(dependency "_subj" "$verb" "$subj")
+			(dependency "_obj" "$verb" "$obj")
+			(dependency "_iobj" "$verb" "$iobj")
 			(LemmaLink
 				(VariableNode "$subj")
 				(VariableNode "$subj-lemma")

--- a/opencog/nlp/relex2logic/rules/SVIO2.scm
+++ b/opencog/nlp/relex2logic/rules/SVIO2.scm
@@ -7,46 +7,16 @@
 (define SVIO2
 	(BindLink
 		(VariableList
-			(TypedVariableLink
-				(VariableNode "$a-parse")
-				(TypeNode "ParseNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$subj")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$verb")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$obj")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$iobj")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$to")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$subj-lemma")
-				(TypeNode "WordNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$verb-lemma")
-				(TypeNode "WordNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$obj-lemma")
-				(TypeNode "WordNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$iobj-lemma")
-				(TypeNode "WordNode")
-			)
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$subj" "WordInstanceNode")
+			(var-decl "$verb" "WordInstanceNode")
+			(var-decl "$obj" "WordInstanceNode")
+			(var-decl "$iobj" "WordInstanceNode")
+			(var-decl "$to" "WordInstanceNode")
+			(var-decl "$subj-lemma" "WordNode")
+			(var-decl "$verb-lemma" "WordNode")
+			(var-decl "$obj-lemma" "WordNode")
+			(var-decl "$iobj-lemma" "WordNode")
 		)
 		(AndLink
 			(WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/SVIO2.scm
+++ b/opencog/nlp/relex2logic/rules/SVIO2.scm
@@ -28,27 +28,9 @@
 				(VariableNode "$to")
 				(WordNode "to")
 			)
-			(EvaluationLink
-				(DefinedLinguisticRelationshipNode "_subj")
-				(ListLink
-					(VariableNode "$verb")
-					(VariableNode "$subj")
-				)
-			)
-			(EvaluationLink
-				(DefinedLinguisticRelationshipNode "_obj")
-				(ListLink
-					(VariableNode "$verb")
-					(VariableNode "$obj")
-				)
-			)
-			(EvaluationLink
-				(DefinedLinguisticRelationshipNode "_pobj")
-				(ListLink
-					(VariableNode "$to")
-					(VariableNode "$iobj")
-				)
-			)
+			(dependency "_subj" "$subj" "$verb")
+			(dependency "_obj" "$obj" "$verb")
+			(dependency "_pobj" "$iobj" "$to")
 			(LemmaLink
 				(VariableNode "$subj")
 				(VariableNode "$subj-lemma")

--- a/opencog/nlp/relex2logic/rules/SVIO2.scm
+++ b/opencog/nlp/relex2logic/rules/SVIO2.scm
@@ -19,26 +19,11 @@
 			(var-decl "$iobj-lemma" "WordNode")
 		)
 		(AndLink
-			(WordInstanceLink
-				(VariableNode "$subj")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$verb")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$obj")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$iobj")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$to")
-				(VariableNode "$a-parse")
-			)
+			(word-in-parse "$subj" "$a-parse")
+			(word-in-parse "$verb" "$a-parse")
+			(word-in-parse "$obj" "$a-parse")
+			(word-in-parse "$iobj" "$a-parse")
+			(word-in-parse "$to" "$a-parse")
 			(LemmaLink
 				(VariableNode "$to")
 				(WordNode "to")

--- a/opencog/nlp/relex2logic/rules/TOBE.scm
+++ b/opencog/nlp/relex2logic/rules/TOBE.scm
@@ -17,18 +17,9 @@
 			(var-decl "$adj" "WordInstanceNode")
 		)
 		(AndLink
-			(WordInstanceLink
-				(VariableNode "$subj")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$verb")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$adj")
-				(VariableNode "$a-parse")
-			)
+			(word-in-parse "$subj" "$a-parse")
+			(word-in-parse "$verb" "$a-parse")
+			(word-in-parse "$adj" "$a-parse")
 			(EvaluationLink
 				(DefinedLinguisticRelationshipNode "_to-be")
 				(ListLink

--- a/opencog/nlp/relex2logic/rules/TOBE.scm
+++ b/opencog/nlp/relex2logic/rules/TOBE.scm
@@ -11,22 +11,10 @@
 (define TOBE
 	(BindLink
 		(VariableList
-			(TypedVariableLink
-				(VariableNode "$a-parse")
-				(TypeNode "ParseNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$subj")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$verb")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$adj")
-				(TypeNode "WordInstanceNode")
-			)
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$subj" "WordInstanceNode")
+			(var-decl "$verb" "WordInstanceNode")
+			(var-decl "$adj" "WordInstanceNode")
 		)
 		(AndLink
 			(WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/TOBE.scm
+++ b/opencog/nlp/relex2logic/rules/TOBE.scm
@@ -20,20 +20,8 @@
 			(word-in-parse "$subj" "$a-parse")
 			(word-in-parse "$verb" "$a-parse")
 			(word-in-parse "$adj" "$a-parse")
-			(EvaluationLink
-				(DefinedLinguisticRelationshipNode "_to-be")
-				(ListLink
-					(VariableNode "$verb")
-					(VariableNode "$adj")
-				)
-			)
-			(EvaluationLink
-				(DefinedLinguisticRelationshipNode "_subj")
-				(ListLink
-					(VariableNode "$verb")
-					(VariableNode "$subj")
-				)
-			)
+			(dependency "_to-be" "$verb" "$adj")
+			(dependency "_subj" "$verb" "$subj")
 		)
 		(ExecutionOutputLink
 			(GroundedSchemaNode "scm: pre-tobe-rule")

--- a/opencog/nlp/relex2logic/rules/adverbialpp.scm
+++ b/opencog/nlp/relex2logic/rules/adverbialpp.scm
@@ -12,20 +12,8 @@
 			(word-in-parse "$prep" "$a-parse")
 			(word-in-parse "$noun" "$a-parse")
 			(word-in-parse "$verb" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_pobj")
-                (ListLink
-                    (VariableNode "$prep")
-                    (VariableNode "$noun")
-                )
-            )
-           (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_advmod")
-                (ListLink
-                    (VariableNode "$verb")
-                    (VariableNode "$prep")
-                )
-           )
+			(dependency "_pobj" "$prep" "$noun")
+			(dependency "_advmod" "$verb" "$prep")
         )
         (ExecutionOutputLink
        	   (GroundedSchemaNode "scm: pre-adverbialpp-rule")

--- a/opencog/nlp/relex2logic/rules/adverbialpp.scm
+++ b/opencog/nlp/relex2logic/rules/adverbialpp.scm
@@ -3,22 +3,10 @@
 (define adverbialpp
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$prep")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$noun")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$verb")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$prep" "WordInstanceNode")
+			(var-decl "$noun" "WordInstanceNode")
+			(var-decl "$verb" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/adverbialpp.scm
+++ b/opencog/nlp/relex2logic/rules/adverbialpp.scm
@@ -9,18 +9,9 @@
 			(var-decl "$verb" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$prep")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$noun")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$verb")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$prep" "$a-parse")
+			(word-in-parse "$noun" "$a-parse")
+			(word-in-parse "$verb" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_pobj")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/advmod.scm
+++ b/opencog/nlp/relex2logic/rules/advmod.scm
@@ -14,13 +14,7 @@
         (AndLink
 			(word-in-parse "$verb" "$a-parse")
 			(word-in-parse "$adv" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_advmod")
-                (ListLink
-                    (VariableNode "$verb")
-                    (VariableNode "$adv")
-                )
-            )
+			(dependency "_advmod" "$verb" "$adv")
         )
         (ExecutionOutputLink
        	   (GroundedSchemaNode "scm: pre-advmod-rule")

--- a/opencog/nlp/relex2logic/rules/advmod.scm
+++ b/opencog/nlp/relex2logic/rules/advmod.scm
@@ -12,14 +12,8 @@
 			(var-decl "$adv" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$verb")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$adv")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$verb" "$a-parse")
+			(word-in-parse "$adv" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_advmod")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/advmod.scm
+++ b/opencog/nlp/relex2logic/rules/advmod.scm
@@ -7,18 +7,9 @@
 (define advmod
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$verb")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$adv")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$verb" "WordInstanceNode")
+			(var-decl "$adv" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/amod.scm
+++ b/opencog/nlp/relex2logic/rules/amod.scm
@@ -11,18 +11,9 @@
 (define amod
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$noun")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$adj")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$noun" "WordInstanceNode")
+			(var-decl "$adj" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/amod.scm
+++ b/opencog/nlp/relex2logic/rules/amod.scm
@@ -18,13 +18,7 @@
         (AndLink
 			(word-in-parse "$noun" "$a-parse")
 			(word-in-parse "$adj" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_amod")
-                (ListLink
-                    (VariableNode "$noun")
-                    (VariableNode "$adj")
-                )
-            )
+			(dependency "_amod" "$noun" "$adj")
         )
         (ExecutionOutputLink
        	   (GroundedSchemaNode "scm: pre-amod-rule")

--- a/opencog/nlp/relex2logic/rules/amod.scm
+++ b/opencog/nlp/relex2logic/rules/amod.scm
@@ -1,11 +1,13 @@
-; NB: there seems to be a bit of a bug in Relex for assigning multiple adjectives to the same noun,
-; which works partially -- it seems to get some of the multiple adjectives but not necessarily all
-; of them.
+; NB: there seems to be a bit of a bug in Relex for assigning multiple
+; adjectives to the same noun, which works partially -- it seems to get
+; some of the multiple adjectives but not necessarily all of them.
 ;
-; This rule treats adjectival phrases as well as adjectives, because I rigged relex that way.  So,
-; amod handles "The tall man" and "the man in the hat."  'in the hat' is an adjectival phrase here.
-; this is why I changed the individual triadic prepositional relations into two rules, one to assign
-; the role of the prepositional phrase and the other to assign the object of the preposition.
+; This rule treats adjectival phrases as well as adjectives, because
+; I rigged relex that way.  So, amod handles "The tall man" and
+; "the man in the hat."  'in the hat' is an adjectival phrase here.
+; this is why I changed the individual triadic prepositional
+; relations into two rules, one to assign the role of the prepositional
+; phrase and the other to assign the object of the preposition.
 ; (AN June 2015)
 
 (define amod

--- a/opencog/nlp/relex2logic/rules/amod.scm
+++ b/opencog/nlp/relex2logic/rules/amod.scm
@@ -16,14 +16,8 @@
 			(var-decl "$adj" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$noun")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$adj")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$noun" "$a-parse")
+			(word-in-parse "$adj" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_amod")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/atTime.scm
+++ b/opencog/nlp/relex2logic/rules/atTime.scm
@@ -6,18 +6,9 @@
 (define atTime
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$pred")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$comp")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$pred" "WordInstanceNode")
+			(var-decl "$comp" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/atTime.scm
+++ b/opencog/nlp/relex2logic/rules/atTime.scm
@@ -11,14 +11,8 @@
 			(var-decl "$comp" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$pred")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$comp")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$pred" "$a-parse")
+			(word-in-parse "$comp" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_%atTime")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/atTime.scm
+++ b/opencog/nlp/relex2logic/rules/atTime.scm
@@ -13,13 +13,7 @@
         (AndLink
 			(word-in-parse "$pred" "$a-parse")
 			(word-in-parse "$comp" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_%atTime")
-                (ListLink
-                    (VariableNode "$pred")
-		    (VariableNode "$comp")
-                )
-            )
+			(dependency "_%atTime" "$pred" "$comp")
         )
         (ExecutionOutputLink
        	   (GroundedSchemaNode "scm: pre-atTime-rule")

--- a/opencog/nlp/relex2logic/rules/be-inheritance.scm
+++ b/opencog/nlp/relex2logic/rules/be-inheritance.scm
@@ -17,20 +17,8 @@
 			(word-in-parse "$X" "$a-parse")
 			(word-in-parse "$Y" "$a-parse")
 			(word-in-parse "$Z" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_subj")
-                (ListLink
-                    (VariableNode "$Y")
-                    (VariableNode "$X")
-                )
-            )
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_obj")
-                (ListLink
-                    (VariableNode "$Y")
-                    (VariableNode "$Z")
-                )
-            )
+			(dependency "_subj" "$Y" "$X")
+			(dependency "_obj" "$Y" "$Z")
             (LemmaLink
                 (VariableNode "$Y")
                 (WordNode "be")

--- a/opencog/nlp/relex2logic/rules/be-inheritance.scm
+++ b/opencog/nlp/relex2logic/rules/be-inheritance.scm
@@ -14,18 +14,9 @@
 			(var-decl "$obj-lemma" "WordNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$X")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$Y")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$Z")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$X" "$a-parse")
+			(word-in-parse "$Y" "$a-parse")
+			(word-in-parse "$Z" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_subj")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/be-inheritance.scm
+++ b/opencog/nlp/relex2logic/rules/be-inheritance.scm
@@ -6,30 +6,12 @@
 (define be-inheritance
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$X")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$Y")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$Z")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-               (VariableNode "$subj-lemma")
-               (TypeNode "WordNode")
-            )
-            (TypedVariableLink
-               (VariableNode "$obj-lemma")
-               (TypeNode "WordNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$X" "WordInstanceNode")
+			(var-decl "$Y" "WordInstanceNode")
+			(var-decl "$Z" "WordInstanceNode")
+			(var-decl "$subj-lemma" "WordNode")
+			(var-decl "$obj-lemma" "WordNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/because.scm
+++ b/opencog/nlp/relex2logic/rules/because.scm
@@ -12,13 +12,7 @@
         (AndLink
 			(word-in-parse "$pred" "$a-parse")
 			(word-in-parse "$comp" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_%because")
-                (ListLink
-                    (VariableNode "$pred")
-					(VariableNode "$comp")
-                )
-            )
+			(dependency "_%because" "$pred" "$comp")
         )
         (ExecutionOutputLink
        	   (GroundedSchemaNode "scm: pre-because-rule")

--- a/opencog/nlp/relex2logic/rules/because.scm
+++ b/opencog/nlp/relex2logic/rules/because.scm
@@ -5,18 +5,9 @@
 (define because
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$pred")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$comp")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$pred" "WordInstanceNode")
+			(var-decl "$comp" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/because.scm
+++ b/opencog/nlp/relex2logic/rules/because.scm
@@ -10,14 +10,8 @@
 			(var-decl "$comp" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$pred")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$comp")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$pred" "$a-parse")
+			(word-in-parse "$comp" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_%because")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/comp.scm
+++ b/opencog/nlp/relex2logic/rules/comp.scm
@@ -5,18 +5,9 @@
 (define comp
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$pred")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$comp")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$pred" "WordInstanceNode")
+			(var-decl "$comp" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/comp.scm
+++ b/opencog/nlp/relex2logic/rules/comp.scm
@@ -10,14 +10,8 @@
 			(var-decl "$comp" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$pred")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$comp")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$pred" "$a-parse")
+			(word-in-parse "$comp" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_comp")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/comp.scm
+++ b/opencog/nlp/relex2logic/rules/comp.scm
@@ -12,13 +12,7 @@
         (AndLink
 			(word-in-parse "$pred" "$a-parse")
 			(word-in-parse "$comp" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_comp")
-                (ListLink
-                    (VariableNode "$comp")
-                    (VariableNode "$pred")
-                )
-            )
+			(dependency "_comp" "$comp" "$pred")
         )
         (ExecutionOutputLink
        	   (GroundedSchemaNode "scm: pre-comp-rule")

--- a/opencog/nlp/relex2logic/rules/compmod.scm
+++ b/opencog/nlp/relex2logic/rules/compmod.scm
@@ -9,18 +9,9 @@
 (define compmod
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$pred")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$comp")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$pred" "WordInstanceNode")
+			(var-decl "$comp" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/compmod.scm
+++ b/opencog/nlp/relex2logic/rules/compmod.scm
@@ -16,13 +16,7 @@
         (AndLink
 			(word-in-parse "$pred" "$a-parse")
 			(word-in-parse "$comp" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_compmod")
-                (ListLink
-                    (VariableNode "$pred")
-                    (VariableNode "$comp")
-                )
-            )
+			(dependency "_compmod" "$pred" "$comp")
         )
         (ExecutionOutputLink
        	   (GroundedSchemaNode "scm: pre-compmod-rule")

--- a/opencog/nlp/relex2logic/rules/compmod.scm
+++ b/opencog/nlp/relex2logic/rules/compmod.scm
@@ -14,14 +14,8 @@
 			(var-decl "$comp" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$pred")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$comp")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$pred" "$a-parse")
+			(word-in-parse "$comp" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_compmod")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/conj.scm
+++ b/opencog/nlp/relex2logic/rules/conj.scm
@@ -19,13 +19,7 @@
                 (VariableNode "$var2")
                 (VariableNode "$pos")
             )
-            (EvaluationLink
-                (VariableNode "$var3")		
-                    (ListLink
-                        (VariableNode "$var1")
-                        (VariableNode "$var2")
-                    )
-            )
+			(dependency  "$var2" "$var1")
             (OrLink
                 (EqualLink
                     (VariableNode "$var3")

--- a/opencog/nlp/relex2logic/rules/conj.scm
+++ b/opencog/nlp/relex2logic/rules/conj.scm
@@ -2,26 +2,11 @@
 (define conj
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$var1")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$var2")
-                (TypeNode "WordInstanceNode")
-            )
-		    (TypedVariableLink
-                (VariableNode "$pos")
-                (TypeNode "DefinedLinguisticConceptNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$var3")
-                (TypeNode "PrepositionalRelationshipNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$var1" "WordInstanceNode")
+			(var-decl "$var2" "WordInstanceNode")
+			(var-decl "$pos" "DefinedLinguisticConceptNode")
+			(var-decl "$var3" "PrepositionalRelationshipNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/conj.scm
+++ b/opencog/nlp/relex2logic/rules/conj.scm
@@ -1,70 +1,76 @@
 
 (define conj
-    (BindLink
-        (VariableList
+	(BindLink
+		(VariableList
 			(var-decl "$a-parse" "ParseNode")
 			(var-decl "$var1" "WordInstanceNode")
 			(var-decl "$var2" "WordInstanceNode")
 			(var-decl "$pos" "DefinedLinguisticConceptNode")
 			(var-decl "$var3" "PrepositionalRelationshipNode")
-        )
-        (AndLink
+		)
+		(AndLink
 			(word-in-parse "$var1" "$a-parse")
 			(word-in-parse "$var2" "$a-parse")
-            (PartOfSpeechLink
-                (VariableNode "$var1")
-                (VariableNode "$pos")
-            )
-            (PartOfSpeechLink
-                (VariableNode "$var2")
-                (VariableNode "$pos")
-            )
-			(dependency  "$var2" "$var1")
-            (OrLink
-                (EqualLink
-                    (VariableNode "$var3")
-                    (PrepositionalRelationshipNode "conj_and")
-                )
-                (EqualLink
-                    (VariableNode "$var3")
-                    (PrepositionalRelationshipNode "conj_but")
-                )
-                (EqualLink
-                    (VariableNode "$var3")
-                    (PrepositionalRelationshipNode "conj_or")
-                )
-            ))
-        (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pre-conj-rule")
-            (ListLink
-                (VariableNode "$var1")
-                (VariableNode "$var2")
-                (VariableNode "$var3")
-                (VariableNode "$pos")
-            )
-        )
-    )
+			(PartOfSpeechLink
+				(VariableNode "$var1")
+				(VariableNode "$pos")
+			)
+			(PartOfSpeechLink
+				(VariableNode "$var2")
+				(VariableNode "$pos")
+			)
+			(EvaluationLink
+				(VariableNode "$var3")
+					(ListLink
+						(VariableNode "$var1")
+						(VariableNode "$var2")
+					)
+			)
+			(OrLink
+				(EqualLink
+					(VariableNode "$var3")
+					(PrepositionalRelationshipNode "conj_and")
+				)
+				(EqualLink
+					(VariableNode "$var3")
+					(PrepositionalRelationshipNode "conj_but")
+				)
+				(EqualLink
+					(VariableNode "$var3")
+					(PrepositionalRelationshipNode "conj_or")
+				)
+			))
+		(ExecutionOutputLink
+			(GroundedSchemaNode "scm: pre-conj-rule")
+			(ListLink
+				(VariableNode "$var1")
+				(VariableNode "$var2")
+				(VariableNode "$var3")
+				(VariableNode "$pos")
+			)
+		)
+	)
 )
 
 (define (pre-conj-rule var1 var2 var3 pos)
   (cond
-    ((string=? (cog-name var3) "conj_and")
-        (and-rule (cog-name (word-inst-get-lemma  var1)) (cog-name var1)
-            (cog-name (word-inst-get-lemma  var2)) (cog-name var2)
-            (cog-name pos)
-        )
-    )
-    ((string=? (cog-name var3) "conj_or")
-        (or-rule (cog-name (word-inst-get-lemma  var1)) (cog-name var1)
-            (cog-name (word-inst-get-lemma  var2)) (cog-name var2)
-            (cog-name pos)
-        )
-    )
-    ((string=? (cog-name var3) "conj_but")
-        (but-rule (cog-name (word-inst-get-lemma  var1)) (cog-name var1)
-            (cog-name (word-inst-get-lemma  var2)) (cog-name var2)
-            (cog-name pos)
-        )
-    )
+	((string=? (cog-name var3) "conj_and")
+		(and-rule (cog-name (word-inst-get-lemma  var1)) (cog-name var1)
+			(cog-name (word-inst-get-lemma  var2)) (cog-name var2)
+			(cog-name pos)
+		)
+	)
+	((string=? (cog-name var3) "conj_or")
+		(or-rule (cog-name (word-inst-get-lemma  var1)) (cog-name var1)
+			(cog-name (word-inst-get-lemma  var2)) (cog-name var2)
+			(cog-name pos)
+		)
+	)
+	((string=? (cog-name var3) "conj_but")
+		(but-rule (cog-name (word-inst-get-lemma  var1)) (cog-name var1)
+			(cog-name (word-inst-get-lemma  var2)) (cog-name var2)
+			(cog-name pos)
+		)
+	)
   )
 )

--- a/opencog/nlp/relex2logic/rules/conj.scm
+++ b/opencog/nlp/relex2logic/rules/conj.scm
@@ -9,14 +9,8 @@
 			(var-decl "$var3" "PrepositionalRelationshipNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$var1")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$var2")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$var1" "$a-parse")
+			(word-in-parse "$var2" "$a-parse")
             (PartOfSpeechLink
                 (VariableNode "$var1")
                 (VariableNode "$pos")

--- a/opencog/nlp/relex2logic/rules/copula-ynq.scm
+++ b/opencog/nlp/relex2logic/rules/copula-ynq.scm
@@ -10,14 +10,8 @@
 			(var-decl "$obj" "WordInstanceNode")
 		)
 		(AndLink
-			(WordInstanceLink
-				(VariableNode "$subj")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$obj")
-				(VariableNode "$a-parse")
-			)
+			(word-in-parse "$subj" "$a-parse")
+			(word-in-parse "$obj" "$a-parse")
 			(EvaluationLink
 				(DefinedLinguisticRelationshipNode "_subj")
 				(ListLink

--- a/opencog/nlp/relex2logic/rules/copula-ynq.scm
+++ b/opencog/nlp/relex2logic/rules/copula-ynq.scm
@@ -12,20 +12,8 @@
 		(AndLink
 			(word-in-parse "$subj" "$a-parse")
 			(word-in-parse "$obj" "$a-parse")
-			(EvaluationLink
-				(DefinedLinguisticRelationshipNode "_subj")
-				(ListLink
-					(VariableNode "$verb")
-					(VariableNode "$subj")
-				)
-			)
-			(EvaluationLink
-				(DefinedLinguisticRelationshipNode "_obj")
-				(ListLink
-					(VariableNode "$verb")
-					(VariableNode "$obj")
-				)
-			)
+			(dependency "_subj" "$verb" "$subj")
+			(dependency "_obj" "$verb" "$obj")
 			(LemmaLink
 				(VariableNode "$verb")
 				(WordNode "be")

--- a/opencog/nlp/relex2logic/rules/copula-ynq.scm
+++ b/opencog/nlp/relex2logic/rules/copula-ynq.scm
@@ -4,22 +4,10 @@
 (define copula-ynq
 	(BindLink
 		(VariableList
-			(TypedVariableLink
-				(VariableNode "$a-parse")
-				(TypeNode "ParseNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$subj")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$verb")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$obj")
-				(TypeNode "WordInstanceNode")
-			)
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$subj" "WordInstanceNode")
+			(var-decl "$verb" "WordInstanceNode")
+			(var-decl "$obj" "WordInstanceNode")
 		)
 		(AndLink
 			(WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/cvt-eval.pl
+++ b/opencog/nlp/relex2logic/rules/cvt-eval.pl
@@ -1,0 +1,35 @@
+#!/usr/bin/perl
+
+$prt = 1;
+$ab = 0;
+$skip = 1;
+while(<>)
+{
+	if (/EvaluationLink/) {
+		$prt = 0;
+		$skip = 1;
+		next;
+	}
+	if (/DefinedLinguisticRelationshipNode/) {
+		($junk, $rel) = split("Node ");
+		$rel =~ s/\)//;
+		chop $rel;
+	}
+
+	if (/VariableNode/) {
+		($junk, $vn) = split("Node ");
+		$vn =~ s/\)//;
+		chop $vn;
+		if (0 == $ab) { $hed = $vn;  $ab = 1; }
+		else { $dep = $vn; $ab = 0; }
+	}
+
+	if (0 == $prt and /\s+\)$/)
+	{
+		if (1 == $skip) { $skip = 0; next; }
+		print "\t\t\t(dependency $rel $hed $dep)\n";
+		$prt = 1;
+		next;
+	}
+	if ($prt) {print "$_"; }
+}

--- a/opencog/nlp/relex2logic/rules/cvt-type.pl
+++ b/opencog/nlp/relex2logic/rules/cvt-type.pl
@@ -1,0 +1,29 @@
+#!/usr/bin/perl
+
+$prt = 1;
+while(<>)
+{
+	if (/TypedVariableLink/) {
+		$prt = 0;
+		next;
+	}
+	if (/VariableNode/) {
+		($junk, $vn) = split("Node ");
+		$vn =~ s/\)//;
+		chop $vn;
+	}
+
+	if (/TypeNode/) {
+		($junk, $tn) = split("Node ");
+		$tn =~ s/\)//;
+		chop $tn;
+	}
+
+	if (0 == $prt and /\s+\)$/)
+	{
+		print "\t\t\t(var-decl $vn $tn)\n";
+		$prt = 1;
+		next;
+	}
+	if ($prt) {print "$_"; }
+}

--- a/opencog/nlp/relex2logic/rules/cvt-word.pl
+++ b/opencog/nlp/relex2logic/rules/cvt-word.pl
@@ -18,7 +18,7 @@ while(<>)
 
 	if (0 == $prt and /\s+\)$/)
 	{
-		print "\t\t\t(word-inst $word $parse)\n";
+		print "\t\t\t(word-in-parse $word $parse)\n";
 		$prt = 1;
 		next;
 	}

--- a/opencog/nlp/relex2logic/rules/cvt-word.pl
+++ b/opencog/nlp/relex2logic/rules/cvt-word.pl
@@ -1,0 +1,26 @@
+#!/usr/bin/perl
+
+$prt = 1;
+$ab = 0;
+while(<>)
+{
+	if (/WordInstanceLink/) {
+		$prt = 0;
+		next;
+	}
+	if (/VariableNode/) {
+		($junk, $vn) = split("Node ");
+		$vn =~ s/\)//;
+		chop $vn;
+		if (0 == $ab) { $word = $vn;  $ab = 1; }
+		else { $parse = $vn; $ab = 0; }
+	}
+
+	if (0 == $prt and /\s+\)$/)
+	{
+		print "\t\t\t(word-inst $word $parse)\n";
+		$prt = 1;
+		next;
+	}
+	if ($prt) {print "$_"; }
+}

--- a/opencog/nlp/relex2logic/rules/cvt.sh
+++ b/opencog/nlp/relex2logic/rules/cvt.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+FILES=*.scm
+
+for f in $FILES; do
+	echo "Processing $f..."
+	cat $f | ./cvt-type.pl > xxx
+	mv xxx $f
+done

--- a/opencog/nlp/relex2logic/rules/cvt.sh
+++ b/opencog/nlp/relex2logic/rules/cvt.sh
@@ -4,6 +4,6 @@ FILES=*.scm
 
 for f in $FILES; do
 	echo "Processing $f..."
-	cat $f | ./cvt-type.pl > xxx
+	cat $f | ./cvt-word.pl > xxx
 	mv xxx $f
 done

--- a/opencog/nlp/relex2logic/rules/cvt.sh
+++ b/opencog/nlp/relex2logic/rules/cvt.sh
@@ -4,6 +4,8 @@ FILES=*.scm
 
 for f in $FILES; do
 	echo "Processing $f..."
-	cat $f | ./cvt-word.pl > xxx
+	# cat $f | ./cvt-type.pl > xxx
+	# cat $f | ./cvt-word.pl > xxx
+	cat $f | ./cvt-eval.pl > xxx
 	mv xxx $f
 done

--- a/opencog/nlp/relex2logic/rules/declarative.scm
+++ b/opencog/nlp/relex2logic/rules/declarative.scm
@@ -4,22 +4,10 @@
 (define declarative
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$interp")
-                (TypeNode "InterpretationNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$wall-inst")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$word-inst")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$interp" "InterpretationNode")
+			(var-decl "$parse" "ParseNode")
+			(var-decl "$wall-inst" "WordInstanceNode")
+			(var-decl "$word-inst" "WordInstanceNode")
         )
         (AndLink
             (InterpretationLink

--- a/opencog/nlp/relex2logic/rules/declarative.scm
+++ b/opencog/nlp/relex2logic/rules/declarative.scm
@@ -14,10 +14,7 @@
                 (VariableNode "$interp")
                 (VariableNode "$parse")
             )
-            (WordInstanceLink
-                (VariableNode "$wall-inst")
-                (VariableNode "$parse")
-            )
+			(word-in-parse "$wall-inst" "$parse")
 
             (ReferenceLink
                 (VariableNode "$wall-inst")

--- a/opencog/nlp/relex2logic/rules/declarative.scm
+++ b/opencog/nlp/relex2logic/rules/declarative.scm
@@ -24,32 +24,7 @@
             ;; If left wall is linked with any of Wd, Wp, Wr, Wt or Wa,
             ;; then its declarative.
             (ChoiceLink
-                (EvaluationLink (LinkGrammarRelationshipNode "Wd")
-                    (ListLink
-                        (VariableNode "$wall-inst")
-                        (VariableNode "$word-inst")))
-
-                (EvaluationLink (LinkGrammarRelationshipNode "Wp")
-                    (ListLink
-                        (VariableNode "$wall-inst")
-                        (VariableNode "$word-inst")))
-
-                (EvaluationLink (LinkGrammarRelationshipNode "Wr")
-                    (ListLink
-                        (VariableNode "$wall-inst")
-                        (VariableNode "$word-inst")))
-
-                (EvaluationLink (LinkGrammarRelationshipNode "Wt")
-                    (ListLink
-                        (VariableNode "$wall-inst")
-                        (VariableNode "$word-inst")))
-
-                (EvaluationLink (LinkGrammarRelationshipNode "Wa")
-                    (ListLink
-                        (VariableNode "$wall-inst")
-                        (VariableNode "$word-inst")))
-            )
-        )
+			(dependency  "$word-inst")) "$wall-inst")
 
         ; Mark this as declarative.
         (InheritanceLink

--- a/opencog/nlp/relex2logic/rules/declarative.scm
+++ b/opencog/nlp/relex2logic/rules/declarative.scm
@@ -2,33 +2,58 @@
 ; Determine declaratives, based on LG link types.
 ;
 (define declarative
-    (BindLink
-        (VariableList
+	(BindLink
+		(VariableList
 			(var-decl "$interp" "InterpretationNode")
 			(var-decl "$parse" "ParseNode")
 			(var-decl "$wall-inst" "WordInstanceNode")
 			(var-decl "$word-inst" "WordInstanceNode")
-        )
-        (AndLink
-            (InterpretationLink
-                (VariableNode "$interp")
-                (VariableNode "$parse")
-            )
+		)
+		(AndLink
+			(InterpretationLink
+				(VariableNode "$interp")
+				(VariableNode "$parse")
+			)
 			(word-in-parse "$wall-inst" "$parse")
 
-            (ReferenceLink
-                (VariableNode "$wall-inst")
-                (WordNode "###LEFT-WALL###")
-            )
+			(ReferenceLink
+				(VariableNode "$wall-inst")
+				(WordNode "###LEFT-WALL###")
+			)
 
-            ;; If left wall is linked with any of Wd, Wp, Wr, Wt or Wa,
-            ;; then its declarative.
-            (ChoiceLink
-			(dependency  "$word-inst")) "$wall-inst")
+			;; If left wall is linked with any of Wd, Wp, Wr, Wt or Wa,
+			;; then its declarative.
+			(ChoiceLink
+				(EvaluationLink (LinkGrammarRelationshipNode "Wd")
+					(ListLink
+						(VariableNode "$wall-inst")
+						(VariableNode "$word-inst")))
 
-        ; Mark this as declarative.
-        (InheritanceLink
-            (VariableNode "$interp")
-            (DefinedLinguisticConceptNode "DeclarativeSpeechAct"))
-    )
+				(EvaluationLink (LinkGrammarRelationshipNode "Wp")
+					(ListLink
+						(VariableNode "$wall-inst")
+						(VariableNode "$word-inst")))
+
+				(EvaluationLink (LinkGrammarRelationshipNode "Wr")
+					(ListLink
+						(VariableNode "$wall-inst")
+						(VariableNode "$word-inst")))
+
+				(EvaluationLink (LinkGrammarRelationshipNode "Wt")
+					(ListLink
+						(VariableNode "$wall-inst")
+						(VariableNode "$word-inst")))
+
+				(EvaluationLink (LinkGrammarRelationshipNode "Wa")
+					(ListLink
+						(VariableNode "$wall-inst")
+						(VariableNode "$word-inst")))
+			)
+		)
+
+		; Mark this as declarative.
+		(InheritanceLink
+			(VariableNode "$interp")
+			(DefinedLinguisticConceptNode "DeclarativeSpeechAct"))
+	)
 )

--- a/opencog/nlp/relex2logic/rules/declarative.scm
+++ b/opencog/nlp/relex2logic/rules/declarative.scm
@@ -24,30 +24,11 @@
 			;; If left wall is linked with any of Wd, Wp, Wr, Wt or Wa,
 			;; then its declarative.
 			(ChoiceLink
-				(EvaluationLink (LinkGrammarRelationshipNode "Wd")
-					(ListLink
-						(VariableNode "$wall-inst")
-						(VariableNode "$word-inst")))
-
-				(EvaluationLink (LinkGrammarRelationshipNode "Wp")
-					(ListLink
-						(VariableNode "$wall-inst")
-						(VariableNode "$word-inst")))
-
-				(EvaluationLink (LinkGrammarRelationshipNode "Wr")
-					(ListLink
-						(VariableNode "$wall-inst")
-						(VariableNode "$word-inst")))
-
-				(EvaluationLink (LinkGrammarRelationshipNode "Wt")
-					(ListLink
-						(VariableNode "$wall-inst")
-						(VariableNode "$word-inst")))
-
-				(EvaluationLink (LinkGrammarRelationshipNode "Wa")
-					(ListLink
-						(VariableNode "$wall-inst")
-						(VariableNode "$word-inst")))
+				(lg-link "Wd" "$wall-inst" "$word-inst")
+				(lg-link "Wp" "$wall-inst" "$word-inst")
+				(lg-link "Wr" "$wall-inst" "$word-inst")
+				(lg-link "Wt" "$wall-inst" "$word-inst")
+				(lg-link "Wa" "$wall-inst" "$word-inst")
 			)
 		)
 

--- a/opencog/nlp/relex2logic/rules/definite.scm
+++ b/opencog/nlp/relex2logic/rules/definite.scm
@@ -5,18 +5,9 @@
 (define definite
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$noun")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$lemma")
-                (TypeNode "WordNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$noun" "WordInstanceNode")
+			(var-decl "$lemma" "WordNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/definite.scm
+++ b/opencog/nlp/relex2logic/rules/definite.scm
@@ -3,28 +3,28 @@
 ; (AN June 2015)
 
 (define definite
-    (BindLink
-        (VariableList
+	(BindLink
+		(VariableList
 			(var-decl "$a-parse" "ParseNode")
 			(var-decl "$noun" "WordInstanceNode")
 			(var-decl "$lemma" "WordNode")
-        )
-        (AndLink
+		)
+		(AndLink
 			(word-in-parse "$noun" "$a-parse")
-            (LemmaLink
-                (VariableNode "$noun")
-                (VariableNode "$lemma")
-            )
-            (InheritanceLink
-                (VariableNode "$noun")
-                (DefinedLinguisticConceptNode "definite")
-            )
-        )
-        (ExecutionOutputLink
-            (GroundedSchemaNode "scm: definite-rule")
-            (ListLink
-                (VariableNode "$lemma")
-                (VariableNode "$noun"))
-        )
-    )
+			(LemmaLink
+				(VariableNode "$noun")
+				(VariableNode "$lemma")
+			)
+			(InheritanceLink
+				(VariableNode "$noun")
+				(DefinedLinguisticConceptNode "definite")
+			)
+		)
+		(ExecutionOutputLink
+			(GroundedSchemaNode "scm: definite-rule")
+			(ListLink
+				(VariableNode "$lemma")
+				(VariableNode "$noun"))
+		)
+	)
 )

--- a/opencog/nlp/relex2logic/rules/definite.scm
+++ b/opencog/nlp/relex2logic/rules/definite.scm
@@ -10,10 +10,7 @@
 			(var-decl "$lemma" "WordNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$noun")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$noun" "$a-parse")
             (LemmaLink
                 (VariableNode "$noun")
                 (VariableNode "$lemma")

--- a/opencog/nlp/relex2logic/rules/demdet.scm
+++ b/opencog/nlp/relex2logic/rules/demdet.scm
@@ -13,13 +13,7 @@
         (AndLink
 			(word-in-parse "$noun" "$a-parse")
 			(word-in-parse "$demdet" "$a-parse")
-            (EvaluationLink
-               (DefinedLinguisticRelationshipNode "_det")
-               (ListLink
-                   (VariableNode "$noun")
-                   (VariableNode "$demdet")
-               )
-            )
+			(dependency "_det" "$noun" "$demdet")
         )
         (ExecutionOutputLink
        	   (GroundedSchemaNode "scm: pre-demdet-rule")

--- a/opencog/nlp/relex2logic/rules/demdet.scm
+++ b/opencog/nlp/relex2logic/rules/demdet.scm
@@ -6,18 +6,9 @@
 (define demdet
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$noun")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$demdet")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$noun" "WordInstanceNode")
+			(var-decl "$demdet" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/demdet.scm
+++ b/opencog/nlp/relex2logic/rules/demdet.scm
@@ -11,14 +11,8 @@
 			(var-decl "$demdet" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$noun")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$demdet")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$noun" "$a-parse")
+			(word-in-parse "$demdet" "$a-parse")
             (EvaluationLink
                (DefinedLinguisticRelationshipNode "_det")
                (ListLink

--- a/opencog/nlp/relex2logic/rules/det.scm
+++ b/opencog/nlp/relex2logic/rules/det.scm
@@ -2,18 +2,9 @@
 (define det
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$noun")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$det")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$noun" "WordInstanceNode")
+			(var-decl "$det" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/det.scm
+++ b/opencog/nlp/relex2logic/rules/det.scm
@@ -9,13 +9,7 @@
         (AndLink
 			(word-in-parse "$noun" "$a-parse")
 			(word-in-parse "$det" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_det")
-                (ListLink
-                    (VariableNode "$noun")
-                    (VariableNode "$det")
-                )
-            )
+			(dependency "_det" "$noun" "$det")
             (InheritanceLink
                 (VariableNode "$noun")
                 (DefinedLinguisticConceptNode "definite")

--- a/opencog/nlp/relex2logic/rules/det.scm
+++ b/opencog/nlp/relex2logic/rules/det.scm
@@ -7,14 +7,8 @@
 			(var-decl "$det" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$noun")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$det")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$noun" "$a-parse")
+			(word-in-parse "$det" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_det")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/gender.scm
+++ b/opencog/nlp/relex2logic/rules/gender.scm
@@ -8,10 +8,7 @@
 			(var-decl "$lemma" "WordNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$word")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$word" "$a-parse")
             (InheritanceLink
                 (VariableNode "$word")
                 (VariableNode "$gtype")

--- a/opencog/nlp/relex2logic/rules/gender.scm
+++ b/opencog/nlp/relex2logic/rules/gender.scm
@@ -2,22 +2,10 @@
 (define gender
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$word")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$gtype")
-                (TypeNode "DefinedLinguisticConceptNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$lemma")
-                (TypeNode "WordNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$word" "WordInstanceNode")
+			(var-decl "$gtype" "DefinedLinguisticConceptNode")
+			(var-decl "$lemma" "WordNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/gender.scm
+++ b/opencog/nlp/relex2logic/rules/gender.scm
@@ -1,42 +1,42 @@
 
 (define gender
-    (BindLink
-        (VariableList
+	(BindLink
+		(VariableList
 			(var-decl "$a-parse" "ParseNode")
 			(var-decl "$word" "WordInstanceNode")
 			(var-decl "$gtype" "DefinedLinguisticConceptNode")
 			(var-decl "$lemma" "WordNode")
-        )
-        (AndLink
+		)
+		(AndLink
 			(word-in-parse "$word" "$a-parse")
-            (InheritanceLink
-                (VariableNode "$word")
-                (VariableNode "$gtype")
-            )
-            (InheritanceLink
-                (VariableNode "$word")
-                (DefinedLinguisticConceptNode "person")
-            )
-            (LemmaLink
-                (VariableNode "$word")
-                (VariableNode "$lemma")
-            )
-            (OrLink
-                (EqualLink
-                    (VariableNode "$gtype")
-                    (DefinedLinguisticRelationshipNode "masculine"))
-                (EqualLink
-                    (VariableNode "$gtype")
-                    (DefinedLinguisticRelationshipNode "feminine"))
-            )
-        )
-        (ExecutionOutputLink
-            (GroundedSchemaNode "scm: gender-rule")
-            (ListLink
-                (VariableNode "$lemma")
-                (VariableNode "$word")
-                (VariableNode "$gtype")
-            )
-        )
-    )
+			(InheritanceLink
+				(VariableNode "$word")
+				(VariableNode "$gtype")
+			)
+			(InheritanceLink
+				(VariableNode "$word")
+				(DefinedLinguisticConceptNode "person")
+			)
+			(LemmaLink
+				(VariableNode "$word")
+				(VariableNode "$lemma")
+			)
+			(OrLink
+				(EqualLink
+					(VariableNode "$gtype")
+					(DefinedLinguisticRelationshipNode "masculine"))
+				(EqualLink
+					(VariableNode "$gtype")
+					(DefinedLinguisticRelationshipNode "feminine"))
+			)
+		)
+		(ExecutionOutputLink
+			(GroundedSchemaNode "scm: gender-rule")
+			(ListLink
+				(VariableNode "$lemma")
+				(VariableNode "$word")
+				(VariableNode "$gtype")
+			)
+		)
+	)
 )

--- a/opencog/nlp/relex2logic/rules/how-q.scm
+++ b/opencog/nlp/relex2logic/rules/how-q.scm
@@ -16,11 +16,11 @@
 			(word-in-parse "$verb" "$a-parse")
 			(word-in-parse "$qVar" "$a-parse")
 			(EvaluationLink
-     			(PrepositionalRelationshipNode "how")
-     			(ListLink
-        			(VariableNode "$verb")
-        			(VariableNode "$qVar")
-     			)
+				(PrepositionalRelationshipNode "how")
+				(ListLink
+					(VariableNode "$verb")
+					(VariableNode "$qVar")
+				)
  			)
 		)
 		(ExecutionOutputLink

--- a/opencog/nlp/relex2logic/rules/how-q.scm
+++ b/opencog/nlp/relex2logic/rules/how-q.scm
@@ -8,18 +8,9 @@
 (define how-q
 	(BindLink
 		(VariableList
-			(TypedVariableLink
-				(VariableNode "$a-parse")
-				(TypeNode "ParseNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$verb")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$qVar")
-				(TypeNode "WordInstanceNode")
-			)
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$verb" "WordInstanceNode")
+			(var-decl "$qVar" "WordInstanceNode")
 		)
 		(AndLink
 			(WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/how-q.scm
+++ b/opencog/nlp/relex2logic/rules/how-q.scm
@@ -13,14 +13,8 @@
 			(var-decl "$qVar" "WordInstanceNode")
 		)
 		(AndLink
-			(WordInstanceLink
-				(VariableNode "$verb")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$qVar")
-				(VariableNode "$a-parse")
-			)
+			(word-in-parse "$verb" "$a-parse")
+			(word-in-parse "$qVar" "$a-parse")
 			(EvaluationLink
      			(PrepositionalRelationshipNode "how")
      			(ListLink

--- a/opencog/nlp/relex2logic/rules/howdeg-q.scm
+++ b/opencog/nlp/relex2logic/rules/howdeg-q.scm
@@ -4,18 +4,9 @@
 (define howdeg-q
 	(BindLink
 		(VariableList
-			(TypedVariableLink
-				(VariableNode "$a-parse")
-				(TypeNode "ParseNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$qVar")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$pred")
-				(TypeNode "WordInstanceNode")
-			)
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$qVar" "WordInstanceNode")
+			(var-decl "$pred" "WordInstanceNode")
 		)
 		(AndLink
 			(WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/howdeg-q.scm
+++ b/opencog/nlp/relex2logic/rules/howdeg-q.scm
@@ -11,13 +11,7 @@
 		(AndLink
 			(word-in-parse "$qVar" "$a-parse")
 			(word-in-parse "$pred" "$a-parse")
-			(EvaluationLink
-           	(DefinedLinguisticRelationshipNode "_%howdeg")
-           	(ListLink
-           		(VariableNode "$pred")
-           		(VariableNode "$qVar")
-           	)
-     		)
+			(dependency "_%howdeg" "$pred" "$qVar")
 			(InheritanceLink
 				(VariableNode "$qVar")
 				(DefinedLinguisticConceptNode "how_much")

--- a/opencog/nlp/relex2logic/rules/howdeg-q.scm
+++ b/opencog/nlp/relex2logic/rules/howdeg-q.scm
@@ -9,14 +9,8 @@
 			(var-decl "$pred" "WordInstanceNode")
 		)
 		(AndLink
-			(WordInstanceLink
-				(VariableNode "$qVar")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$pred")
-				(VariableNode "$a-parse")
-			)
+			(word-in-parse "$qVar" "$a-parse")
+			(word-in-parse "$pred" "$a-parse")
 			(EvaluationLink
            	(DefinedLinguisticRelationshipNode "_%howdeg")
            	(ListLink

--- a/opencog/nlp/relex2logic/rules/howpredadj1-q.scm
+++ b/opencog/nlp/relex2logic/rules/howpredadj1-q.scm
@@ -5,22 +5,10 @@
 (define howpredadj1-q
 	(BindLink
 		(VariableList
-			(TypedVariableLink
-				(VariableNode "$a-parse")
-				(TypeNode "ParseNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$subj")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$qVar")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$verb")
-				(TypeNode "WordInstanceNode")
-			)
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$subj" "WordInstanceNode")
+			(var-decl "$qVar" "WordInstanceNode")
+			(var-decl "$verb" "WordInstanceNode")
 		)
 		(AndLink
 			(WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/howpredadj1-q.scm
+++ b/opencog/nlp/relex2logic/rules/howpredadj1-q.scm
@@ -11,18 +11,9 @@
 			(var-decl "$verb" "WordInstanceNode")
 		)
 		(AndLink
-			(WordInstanceLink
-				(VariableNode "$verb")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$subj")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$qVar")
-				(VariableNode "$a-parse")
-			)
+			(word-in-parse "$verb" "$a-parse")
+			(word-in-parse "$subj" "$a-parse")
+			(word-in-parse "$qVar" "$a-parse")
 			(EvaluationLink
      			(DefinedLinguisticRelationshipNode "_%how")
      			(ListLink

--- a/opencog/nlp/relex2logic/rules/howpredadj1-q.scm
+++ b/opencog/nlp/relex2logic/rules/howpredadj1-q.scm
@@ -14,20 +14,8 @@
 			(word-in-parse "$verb" "$a-parse")
 			(word-in-parse "$subj" "$a-parse")
 			(word-in-parse "$qVar" "$a-parse")
-			(EvaluationLink
-     			(DefinedLinguisticRelationshipNode "_%how")
-     			(ListLink
-        			(VariableNode "$verb")
-        			(VariableNode "$qVar")
-     			)
-     		)
-			(EvaluationLink
-     			(DefinedLinguisticRelationshipNode "_subj")
-     			(ListLink
-        			(VariableNode "$verb")
-        			(VariableNode "$subj")
-     			)
-     		)
+			(dependency "_%how" "$verb" "$qVar")
+			(dependency "_subj" "$verb" "$subj")
 			(LemmaLink
 				(WordInstanceNode "$verb")
 				(WordNode "be")

--- a/opencog/nlp/relex2logic/rules/howquant-q.scm
+++ b/opencog/nlp/relex2logic/rules/howquant-q.scm
@@ -4,18 +4,9 @@
 (define howquant-q
 	(BindLink
 		(VariableList
-			(TypedVariableLink
-				(VariableNode "$a-parse")
-				(TypeNode "ParseNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$qVar")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$noun")
-				(TypeNode "WordInstanceNode")
-			)
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$qVar" "WordInstanceNode")
+			(var-decl "$noun" "WordInstanceNode")
 		)
 		(AndLink
 			(WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/howquant-q.scm
+++ b/opencog/nlp/relex2logic/rules/howquant-q.scm
@@ -11,13 +11,7 @@
 		(AndLink
 			(word-in-parse "$qVar" "$a-parse")
 			(word-in-parse "$noun" "$a-parse")
-			(EvaluationLink
-     			(DefinedLinguisticRelationshipNode "_quantity")
-     			(ListLink
-        			(VariableNode "$noun")
-        			(VariableNode "$qVar")
-     			)
-	 		)
+			(dependency "_quantity" "$noun" "$qVar")
 			(InheritanceLink
 				(VariableNode "$qVar")
 				(DefinedLinguisticConceptNode "how_much")

--- a/opencog/nlp/relex2logic/rules/howquant-q.scm
+++ b/opencog/nlp/relex2logic/rules/howquant-q.scm
@@ -9,14 +9,8 @@
 			(var-decl "$noun" "WordInstanceNode")
 		)
 		(AndLink
-			(WordInstanceLink
-				(VariableNode "$qVar")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$noun")
-				(VariableNode "$a-parse")
-			)
+			(word-in-parse "$qVar" "$a-parse")
+			(word-in-parse "$noun" "$a-parse")
 			(EvaluationLink
      			(DefinedLinguisticRelationshipNode "_quantity")
      			(ListLink

--- a/opencog/nlp/relex2logic/rules/imperative.scm
+++ b/opencog/nlp/relex2logic/rules/imperative.scm
@@ -14,10 +14,7 @@
                 (VariableNode "$interp")
                 (VariableNode "$parse")
             )
-            (WordInstanceLink
-                (VariableNode "$wall-inst")
-                (VariableNode "$parse")
-            )
+			(word-in-parse "$wall-inst" "$parse")
 
             (ReferenceLink
                 (VariableNode "$wall-inst")

--- a/opencog/nlp/relex2logic/rules/imperative.scm
+++ b/opencog/nlp/relex2logic/rules/imperative.scm
@@ -2,35 +2,35 @@
 ; Determine imperatives, based on LG link types.
 ;
 (define imperative
-    (BindLink
-        (VariableList
+	(BindLink
+		(VariableList
 			(var-decl "$interp" "InterpretationNode")
 			(var-decl "$parse" "ParseNode")
 			(var-decl "$wall-inst" "WordInstanceNode")
 			(var-decl "$word-inst" "WordInstanceNode")
-        )
-        (AndLink
-            (InterpretationLink
-                (VariableNode "$interp")
-                (VariableNode "$parse")
-            )
+		)
+		(AndLink
+			(InterpretationLink
+				(VariableNode "$interp")
+				(VariableNode "$parse")
+			)
 			(word-in-parse "$wall-inst" "$parse")
 
-            (ReferenceLink
-                (VariableNode "$wall-inst")
-                (WordNode "###LEFT-WALL###")
-            )
+			(ReferenceLink
+				(VariableNode "$wall-inst")
+				(WordNode "###LEFT-WALL###")
+			)
 
-            ;; If left wall is linked with Wi,
-            ;; then its imperative.
-            (EvaluationLink (LinkGrammarRelationshipNode "Wi")
-                (ListLink
-                    (VariableNode "$wall-inst")
-                    (VariableNode "$word-inst")))
-        )
-        ; Mark this as an imperative.
-        (InheritanceLink
-            (VariableNode "$interp")
-            (DefinedLinguisticConceptNode "ImperativeSpeechAct"))
-    )
+			;; If left wall is linked with Wi,
+			;; then its imperative.
+			(EvaluationLink (LinkGrammarRelationshipNode "Wi")
+				(ListLink
+					(VariableNode "$wall-inst")
+					(VariableNode "$word-inst")))
+		)
+		; Mark this as an imperative.
+		(InheritanceLink
+			(VariableNode "$interp")
+			(DefinedLinguisticConceptNode "ImperativeSpeechAct"))
+	)
 )

--- a/opencog/nlp/relex2logic/rules/imperative.scm
+++ b/opencog/nlp/relex2logic/rules/imperative.scm
@@ -4,22 +4,10 @@
 (define imperative
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$interp")
-                (TypeNode "InterpretationNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$wall-inst")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$word-inst")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$interp" "InterpretationNode")
+			(var-decl "$parse" "ParseNode")
+			(var-decl "$wall-inst" "WordInstanceNode")
+			(var-decl "$word-inst" "WordInstanceNode")
         )
         (AndLink
             (InterpretationLink

--- a/opencog/nlp/relex2logic/rules/imperative.scm
+++ b/opencog/nlp/relex2logic/rules/imperative.scm
@@ -23,10 +23,7 @@
 
 			;; If left wall is linked with Wi,
 			;; then its imperative.
-			(EvaluationLink (LinkGrammarRelationshipNode "Wi")
-				(ListLink
-					(VariableNode "$wall-inst")
-					(VariableNode "$word-inst")))
+			(lg-link "Wi" "$wall-inst" "$word-inst")
 		)
 		; Mark this as an imperative.
 		(InheritanceLink

--- a/opencog/nlp/relex2logic/rules/interrogative.scm
+++ b/opencog/nlp/relex2logic/rules/interrogative.scm
@@ -2,32 +2,62 @@
 ; A more accurate interrogative detector, based on LG link types.
 ;
 (define interrogative
-    (BindLink
-        (VariableList
+	(BindLink
+		(VariableList
 			(var-decl "$interp" "InterpretationNode")
 			(var-decl "$parse" "ParseNode")
 			(var-decl "$wall-inst" "WordInstanceNode")
 			(var-decl "$wh-word-inst" "WordInstanceNode")
-        )
-        (AndLink
-            (InterpretationLink
-                (VariableNode "$interp")
-                (VariableNode "$parse")
-            )
+		)
+		(AndLink
+			(InterpretationLink
+				(VariableNode "$interp")
+				(VariableNode "$parse")
+			)
 			(word-in-parse "$wall-inst" "$parse")
 
-            (ReferenceLink
-                (VariableNode "$wall-inst")
-                (WordNode "###LEFT-WALL###")
-            )
+			(ReferenceLink
+				(VariableNode "$wall-inst")
+				(WordNode "###LEFT-WALL###")
+			)
 
-            ;; If left wall is linked with any of Wq, Ws, Wj or Ww
-            ;; or Qe, Qw then its interrogative.
-            (ChoiceLink
-			(dependency  "$wh-word-inst")) "$wall-inst")
-        ; Mark this as a question.
-        (InheritanceLink
-            (VariableNode "$interp")
-            (DefinedLinguisticConceptNode "InterrogativeSpeechAct"))
-    )
+			;; If left wall is linked with any of Wq, Ws, Wj or Ww
+			;; or Qe, Qw then its interrogative.
+			(ChoiceLink
+				(EvaluationLink (LinkGrammarRelationshipNode "Wq")
+					(ListLink
+						(VariableNode "$wall-inst")
+						(VariableNode "$wh-word-inst")))
+
+				(EvaluationLink (LinkGrammarRelationshipNode "Ws")
+					(ListLink
+						(VariableNode "$wall-inst")
+						(VariableNode "$wh-word-inst")))
+
+				(EvaluationLink (LinkGrammarRelationshipNode "Wj")
+					(ListLink
+						(VariableNode "$wall-inst")
+						(VariableNode "$wh-word-inst")))
+
+				(EvaluationLink (LinkGrammarRelationshipNode "Ww")
+					(ListLink
+						(VariableNode "$wall-inst")
+						(VariableNode "$wh-word-inst")))
+
+				(EvaluationLink (LinkGrammarRelationshipNode "Qe")
+					(ListLink
+						(VariableNode "$wall-inst")
+						(VariableNode "$wh-word-inst")))
+
+				(EvaluationLink (LinkGrammarRelationshipNode "Qw")
+					(ListLink
+						(VariableNode "$wall-inst")
+						(VariableNode "$wh-word-inst")))
+			)
+		)
+		; Mark this as a question.
+		(InheritanceLink
+			(VariableNode "$interp")
+			(DefinedLinguisticConceptNode "InterrogativeSpeechAct"))
+	)
 )

--- a/opencog/nlp/relex2logic/rules/interrogative.scm
+++ b/opencog/nlp/relex2logic/rules/interrogative.scm
@@ -24,37 +24,7 @@
             ;; If left wall is linked with any of Wq, Ws, Wj or Ww
             ;; or Qe, Qw then its interrogative.
             (ChoiceLink
-                (EvaluationLink (LinkGrammarRelationshipNode "Wq")
-                    (ListLink
-                        (VariableNode "$wall-inst")
-                        (VariableNode "$wh-word-inst")))
-
-                (EvaluationLink (LinkGrammarRelationshipNode "Ws")
-                    (ListLink
-                        (VariableNode "$wall-inst")
-                        (VariableNode "$wh-word-inst")))
-
-                (EvaluationLink (LinkGrammarRelationshipNode "Wj")
-                    (ListLink
-                        (VariableNode "$wall-inst")
-                        (VariableNode "$wh-word-inst")))
-
-                (EvaluationLink (LinkGrammarRelationshipNode "Ww")
-                    (ListLink
-                        (VariableNode "$wall-inst")
-                        (VariableNode "$wh-word-inst")))
-
-                (EvaluationLink (LinkGrammarRelationshipNode "Qe")
-                    (ListLink
-                        (VariableNode "$wall-inst")
-                        (VariableNode "$wh-word-inst")))
-
-                (EvaluationLink (LinkGrammarRelationshipNode "Qw")
-                    (ListLink
-                        (VariableNode "$wall-inst")
-                        (VariableNode "$wh-word-inst")))
-            )
-        )
+			(dependency  "$wh-word-inst")) "$wall-inst")
         ; Mark this as a question.
         (InheritanceLink
             (VariableNode "$interp")

--- a/opencog/nlp/relex2logic/rules/interrogative.scm
+++ b/opencog/nlp/relex2logic/rules/interrogative.scm
@@ -14,10 +14,7 @@
                 (VariableNode "$interp")
                 (VariableNode "$parse")
             )
-            (WordInstanceLink
-                (VariableNode "$wall-inst")
-                (VariableNode "$parse")
-            )
+			(word-in-parse "$wall-inst" "$parse")
 
             (ReferenceLink
                 (VariableNode "$wall-inst")

--- a/opencog/nlp/relex2logic/rules/interrogative.scm
+++ b/opencog/nlp/relex2logic/rules/interrogative.scm
@@ -24,35 +24,12 @@
 			;; If left wall is linked with any of Wq, Ws, Wj or Ww
 			;; or Qe, Qw then its interrogative.
 			(ChoiceLink
-				(EvaluationLink (LinkGrammarRelationshipNode "Wq")
-					(ListLink
-						(VariableNode "$wall-inst")
-						(VariableNode "$wh-word-inst")))
-
-				(EvaluationLink (LinkGrammarRelationshipNode "Ws")
-					(ListLink
-						(VariableNode "$wall-inst")
-						(VariableNode "$wh-word-inst")))
-
-				(EvaluationLink (LinkGrammarRelationshipNode "Wj")
-					(ListLink
-						(VariableNode "$wall-inst")
-						(VariableNode "$wh-word-inst")))
-
-				(EvaluationLink (LinkGrammarRelationshipNode "Ww")
-					(ListLink
-						(VariableNode "$wall-inst")
-						(VariableNode "$wh-word-inst")))
-
-				(EvaluationLink (LinkGrammarRelationshipNode "Qe")
-					(ListLink
-						(VariableNode "$wall-inst")
-						(VariableNode "$wh-word-inst")))
-
-				(EvaluationLink (LinkGrammarRelationshipNode "Qw")
-					(ListLink
-						(VariableNode "$wall-inst")
-						(VariableNode "$wh-word-inst")))
+				(lg-link "Wq" "$wall-inst" "$wh-word-inst")
+				(lg-link "Ws" "$wall-inst" "$wh-word-inst")
+				(lg-link "Wj" "$wall-inst" "$wh-word-inst")
+				(lg-link "Ww" "$wall-inst" "$wh-word-inst")
+				(lg-link "Qe" "$wall-inst" "$wh-word-inst")
+				(lg-link "Qw" "$wall-inst" "$wh-word-inst")
 			)
 		)
 		; Mark this as a question.

--- a/opencog/nlp/relex2logic/rules/interrogative.scm
+++ b/opencog/nlp/relex2logic/rules/interrogative.scm
@@ -4,22 +4,10 @@
 (define interrogative
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$interp")
-                (TypeNode "InterpretationNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$wall-inst")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$wh-word-inst")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$interp" "InterpretationNode")
+			(var-decl "$parse" "ParseNode")
+			(var-decl "$wall-inst" "WordInstanceNode")
+			(var-decl "$wh-word-inst" "WordInstanceNode")
         )
         (AndLink
             (InterpretationLink

--- a/opencog/nlp/relex2logic/rules/neg.scm
+++ b/opencog/nlp/relex2logic/rules/neg.scm
@@ -9,10 +9,7 @@
 			(var-decl "$pred" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$pred")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$pred" "$a-parse")
             (InheritanceLink
                 (VariableNode "$pred")
                 (DefinedLinguisticConceptNode "negative")

--- a/opencog/nlp/relex2logic/rules/neg.scm
+++ b/opencog/nlp/relex2logic/rules/neg.scm
@@ -5,14 +5,8 @@
 (define neg
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$pred")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$pred" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/nn.scm
+++ b/opencog/nlp/relex2logic/rules/nn.scm
@@ -9,13 +9,7 @@
         (AndLink
 			(word-in-parse "$N1" "$a-parse")
 			(word-in-parse "$N2" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_nn")
-                (ListLink
-                    (VariableNode "$N1")
-                    (VariableNode "$N2")
-                )
-            )
+			(dependency "_nn" "$N1" "$N2")
         )
         (ExecutionOutputLink
        	   (GroundedSchemaNode "scm: pre-nn-rule")

--- a/opencog/nlp/relex2logic/rules/nn.scm
+++ b/opencog/nlp/relex2logic/rules/nn.scm
@@ -7,14 +7,8 @@
 			(var-decl "$N2" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$N1")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$N2")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$N1" "$a-parse")
+			(word-in-parse "$N2" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_nn")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/nn.scm
+++ b/opencog/nlp/relex2logic/rules/nn.scm
@@ -2,18 +2,9 @@
 (define nn
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$N1")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$N2")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$N1" "WordInstanceNode")
+			(var-decl "$N2" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/passive.scm
+++ b/opencog/nlp/relex2logic/rules/passive.scm
@@ -1,46 +1,46 @@
-;check the tense if it is passive 
+;check the tense if it is passive
 (define (check-tense tense)
 	(if (string-contains (cog-name tense) "passive")
 		(begin (stv 1 1))
-		(begin (stv 0 1)) 	
-    ) 	
+		(begin (stv 0 1))
+	)
 )
- 
+
 (define passive
-    (BindLink
-        (VariableList
+	(BindLink
+		(VariableList
 			(var-decl "$a-parse" "ParseNode")
 			(var-decl "$tense" "DefinedLinguisticConceptNode")
-        )
-        (AndLink
+		)
+		(AndLink
 			(word-in-parse "$verb" "$a-parse")
 			(word-in-parse "$obj" "$a-parse")
-            (InheritanceLink 
-                (VariableNode "$verb")
-                (VariableNode "$tense")
-            )
+			(InheritanceLink
+				(VariableNode "$verb")
+				(VariableNode "$tense")
+			)
 			(dependency "_obj" "$verb" "$obj")
-            (EvaluationLink
-                (GroundedPredicateNode "scm: check-tense")
-                (ListLink
-                    (VariableNode "$tense")
-                )
-            )
-        )
-        (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pre-passive-rule")
-            (ListLink
-                (VariableNode "$verb")
-                (VariableNode "$obj")
-            )
-        )
-    )
+			(EvaluationLink
+				(GroundedPredicateNode "scm: check-tense")
+				(ListLink
+					(VariableNode "$tense")
+				)
+			)
+		)
+		(ExecutionOutputLink
+			(GroundedSchemaNode "scm: pre-passive-rule")
+			(ListLink
+				(VariableNode "$verb")
+				(VariableNode "$obj")
+			)
+		)
+	)
 )
 
 
 (define (pre-passive-rule verb obj)
-    (passive-rule2
-        (cog-name (word-inst-get-lemma verb)) (cog-name verb)
-        (cog-name (word-inst-get-lemma obj)) (cog-name obj)
-    )
+	(passive-rule2
+		(cog-name (word-inst-get-lemma verb)) (cog-name verb)
+		(cog-name (word-inst-get-lemma obj)) (cog-name obj)
+	)
 )

--- a/opencog/nlp/relex2logic/rules/passive.scm
+++ b/opencog/nlp/relex2logic/rules/passive.scm
@@ -13,14 +13,8 @@
 			(var-decl "$tense" "DefinedLinguisticConceptNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$verb")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$obj")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$verb" "$a-parse")
+			(word-in-parse "$obj" "$a-parse")
             (InheritanceLink 
                 (VariableNode "$verb")
                 (VariableNode "$tense")

--- a/opencog/nlp/relex2logic/rules/passive.scm
+++ b/opencog/nlp/relex2logic/rules/passive.scm
@@ -9,22 +9,8 @@
 (define passive
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$verb")
-                (TypeNode "WordInstanceNode")
-            ) 
-            (TypedVariableLink
-                (VariableNode "$obj")
-                (TypeNode "WordInstanceNode")
-            ) 
-            (TypedVariableLink
-                (VariableNode "$tense")
-                (TypeNode "DefinedLinguisticConceptNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$tense" "DefinedLinguisticConceptNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/passive.scm
+++ b/opencog/nlp/relex2logic/rules/passive.scm
@@ -19,13 +19,7 @@
                 (VariableNode "$verb")
                 (VariableNode "$tense")
             )
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_obj")
-                (ListLink
-                    (VariableNode "$verb")
-                    (VariableNode "$obj")
-                )
-            )
+			(dependency "_obj" "$verb" "$obj")
             (EvaluationLink
                 (GroundedPredicateNode "scm: check-tense")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/poss.scm
+++ b/opencog/nlp/relex2logic/rules/poss.scm
@@ -5,18 +5,9 @@
 (define poss
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$noun")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$poss")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$noun" "WordInstanceNode")
+			(var-decl "$poss" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/poss.scm
+++ b/opencog/nlp/relex2logic/rules/poss.scm
@@ -10,14 +10,8 @@
 			(var-decl "$poss" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$noun")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$poss")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$noun" "$a-parse")
+			(word-in-parse "$poss" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_poss")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/poss.scm
+++ b/opencog/nlp/relex2logic/rules/poss.scm
@@ -12,13 +12,7 @@
         (AndLink
 			(word-in-parse "$noun" "$a-parse")
 			(word-in-parse "$poss" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_poss")
-                (ListLink
-                    (VariableNode "$noun")
-                    (VariableNode "$poss")
-                )
-            )
+			(dependency "_poss" "$noun" "$poss")
         )
         (ExecutionOutputLink
        	   (GroundedSchemaNode "scm: pre-poss-rule")

--- a/opencog/nlp/relex2logic/rules/pp.scm
+++ b/opencog/nlp/relex2logic/rules/pp.scm
@@ -6,18 +6,9 @@
 (define pp
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$noun")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$prep")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$noun" "WordInstanceNode")
+			(var-decl "$prep" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/pp.scm
+++ b/opencog/nlp/relex2logic/rules/pp.scm
@@ -11,14 +11,8 @@
 			(var-decl "$prep" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$noun")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$prep")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$noun" "$a-parse")
+			(word-in-parse "$prep" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_pobj")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/pp.scm
+++ b/opencog/nlp/relex2logic/rules/pp.scm
@@ -13,13 +13,7 @@
         (AndLink
 			(word-in-parse "$noun" "$a-parse")
 			(word-in-parse "$prep" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_pobj")
-                (ListLink
-                    (VariableNode "$prep")
-                    (VariableNode "$noun")
-                )
-            )
+			(dependency "_pobj" "$prep" "$noun")
         )
         (ExecutionOutputLink
        	   (GroundedSchemaNode "scm: pre-pp-rule")

--- a/opencog/nlp/relex2logic/rules/pred-ynq.scm
+++ b/opencog/nlp/relex2logic/rules/pred-ynq.scm
@@ -10,10 +10,7 @@
 			(var-decl "$verb" "WordInstanceNode")
 		)
 		(AndLink
-			(WordInstanceLink
-				(VariableNode "$verb")
-				(VariableNode "$a-parse")
-			)
+			(word-in-parse "$verb" "$a-parse")
 			(InheritanceLink
 				(VariableNode "$verb")
 				(DefinedLinguisticConceptNode "truth-query")

--- a/opencog/nlp/relex2logic/rules/pred-ynq.scm
+++ b/opencog/nlp/relex2logic/rules/pred-ynq.scm
@@ -6,14 +6,8 @@
 (define pred-ynq
 	(BindLink
 		(VariableList
-			(TypedVariableLink
-				(VariableNode "$a-parse")
-				(TypeNode "ParseNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$verb")
-				(TypeNode "WordInstanceNode")
-			)
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$verb" "WordInstanceNode")
 		)
 		(AndLink
 			(WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/prepadj.scm
+++ b/opencog/nlp/relex2logic/rules/prepadj.scm
@@ -13,13 +13,7 @@
         (AndLink
 			(word-in-parse "$noun" "$a-parse")
 			(word-in-parse "$adj" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_prepadj")
-                (ListLink
-                    (VariableNode "$noun")
-                    (VariableNode "$adj")
-                )
-            )
+			(dependency "_prepadj" "$noun" "$adj")
         )
         (ExecutionOutputLink
        	   (GroundedSchemaNode "scm: pre-prepadj-rule")

--- a/opencog/nlp/relex2logic/rules/prepadj.scm
+++ b/opencog/nlp/relex2logic/rules/prepadj.scm
@@ -6,18 +6,9 @@
 (define prepadj
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$noun")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$adj")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$noun" "WordInstanceNode")
+			(var-decl "$adj" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/prepadj.scm
+++ b/opencog/nlp/relex2logic/rules/prepadj.scm
@@ -11,14 +11,8 @@
 			(var-decl "$adj" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$noun")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$adj")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$noun" "$a-parse")
+			(word-in-parse "$adj" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_prepadj")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/quantity.scm
+++ b/opencog/nlp/relex2logic/rules/quantity.scm
@@ -14,13 +14,7 @@
         (AndLink
 			(word-in-parse "$noun" "$a-parse")
 			(word-in-parse "$quant" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_quantity")
-                (ListLink
-                    (VariableNode "$noun")
-                    (VariableNode "$quant")
-                )
-            )
+			(dependency "_quantity" "$noun" "$quant")
         )
         (ExecutionOutputLink
        	   (GroundedSchemaNode "scm: pre-quantity-rule")

--- a/opencog/nlp/relex2logic/rules/quantity.scm
+++ b/opencog/nlp/relex2logic/rules/quantity.scm
@@ -7,18 +7,9 @@
 (define quantity
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$noun")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$quant")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$noun" "WordInstanceNode")
+			(var-decl "$quant" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/quantity.scm
+++ b/opencog/nlp/relex2logic/rules/quantity.scm
@@ -12,14 +12,8 @@
 			(var-decl "$quant" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$noun")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$quant")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$noun" "$a-parse")
+			(word-in-parse "$quant" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_quantity")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/rel.scm
+++ b/opencog/nlp/relex2logic/rules/rel.scm
@@ -13,13 +13,7 @@
         (AndLink
 			(word-in-parse "$pred" "$a-parse")
 			(word-in-parse "$rel" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_rel")
-                (ListLink
-                    (VariableNode "$rel")
-                    (VariableNode "$pred")
-                )
-            )
+			(dependency "_rel" "$rel" "$pred")
         )
         (ExecutionOutputLink
        	   (GroundedSchemaNode "scm: pre-rel-rule")

--- a/opencog/nlp/relex2logic/rules/rel.scm
+++ b/opencog/nlp/relex2logic/rules/rel.scm
@@ -11,14 +11,8 @@
 			(var-decl "$rel" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$pred")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$rel")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$pred" "$a-parse")
+			(word-in-parse "$rel" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_rel")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/rel.scm
+++ b/opencog/nlp/relex2logic/rules/rel.scm
@@ -6,18 +6,9 @@
 (define rel
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$pred")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$rel")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$pred" "WordInstanceNode")
+			(var-decl "$rel" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/rep.scm
+++ b/opencog/nlp/relex2logic/rules/rep.scm
@@ -11,18 +11,9 @@
 (define rep
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$pred")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$comp")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$pred" "WordInstanceNode")
+			(var-decl "$comp" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/rep.scm
+++ b/opencog/nlp/relex2logic/rules/rep.scm
@@ -18,13 +18,7 @@
         (AndLink
 			(word-in-parse "$pred" "$a-parse")
 			(word-in-parse "$comp" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_rep")
-                (ListLink
-                    (VariableNode "$pred")
-                    (VariableNode "$comp")
-                )
-            )
+			(dependency "_rep" "$pred" "$comp")
         )
         (ExecutionOutputLink
        	   (GroundedSchemaNode "scm: pre-rep-rule")

--- a/opencog/nlp/relex2logic/rules/rep.scm
+++ b/opencog/nlp/relex2logic/rules/rep.scm
@@ -16,14 +16,8 @@
 			(var-decl "$comp" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$pred")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$comp")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$pred" "$a-parse")
+			(word-in-parse "$comp" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_rep")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/svo.scm
+++ b/opencog/nlp/relex2logic/rules/svo.scm
@@ -5,38 +5,14 @@
 (define svo
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$W")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$X")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$Y")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$Z")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-               (VariableNode "$subj-lemma")
-               (TypeNode "WordNode")
-            )
-            (TypedVariableLink
-               (VariableNode "$verb-lemma")
-               (TypeNode "WordNode")
-            )
-            (TypedVariableLink
-               (VariableNode "$obj-lemma")
-               (TypeNode "WordNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$W" "WordInstanceNode")
+			(var-decl "$X" "WordInstanceNode")
+			(var-decl "$Y" "WordInstanceNode")
+			(var-decl "$Z" "WordInstanceNode")
+			(var-decl "$subj-lemma" "WordNode")
+			(var-decl "$verb-lemma" "WordNode")
+			(var-decl "$obj-lemma" "WordNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/svo.scm
+++ b/opencog/nlp/relex2logic/rules/svo.scm
@@ -15,18 +15,9 @@
 			(var-decl "$obj-lemma" "WordNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$X")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$Y")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$Z")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$X" "$a-parse")
+			(word-in-parse "$Y" "$a-parse")
+			(word-in-parse "$Z" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_subj")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/svo.scm
+++ b/opencog/nlp/relex2logic/rules/svo.scm
@@ -18,20 +18,8 @@
 			(word-in-parse "$X" "$a-parse")
 			(word-in-parse "$Y" "$a-parse")
 			(word-in-parse "$Z" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_subj")
-                (ListLink
-                    (VariableNode "$Y")
-                    (VariableNode "$X")
-                )
-            )
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_obj")
-                (ListLink
-                    (VariableNode "$Y")
-                    (VariableNode "$Z")
-                )
-            )
+			(dependency "_subj" "$Y" "$X")
+			(dependency "_obj" "$Y" "$Z")
             (LemmaLink
                (VariableNode "$X")
                (VariableNode "$subj-lemma")
@@ -45,13 +33,7 @@
                (VariableNode "$obj-lemma")
             )
             (AbsentLink
-                (EvaluationLink
-                    (DefinedLinguisticRelationshipNode "_iobj")
-                    (ListLink
-                        (VariableNode "$Y")
-                        (VariableNode "$W")
-                    )
-                )
+			(dependency "_iobj" "$Y" "$W")
             )
         )
         (ExecutionOutputLink

--- a/opencog/nlp/relex2logic/rules/tense.scm
+++ b/opencog/nlp/relex2logic/rules/tense.scm
@@ -2,22 +2,10 @@
 (define tense
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$verb")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$tense")
-                (TypeNode "DefinedLinguisticConceptNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$lemma")
-                (TypeNode "WordNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$verb" "WordInstanceNode")
+			(var-decl "$tense" "DefinedLinguisticConceptNode")
+			(var-decl "$lemma" "WordNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/tense.scm
+++ b/opencog/nlp/relex2logic/rules/tense.scm
@@ -8,10 +8,7 @@
 			(var-decl "$lemma" "WordNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$verb")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$verb" "$a-parse")
             (PartOfSpeechLink
                 (VariableNode "$verb")
                 (DefinedLinguisticConceptNode "verb")

--- a/opencog/nlp/relex2logic/rules/to-do-rule-3.scm
+++ b/opencog/nlp/relex2logic/rules/to-do-rule-3.scm
@@ -3,22 +3,10 @@
 (define to-do-rule-3
 	(BindLink
 		(VariableList
-			(TypedVariableLink
-				(VariableNode "$a-parse")
-				(TypeNode "ParseNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$adj")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$verb")
-				(TypeNode "WordInstanceNode")
-			)
-		    (TypedVariableLink
-				(VariableNode "$subj")
-				(TypeNode "WordInstanceNode")
-		    )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$adj" "WordInstanceNode")
+			(var-decl "$verb" "WordInstanceNode")
+			(var-decl "$subj" "WordInstanceNode")
 		)
 		(AndLink
 			(WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/to-do-rule-3.scm
+++ b/opencog/nlp/relex2logic/rules/to-do-rule-3.scm
@@ -9,18 +9,9 @@
 			(var-decl "$subj" "WordInstanceNode")
 		)
 		(AndLink
-			(WordInstanceLink
-				(VariableNode "$adj")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$verb")
-				(VariableNode "$a-parse")
-			)
-		 	(WordInstanceLink
-				(VariableNode "$subj")
-				(VariableNode "$a-parse")
-			)
+			(word-in-parse "$adj" "$a-parse")
+			(word-in-parse "$verb" "$a-parse")
+			(word-in-parse "$subj" "$a-parse")
 			(EvaluationLink
 				(DefinedLinguisticRelationshipNode "_to-do")
 				(ListLink

--- a/opencog/nlp/relex2logic/rules/to-do-rule-3.scm
+++ b/opencog/nlp/relex2logic/rules/to-do-rule-3.scm
@@ -12,20 +12,8 @@
 			(word-in-parse "$adj" "$a-parse")
 			(word-in-parse "$verb" "$a-parse")
 			(word-in-parse "$subj" "$a-parse")
-			(EvaluationLink
-				(DefinedLinguisticRelationshipNode "_to-do")
-				(ListLink
-					(VariableNode "$adj")
-					(VariableNode "$verb")
-				)
-			)
-			(EvaluationLink
-				(DefinedLinguisticRelationshipNode "_predadj")
-				(ListLink
-					(VariableNode "$subj")
-					(VariableNode "$adj")
-				)
-			)
+			(dependency "_to-do" "$adj" "$verb")
+			(dependency "_predadj" "$subj" "$adj")
 		)
 		(ExecutionOutputLink
 			(GroundedSchemaNode "scm: pre-todo3-rule")

--- a/opencog/nlp/relex2logic/rules/todo1.scm
+++ b/opencog/nlp/relex2logic/rules/todo1.scm
@@ -7,30 +7,12 @@
 (define todo1
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$subj")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$subj2")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$verb1")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$verb2")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$obj")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$subj" "WordInstanceNode")
+			(var-decl "$subj2" "WordInstanceNode")
+			(var-decl "$verb1" "WordInstanceNode")
+			(var-decl "$verb2" "WordInstanceNode")
+			(var-decl "$obj" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/todo1.scm
+++ b/opencog/nlp/relex2logic/rules/todo1.scm
@@ -19,36 +19,12 @@
 			(word-in-parse "$verb1" "$a-parse")
 			(word-in-parse "$verb2" "$a-parse")
 			(word-in-parse "$obj" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_subj")
-                (ListLink
-                    (VariableNode "$verb1")
-                    (VariableNode "$subj")
-                )
-            )
+			(dependency "_subj" "$verb1" "$subj")
             (AbsentLink
-                (EvaluationLink
-                    (DefinedLinguisticRelationshipNode "_subj")
-                    (ListLink
-                        (VariableNode "$verb2")
-                        (VariableNode "$subj2")
-                    )
-                )
+			(dependency "_subj" "$verb2" "$subj2")
             )
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_obj")
-                (ListLink
-                    (VariableNode "$verb2")
-                    (VariableNode "$obj")
-                )
-            )
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_to-do")
-                (ListLink
-                    (VariableNode "$verb1")
-                    (VariableNode "$verb2")
-                )
-            )
+			(dependency "_obj" "$verb2" "$obj")
+			(dependency "_to-do" "$verb1" "$verb2")
         )
         (ExecutionOutputLink
             (GroundedSchemaNode "scm: pre-todo1-rule")

--- a/opencog/nlp/relex2logic/rules/todo1.scm
+++ b/opencog/nlp/relex2logic/rules/todo1.scm
@@ -15,22 +15,10 @@
 			(var-decl "$obj" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$subj")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$verb1")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$verb2")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$obj")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$subj" "$a-parse")
+			(word-in-parse "$verb1" "$a-parse")
+			(word-in-parse "$verb2" "$a-parse")
+			(word-in-parse "$obj" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_subj")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/todo2.scm
+++ b/opencog/nlp/relex2logic/rules/todo2.scm
@@ -20,34 +20,10 @@
 			(word-in-parse "$verb1" "$a-parse")
 			(word-in-parse "$verb2" "$a-parse")
 			(word-in-parse "$obj" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_subj")
-                (ListLink
-                    (VariableNode "$verb1")
-                    (VariableNode "$subj1")
-                )
-            )
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_subj")
-                (ListLink
-                    (VariableNode "$verb2")
-                    (VariableNode "$subj2")
-                )
-            )
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_obj")
-                (ListLink
-                    (VariableNode "$verb2")
-                    (VariableNode "$obj")
-                )
-            )
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_to-do")
-                (ListLink
-                    (VariableNode "$verb1")
-                    (VariableNode "$verb2")
-                )
-            )
+			(dependency "_subj" "$verb1" "$subj1")
+			(dependency "_subj" "$verb2" "$subj2")
+			(dependency "_obj" "$verb2" "$obj")
+			(dependency "_to-do" "$verb1" "$verb2")
         )
         (ExecutionOutputLink
             (GroundedSchemaNode "scm: pre-todo2-rule")

--- a/opencog/nlp/relex2logic/rules/todo2.scm
+++ b/opencog/nlp/relex2logic/rules/todo2.scm
@@ -15,26 +15,11 @@
 			(var-decl "$obj" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$subj1")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$subj2")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$verb1")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$verb2")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$obj")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$subj1" "$a-parse")
+			(word-in-parse "$subj2" "$a-parse")
+			(word-in-parse "$verb1" "$a-parse")
+			(word-in-parse "$verb2" "$a-parse")
+			(word-in-parse "$obj" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_subj")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/todo2.scm
+++ b/opencog/nlp/relex2logic/rules/todo2.scm
@@ -7,30 +7,12 @@
 (define todo2
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$subj1")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$subj2")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$verb1")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$verb2")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$obj")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$subj1" "WordInstanceNode")
+			(var-decl "$subj2" "WordInstanceNode")
+			(var-decl "$verb1" "WordInstanceNode")
+			(var-decl "$verb2" "WordInstanceNode")
+			(var-decl "$obj" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/todo5.scm
+++ b/opencog/nlp/relex2logic/rules/todo5.scm
@@ -18,38 +18,14 @@
 			(word-in-parse "$subj" "$a-parse")
 			(word-in-parse "$verb1" "$a-parse")
 			(word-in-parse "$verb2" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_subj")
-                (ListLink
-                    (VariableNode "$verb1")
-                    (VariableNode "$subj")
-                )
+			(dependency "_subj" "$verb1" "$subj")
+            (AbsentLink
+			(dependency "_subj" "$verb2" "$subj2")
             )
             (AbsentLink
-                (EvaluationLink
-                    (DefinedLinguisticRelationshipNode "_subj")
-                    (ListLink
-                        (VariableNode "$verb2")
-                        (VariableNode "$subj2")
-                    )
-                )
+			(dependency "_obj" "$verb2" "$obj")
             )
-            (AbsentLink
-                (EvaluationLink
-                    (DefinedLinguisticRelationshipNode "_obj")
-                    (ListLink
-                        (VariableNode "$verb2")
-                        (VariableNode "$obj")
-                     )
-                 )
-            )
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_to-do")
-                (ListLink
-                    (VariableNode "$verb1")
-                    (VariableNode "$verb2")
-                )
-            )
+			(dependency "_to-do" "$verb1" "$verb2")
         )
         (ExecutionOutputLink
             (GroundedSchemaNode "scm: pre-todo5-rule")

--- a/opencog/nlp/relex2logic/rules/todo5.scm
+++ b/opencog/nlp/relex2logic/rules/todo5.scm
@@ -15,18 +15,9 @@
 			(var-decl "$obj" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$subj")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$verb1")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$verb2")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$subj" "$a-parse")
+			(word-in-parse "$verb1" "$a-parse")
+			(word-in-parse "$verb2" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_subj")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/todo5.scm
+++ b/opencog/nlp/relex2logic/rules/todo5.scm
@@ -7,30 +7,12 @@
 (define todo5
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$subj")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$subj2")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$verb1")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$verb2")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$obj")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$subj" "WordInstanceNode")
+			(var-decl "$subj2" "WordInstanceNode")
+			(var-decl "$verb1" "WordInstanceNode")
+			(var-decl "$verb2" "WordInstanceNode")
+			(var-decl "$obj" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/truthquery.scm
+++ b/opencog/nlp/relex2logic/rules/truthquery.scm
@@ -4,22 +4,10 @@
 (define truthquery
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$interp")
-                (TypeNode "InterpretationNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$wall-inst")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$word-inst")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$interp" "InterpretationNode")
+			(var-decl "$parse" "ParseNode")
+			(var-decl "$wall-inst" "WordInstanceNode")
+			(var-decl "$word-inst" "WordInstanceNode")
         )
         (AndLink
             (InterpretationLink

--- a/opencog/nlp/relex2logic/rules/truthquery.scm
+++ b/opencog/nlp/relex2logic/rules/truthquery.scm
@@ -14,10 +14,7 @@
                 (VariableNode "$interp")
                 (VariableNode "$parse")
             )
-            (WordInstanceLink
-                (VariableNode "$wall-inst")
-                (VariableNode "$parse")
-            )
+			(word-in-parse "$wall-inst" "$parse")
 
             (ReferenceLink
                 (VariableNode "$wall-inst")

--- a/opencog/nlp/relex2logic/rules/truthquery.scm
+++ b/opencog/nlp/relex2logic/rules/truthquery.scm
@@ -2,35 +2,33 @@
 ; A truth-query detector, based on LG link types.
 ;
 (define truthquery
-    (BindLink
-        (VariableList
+	(BindLink
+		(VariableList
 			(var-decl "$interp" "InterpretationNode")
 			(var-decl "$parse" "ParseNode")
 			(var-decl "$wall-inst" "WordInstanceNode")
 			(var-decl "$word-inst" "WordInstanceNode")
-        )
-        (AndLink
-            (InterpretationLink
-                (VariableNode "$interp")
-                (VariableNode "$parse")
-            )
+		)
+		(AndLink
+			(InterpretationLink
+				(VariableNode "$interp")
+				(VariableNode "$parse")
+			)
 			(word-in-parse "$wall-inst" "$parse")
 
-            (ReferenceLink
-                (VariableNode "$wall-inst")
-                (WordNode "###LEFT-WALL###")
-            )
+			(ReferenceLink
+				(VariableNode "$wall-inst")
+				(WordNode "###LEFT-WALL###")
+			)
 
-            ;; If left wall is linked with Qd,
-            ;; then it is a truth-query.
-            (EvaluationLink (LinkGrammarRelationshipNode "Qd")
-                (ListLink
-                    (VariableNode "$wall-inst")
-                    (VariableNode "$word-inst")))
-        )
-        ; Mark this as a truth-query.
-        (InheritanceLink
-            (VariableNode "$interp")
-            (DefinedLinguisticConceptNode "TruthQuerySpeechAct"))
-    )
+			;; If left wall is linked with Qd,
+			;; then it is a truth-query.
+			(lg-link "Qd" "$wall-inst" "$word-inst")
+		)
+		; Mark this as a truth-query.
+		(InheritanceLink
+			(VariableNode "$interp")
+			(DefinedLinguisticConceptNode "TruthQuerySpeechAct")
+		)
+	)
 )

--- a/opencog/nlp/relex2logic/rules/when-cop-q.scm
+++ b/opencog/nlp/relex2logic/rules/when-cop-q.scm
@@ -11,18 +11,9 @@
 			(var-decl "$subj" "WordInstanceNode")
 		)
 		(AndLink
-			(WordInstanceLink
-				(VariableNode "$verb")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$qVar")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$subj")
-				(VariableNode "$a-parse")
-			)
+			(word-in-parse "$verb" "$a-parse")
+			(word-in-parse "$qVar" "$a-parse")
+			(word-in-parse "$subj" "$a-parse")
 			(EvaluationLink
      			(DefinedLinguisticRelationshipNode "_%atTime")
      			(ListLink

--- a/opencog/nlp/relex2logic/rules/when-cop-q.scm
+++ b/opencog/nlp/relex2logic/rules/when-cop-q.scm
@@ -14,20 +14,8 @@
 			(word-in-parse "$verb" "$a-parse")
 			(word-in-parse "$qVar" "$a-parse")
 			(word-in-parse "$subj" "$a-parse")
-			(EvaluationLink
-     			(DefinedLinguisticRelationshipNode "_%atTime")
-     			(ListLink
-        			(VariableNode "$verb")
-        			(VariableNode "$qVar")
-	  			)
-     		)
-			(EvaluationLink
-     			(DefinedLinguisticRelationshipNode "_subj")
-     			(ListLink
-        			(VariableNode "$verb")
-        			(VariableNode "$subj")
-     			)
-  			)
+			(dependency "_%atTime" "$verb" "$qVar")
+			(dependency "_subj" "$verb" "$subj")
 			(LemmaLink
 				(VariableNode "$verb")
 				(WordNode "be")

--- a/opencog/nlp/relex2logic/rules/when-cop-q.scm
+++ b/opencog/nlp/relex2logic/rules/when-cop-q.scm
@@ -5,22 +5,10 @@
 (define when-cop-q
 	(BindLink
 		(VariableList
-			(TypedVariableLink
-				(VariableNode "$a-parse")
-				(TypeNode "ParseNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$verb")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$qVar")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$subj")
-				(TypeNode "WordInstanceNode")
-			)
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$verb" "WordInstanceNode")
+			(var-decl "$qVar" "WordInstanceNode")
+			(var-decl "$subj" "WordInstanceNode")
 		)
 		(AndLink
 			(WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/when-q.scm
+++ b/opencog/nlp/relex2logic/rules/when-q.scm
@@ -13,13 +13,7 @@
 		(AndLink
 			(word-in-parse "$verb" "$a-parse")
 			(word-in-parse "$qVar" "$a-parse")
-			(EvaluationLink
-     			(DefinedLinguisticRelationshipNode "_%atTime")
-     			(ListLink
-       			(VariableNode "$verb")
-      			(VariableNode "$qVar")
-     			)
-			)
+			(dependency "_%atTime" "$verb" "$qVar")
 			(AbsentLink
 				(LemmaLink
 					(VariableNode "$verb")

--- a/opencog/nlp/relex2logic/rules/when-q.scm
+++ b/opencog/nlp/relex2logic/rules/when-q.scm
@@ -6,18 +6,9 @@
 (define when-q
 	(BindLink
 		(VariableList
-			(TypedVariableLink
-				(VariableNode "$a-parse")
-				(TypeNode "ParseNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$verb")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$qVar")
-				(TypeNode "WordInstanceNode")
-			)
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$verb" "WordInstanceNode")
+			(var-decl "$qVar" "WordInstanceNode")
 		)
 		(AndLink
 			(WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/when-q.scm
+++ b/opencog/nlp/relex2logic/rules/when-q.scm
@@ -11,14 +11,8 @@
 			(var-decl "$qVar" "WordInstanceNode")
 		)
 		(AndLink
-			(WordInstanceLink
-				(VariableNode "$verb")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$qVar")
-				(VariableNode "$a-parse")
-			)
+			(word-in-parse "$verb" "$a-parse")
+			(word-in-parse "$qVar" "$a-parse")
 			(EvaluationLink
      			(DefinedLinguisticRelationshipNode "_%atTime")
      			(ListLink

--- a/opencog/nlp/relex2logic/rules/where-cop-q.scm
+++ b/opencog/nlp/relex2logic/rules/where-cop-q.scm
@@ -14,20 +14,8 @@
 			(word-in-parse "$verb" "$a-parse")
 			(word-in-parse "$qVar" "$a-parse")
 			(word-in-parse "$subj" "$a-parse")
-			(EvaluationLink
-     			(DefinedLinguisticRelationshipNode "_%atLocation")
-     			(ListLink
-        			(VariableNode "$verb")
-        			(VariableNode "$qVar")
-     			)
- 			)
-			(EvaluationLink
-     			(DefinedLinguisticRelationshipNode "_subj")
-     			(ListLink
-        			(VariableNode "$verb")
-        			(VariableNode "$subj")
-     			)
-			)
+			(dependency "_%atLocation" "$verb" "$qVar")
+			(dependency "_subj" "$verb" "$subj")
 			(LemmaLink
 				(VariableNode "$verb")
 				(WordNode "be")

--- a/opencog/nlp/relex2logic/rules/where-cop-q.scm
+++ b/opencog/nlp/relex2logic/rules/where-cop-q.scm
@@ -5,22 +5,10 @@
 (define where-cop-q
 	(BindLink
 		(VariableList
-			(TypedVariableLink
-				(VariableNode "$a-parse")
-				(TypeNode "ParseNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$verb")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$qVar")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$subj")
-				(TypeNode "WordInstanceNode")
-			)
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$verb" "WordInstanceNode")
+			(var-decl "$qVar" "WordInstanceNode")
+			(var-decl "$subj" "WordInstanceNode")
 		)
 		(AndLink
 			(WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/where-cop-q.scm
+++ b/opencog/nlp/relex2logic/rules/where-cop-q.scm
@@ -11,18 +11,9 @@
 			(var-decl "$subj" "WordInstanceNode")
 		)
 		(AndLink
-			(WordInstanceLink
-				(VariableNode "$verb")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$qVar")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$subj")
-				(VariableNode "$a-parse")
-			)
+			(word-in-parse "$verb" "$a-parse")
+			(word-in-parse "$qVar" "$a-parse")
+			(word-in-parse "$subj" "$a-parse")
 			(EvaluationLink
      			(DefinedLinguisticRelationshipNode "_%atLocation")
      			(ListLink

--- a/opencog/nlp/relex2logic/rules/where-q.scm
+++ b/opencog/nlp/relex2logic/rules/where-q.scm
@@ -6,18 +6,9 @@
 (define where-q
 	(BindLink
 		(VariableList
-			(TypedVariableLink
-				(VariableNode "$a-parse")
-				(TypeNode "ParseNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$verb")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$qVar")
-				(TypeNode "WordInstanceNode")
-			)
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$verb" "WordInstanceNode")
+			(var-decl "$qVar" "WordInstanceNode")
 		)
 		(AndLink
 			(WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/where-q.scm
+++ b/opencog/nlp/relex2logic/rules/where-q.scm
@@ -11,14 +11,8 @@
 			(var-decl "$qVar" "WordInstanceNode")
 		)
 		(AndLink
-			(WordInstanceLink
-				(VariableNode "$verb")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$qVar")
-				(VariableNode "$a-parse")
-			)
+			(word-in-parse "$verb" "$a-parse")
+			(word-in-parse "$qVar" "$a-parse")
 			(EvaluationLink
      			(DefinedLinguisticRelationshipNode "_%atLocation")
      			(ListLink

--- a/opencog/nlp/relex2logic/rules/where-q.scm
+++ b/opencog/nlp/relex2logic/rules/where-q.scm
@@ -13,13 +13,7 @@
 		(AndLink
 			(word-in-parse "$verb" "$a-parse")
 			(word-in-parse "$qVar" "$a-parse")
-			(EvaluationLink
-     			(DefinedLinguisticRelationshipNode "_%atLocation")
-     			(ListLink
-        			(VariableNode "$verb")
-        			(VariableNode "$qVar")
-     			)
-	 		)
+			(dependency "_%atLocation" "$verb" "$qVar")
 			(AbsentLink
 				(LemmaLink
 					(VariableNode "$verb")

--- a/opencog/nlp/relex2logic/rules/whichiobjQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichiobjQ.scm
@@ -16,22 +16,10 @@
 			(var-decl "$qVar" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$subj")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$verb")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$obj")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$iobj")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$subj" "$a-parse")
+			(word-in-parse "$verb" "$a-parse")
+			(word-in-parse "$obj" "$a-parse")
+			(word-in-parse "$iobj" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_iobj")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/whichiobjQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichiobjQ.scm
@@ -8,30 +8,12 @@
 (define whichiobjQ
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$subj")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$verb")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$obj")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$iobj")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$qVar")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$subj" "WordInstanceNode")
+			(var-decl "$verb" "WordInstanceNode")
+			(var-decl "$obj" "WordInstanceNode")
+			(var-decl "$iobj" "WordInstanceNode")
+			(var-decl "$qVar" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/whichiobjQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichiobjQ.scm
@@ -20,20 +20,8 @@
 			(word-in-parse "$verb" "$a-parse")
 			(word-in-parse "$obj" "$a-parse")
 			(word-in-parse "$iobj" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_iobj")
-                (ListLink
-                    (VariableNode "$verb")
-                    (VariableNode "$iobj")
-                )
-            )
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_det")
-                (ListLink
-                    (VariableNode "$iobj")
-                    (VariableNode "$qVar")
-                )
-            )
+			(dependency "_iobj" "$verb" "$iobj")
+			(dependency "_det" "$iobj" "$qVar")
             (InheritanceLink
                 (VariableNode "$qVar")
                 (DefinedLinguisticConceptNode "which")

--- a/opencog/nlp/relex2logic/rules/whichobjQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichobjQ.scm
@@ -15,27 +15,9 @@
 			(word-in-parse "$subj" "$a-parse")
 			(word-in-parse "$verb" "$a-parse")
 			(word-in-parse "$obj" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_subj")
-                (ListLink
-                    (VariableNode "$verb")
-                    (VariableNode "$subj")
-                )
-            )
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_obj")
-                (ListLink
-                    (VariableNode "$verb")
-                    (VariableNode "$obj")
-                )
-            )
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_det")
-                (ListLink
-                    (VariableNode "$obj")
-                    (VariableNode "$qVar")
-                )
-            )
+			(dependency "_subj" "$verb" "$subj")
+			(dependency "_obj" "$verb" "$obj")
+			(dependency "_det" "$obj" "$qVar")
             (InheritanceLink
                 (VariableNode "$qVar")
                 (DefinedLinguisticConceptNode "which")

--- a/opencog/nlp/relex2logic/rules/whichobjQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichobjQ.scm
@@ -12,18 +12,9 @@
 			(var-decl "$qVar" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$subj")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$verb")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$obj")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$subj" "$a-parse")
+			(word-in-parse "$verb" "$a-parse")
+			(word-in-parse "$obj" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_subj")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/whichobjQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichobjQ.scm
@@ -5,26 +5,11 @@
 (define whichobjQ
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$subj")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$verb")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$obj")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$qVar")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$subj" "WordInstanceNode")
+			(var-decl "$verb" "WordInstanceNode")
+			(var-decl "$obj" "WordInstanceNode")
+			(var-decl "$qVar" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/whichobjSVIOQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichobjSVIOQ.scm
@@ -5,30 +5,12 @@
 (define whichobjSVIOQ
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$subj")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$verb")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$obj")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$iobj")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$qVar")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$subj" "WordInstanceNode")
+			(var-decl "$verb" "WordInstanceNode")
+			(var-decl "$obj" "WordInstanceNode")
+			(var-decl "$iobj" "WordInstanceNode")
+			(var-decl "$qVar" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/whichobjSVIOQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichobjSVIOQ.scm
@@ -13,22 +13,10 @@
 			(var-decl "$qVar" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$subj")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$verb")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$obj")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$iobj")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$subj" "$a-parse")
+			(word-in-parse "$verb" "$a-parse")
+			(word-in-parse "$obj" "$a-parse")
+			(word-in-parse "$iobj" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_subj")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/whichobjSVIOQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichobjSVIOQ.scm
@@ -17,34 +17,10 @@
 			(word-in-parse "$verb" "$a-parse")
 			(word-in-parse "$obj" "$a-parse")
 			(word-in-parse "$iobj" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_subj")
-                (ListLink
-                    (VariableNode "$verb")
-                    (VariableNode "$subj")
-                )
-            )
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_obj")
-                (ListLink
-                    (VariableNode "$verb")
-                    (VariableNode "$obj")
-                )
-            )
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_iobj")
-                (ListLink
-                    (VariableNode "$verb")
-                    (VariableNode "$iobj")
-                )
-            )
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_det")
-                (ListLink
-                    (VariableNode "$obj")
-                    (VariableNode "$qVar")
-                )
-            )
+			(dependency "_subj" "$verb" "$subj")
+			(dependency "_obj" "$verb" "$obj")
+			(dependency "_iobj" "$verb" "$iobj")
+			(dependency "_det" "$obj" "$qVar")
             (InheritanceLink
                 (VariableNode "$qVar")
                 (DefinedLinguisticConceptNode "which")

--- a/opencog/nlp/relex2logic/rules/whichobjSVIOQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichobjSVIOQ.scm
@@ -3,16 +3,16 @@
 ; (AN June 2015)
 
 (define whichobjSVIOQ
-    (BindLink
-        (VariableList
+	(BindLink
+		(VariableList
 			(var-decl "$a-parse" "ParseNode")
 			(var-decl "$subj" "WordInstanceNode")
 			(var-decl "$verb" "WordInstanceNode")
 			(var-decl "$obj" "WordInstanceNode")
 			(var-decl "$iobj" "WordInstanceNode")
 			(var-decl "$qVar" "WordInstanceNode")
-        )
-        (AndLink
+		)
+		(AndLink
 			(word-in-parse "$subj" "$a-parse")
 			(word-in-parse "$verb" "$a-parse")
 			(word-in-parse "$obj" "$a-parse")
@@ -21,29 +21,29 @@
 			(dependency "_obj" "$verb" "$obj")
 			(dependency "_iobj" "$verb" "$iobj")
 			(dependency "_det" "$obj" "$qVar")
-            (InheritanceLink
-                (VariableNode "$qVar")
-                (DefinedLinguisticConceptNode "which")
-            )
-        )
-        (ExecutionOutputLink
-            (GroundedSchemaNode "scm: pre-whichobjSVIOQ-rule")
-            (ListLink
-               (VariableNode "$subj")
-               (VariableNode "$verb")
-               (VariableNode "$obj")
-               (VariableNode "$iobj")
-            )
-        )
-    )
+			(InheritanceLink
+				(VariableNode "$qVar")
+				(DefinedLinguisticConceptNode "which")
+			)
+		)
+		(ExecutionOutputLink
+			(GroundedSchemaNode "scm: pre-whichobjSVIOQ-rule")
+			(ListLink
+			   (VariableNode "$subj")
+			   (VariableNode "$verb")
+			   (VariableNode "$obj")
+			   (VariableNode "$iobj")
+			)
+		)
+	)
 )
 ;;ToDo: XXX FIXME define whichobjSVIOQ
 ; This is function is not needed. It is added so as not to break the existing
 ; r2l pipeline.
 (define (pre-whichobjSVIOQ-rule subj verb obj iobj)
-    (whichobjSVIOQ-rule (cog-name (word-inst-get-lemma  obj)) (cog-name obj)
-              (cog-name (word-inst-get-lemma verb)) (cog-name verb)
-              (cog-name (word-inst-get-lemma subj)) (cog-name subj)
-		      (cog-name (word-inst-get-lemma iobj)) (cog-name iobj)
-    )
+	(whichobjSVIOQ-rule (cog-name (word-inst-get-lemma  obj)) (cog-name obj)
+			  (cog-name (word-inst-get-lemma verb)) (cog-name verb)
+			  (cog-name (word-inst-get-lemma subj)) (cog-name subj)
+			  (cog-name (word-inst-get-lemma iobj)) (cog-name iobj)
+	)
 )

--- a/opencog/nlp/relex2logic/rules/whichpobjQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichpobjQ.scm
@@ -5,30 +5,12 @@
 (define whichpobjQ
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$subj")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$prep")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$pobj")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$qVar")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$be")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$subj" "WordInstanceNode")
+			(var-decl "$prep" "WordInstanceNode")
+			(var-decl "$pobj" "WordInstanceNode")
+			(var-decl "$qVar" "WordInstanceNode")
+			(var-decl "$be" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/whichpobjQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichpobjQ.scm
@@ -13,18 +13,9 @@
 			(var-decl "$be" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$subj")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$prep")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$pobj")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$subj" "$a-parse")
+			(word-in-parse "$prep" "$a-parse")
+			(word-in-parse "$pobj" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_subj")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/whichpobjQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichpobjQ.scm
@@ -16,34 +16,10 @@
 			(word-in-parse "$subj" "$a-parse")
 			(word-in-parse "$prep" "$a-parse")
 			(word-in-parse "$pobj" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_subj")
-                (ListLink
-                    (VariableNode "$be")
-                    (VariableNode "$subj")
-                )
-            )
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_obj")
-                (ListLink
-                    (VariableNode "$prep")
-                    (VariableNode "$pobj")
-                )
-            )
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_advmod")
-                (ListLink
-                    (VariableNode "$be")
-                    (VariableNode "$prep")
-                )
-            )
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_det")
-                (ListLink
-                    (VariableNode "$pobj")
-                    (VariableNode "$qVar")
-                )
-            )
+			(dependency "_subj" "$be" "$subj")
+			(dependency "_obj" "$prep" "$pobj")
+			(dependency "_advmod" "$be" "$prep")
+			(dependency "_det" "$pobj" "$qVar")
             (InheritanceLink
                 (VariableNode "$qVar")
                 (DefinedLinguisticConceptNode "which")

--- a/opencog/nlp/relex2logic/rules/whichpredadjQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichpredadjQ.scm
@@ -6,22 +6,10 @@
 (define whichpredadjQ
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$subj")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$predadj")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$qVar")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$subj" "WordInstanceNode")
+			(var-decl "$predadj" "WordInstanceNode")
+			(var-decl "$qVar" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/whichpredadjQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichpredadjQ.scm
@@ -14,20 +14,8 @@
         (AndLink
 			(word-in-parse "$subj" "$a-parse")
 			(word-in-parse "$predadj" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_predadj")
-                (ListLink
-					(VariableNode "$subj")
-					(VariableNode "$predadj")
-                )
-            )
-			(EvaluationLink
-				(DefinedLinguisticRelationshipNode "_det")
-				(ListLink
- 					(VariableNode "$subj")
-  					(VariableNode "$qVar")
-				)
-			)
+			(dependency "_predadj" "$subj" "$predadj")
+			(dependency "_det" "$subj" "$qVar")
 			(InheritanceLink
 				(VariableNode "$qVar")
 				(DefinedLinguisticConceptNode "which")

--- a/opencog/nlp/relex2logic/rules/whichpredadjQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichpredadjQ.scm
@@ -12,14 +12,8 @@
 			(var-decl "$qVar" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$subj")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$predadj")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$subj" "$a-parse")
+			(word-in-parse "$predadj" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_predadj")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/whichsubjQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichsubjQ.scm
@@ -5,26 +5,11 @@
 (define whichsubjQ
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$subj")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$verb")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$obj")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$qVar")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$subj" "WordInstanceNode")
+			(var-decl "$verb" "WordInstanceNode")
+			(var-decl "$obj" "WordInstanceNode")
+			(var-decl "$qVar" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/whichsubjQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichsubjQ.scm
@@ -3,15 +3,15 @@
 ; (AN June 2015)
 
 (define whichsubjQ
-    (BindLink
-        (VariableList
+	(BindLink
+		(VariableList
 			(var-decl "$a-parse" "ParseNode")
 			(var-decl "$subj" "WordInstanceNode")
 			(var-decl "$verb" "WordInstanceNode")
 			(var-decl "$obj" "WordInstanceNode")
 			(var-decl "$qVar" "WordInstanceNode")
-        )
-        (AndLink
+		)
+		(AndLink
 			(word-in-parse "$subj" "$a-parse")
 			(word-in-parse "$verb" "$a-parse")
 			(word-in-parse "$obj" "$a-parse")
@@ -22,23 +22,23 @@
 				(VariableNode "$qVar")
 				(DefinedLinguisticConceptNode "which")
 			)
-        )
-        (ExecutionOutputLink
-       	   (GroundedSchemaNode "scm: pre-whichsubjQ-rule")
-       	      (ListLink
-       	         (VariableNode "$subj")
-       	         (VariableNode "$verb")
-       	         (VariableNode "$obj")
-            )
-        )
-    )
+		)
+		(ExecutionOutputLink
+			(GroundedSchemaNode "scm: pre-whichsubjQ-rule")
+			  (ListLink
+				 (VariableNode "$subj")
+				 (VariableNode "$verb")
+				 (VariableNode "$obj")
+			)
+		)
+	)
 )
 ;ToDo: XXX FIXME define whichsubjQ-rule
 ; This is function is not needed. It is added so as not to break the existing
 ; r2l pipeline.
 (define (pre-whichsubjQ-rule subj verb obj)
-    (whichsubjQ-rule (cog-name (word-inst-get-lemma  subj)) (cog-name subj)
-              (cog-name (word-inst-get-lemma verb)) (cog-name verb)
-              (cog-name (word-inst-get-lemma  obj)) (cog-name obj)
-    )
+	(whichsubjQ-rule (cog-name (word-inst-get-lemma  subj)) (cog-name subj)
+			  (cog-name (word-inst-get-lemma verb)) (cog-name verb)
+			  (cog-name (word-inst-get-lemma  obj)) (cog-name obj)
+	)
 )

--- a/opencog/nlp/relex2logic/rules/whichsubjQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichsubjQ.scm
@@ -12,18 +12,9 @@
 			(var-decl "$qVar" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$subj")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$verb")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$obj")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$subj" "$a-parse")
+			(word-in-parse "$verb" "$a-parse")
+			(word-in-parse "$obj" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_subj")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/whichsubjQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichsubjQ.scm
@@ -15,27 +15,9 @@
 			(word-in-parse "$subj" "$a-parse")
 			(word-in-parse "$verb" "$a-parse")
 			(word-in-parse "$obj" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_subj")
-                (ListLink
-                    (VariableNode "$verb")
-                    (VariableNode "$subj")
-                )
-            )
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_obj")
-                (ListLink
-                    (VariableNode "$verb")
-                    (VariableNode "$obj")
-                )
-            )
-			(EvaluationLink
-   				(DefinedLinguisticRelationshipNode "_det")
-  			 	(ListLink
-     					(VariableNode "$subj")
-      					(VariableNode "$qVar")
-				)
-			)
+			(dependency "_subj" "$verb" "$subj")
+			(dependency "_obj" "$verb" "$obj")
+			(dependency "_det" "$subj" "$qVar")
 			(InheritanceLink
 				(VariableNode "$qVar")
 				(DefinedLinguisticConceptNode "which")

--- a/opencog/nlp/relex2logic/rules/whichsubjSVIOQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichsubjSVIOQ.scm
@@ -5,30 +5,12 @@
 (define whichsubjSVIOQ
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$subj")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$verb")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$obj")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$iobj")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$qVar")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$subj" "WordInstanceNode")
+			(var-decl "$verb" "WordInstanceNode")
+			(var-decl "$obj" "WordInstanceNode")
+			(var-decl "$iobj" "WordInstanceNode")
+			(var-decl "$qVar" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/whichsubjSVIOQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichsubjSVIOQ.scm
@@ -17,34 +17,10 @@
 			(word-in-parse "$verb" "$a-parse")
 			(word-in-parse "$obj" "$a-parse")
 			(word-in-parse "$iobj" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_subj")
-                (ListLink
-                    (VariableNode "$verb")
-                    (VariableNode "$subj")
-                )
-            )
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_obj")
-                (ListLink
-                    (VariableNode "$verb")
-                    (VariableNode "$obj")
-                )
-            )
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_iobj")
-                (ListLink
-                    (VariableNode "$verb")
-                    (VariableNode "$iobj")
-                )
-            )
-	(EvaluationLink
-		(DefinedLinguisticRelationshipNode "_det")
-		 (ListLink
- 				(VariableNode "$subj")
-  				(VariableNode "$qVar")
-		)
-	)
+			(dependency "_subj" "$verb" "$subj")
+			(dependency "_obj" "$verb" "$obj")
+			(dependency "_iobj" "$verb" "$iobj")
+			(dependency "_det" "$subj" "$qVar")
 	(InheritanceLink
 		(VariableNode "$qVar")
 		(DefinedLinguisticConceptNode "which")

--- a/opencog/nlp/relex2logic/rules/whichsubjSVIOQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichsubjSVIOQ.scm
@@ -13,22 +13,10 @@
 			(var-decl "$qVar" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$subj")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$verb")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$obj")
-                (VariableNode "$a-parse")
-            )
-	    (WordInstanceLink
-                (VariableNode "$iobj")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$subj" "$a-parse")
+			(word-in-parse "$verb" "$a-parse")
+			(word-in-parse "$obj" "$a-parse")
+			(word-in-parse "$iobj" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_subj")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/whichsubjSVOQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichsubjSVOQ.scm
@@ -12,18 +12,9 @@
 			(var-decl "$qVar" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$subj")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$verb")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$obj")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$subj" "$a-parse")
+			(word-in-parse "$verb" "$a-parse")
+			(word-in-parse "$obj" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_subj")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/whichsubjSVOQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichsubjSVOQ.scm
@@ -5,26 +5,11 @@
 (define whichsubjSVOQ
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$subj")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$verb")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$obj")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$qVar")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$subj" "WordInstanceNode")
+			(var-decl "$verb" "WordInstanceNode")
+			(var-decl "$obj" "WordInstanceNode")
+			(var-decl "$qVar" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/whichsubjSVOQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichsubjSVOQ.scm
@@ -15,27 +15,9 @@
 			(word-in-parse "$subj" "$a-parse")
 			(word-in-parse "$verb" "$a-parse")
 			(word-in-parse "$obj" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_subj")
-                (ListLink
-                    (VariableNode "$verb")
-                    (VariableNode "$subj")
-                )
-            )
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_obj")
-                (ListLink
-                    (VariableNode "$verb")
-                    (VariableNode "$obj")
-                )
-            )
-	(EvaluationLink
-		(DefinedLinguisticRelationshipNode "_det")
-		 (ListLink
- 				(VariableNode "$subj")
-  				(VariableNode "$qVar")
-		)
-	)
+			(dependency "_subj" "$verb" "$subj")
+			(dependency "_obj" "$verb" "$obj")
+			(dependency "_det" "$subj" "$qVar")
 	(InheritanceLink
 		(VariableNode "$qVar")
 		(DefinedLinguisticConceptNode "which")

--- a/opencog/nlp/relex2logic/rules/whichsubjSVQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichsubjSVQ.scm
@@ -7,26 +7,11 @@
 (define whichsubjSVQ
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$subj")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$verb")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$obj")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$qVar")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$subj" "WordInstanceNode")
+			(var-decl "$verb" "WordInstanceNode")
+			(var-decl "$obj" "WordInstanceNode")
+			(var-decl "$qVar" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/whichsubjSVQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichsubjSVQ.scm
@@ -14,14 +14,8 @@
 			(var-decl "$qVar" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$subj")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$verb")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$subj" "$a-parse")
+			(word-in-parse "$verb" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_subj")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/whichsubjSVQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichsubjSVQ.scm
@@ -16,29 +16,11 @@
         (AndLink
 			(word-in-parse "$subj" "$a-parse")
 			(word-in-parse "$verb" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_subj")
-                (ListLink
-                    (VariableNode "$verb")
-                    (VariableNode "$subj")
-                )
-            )
+			(dependency "_subj" "$verb" "$subj")
 		(AbsentLink
-			(EvaluationLink
-        	        	(DefinedLinguisticRelationshipNode "_obj")
-        	       		 (ListLink
-        	           		 (VariableNode "$verb")
-        	           		 (VariableNode "$obj")
-        	        	)
-        	   	 )
+			(dependency "_obj" "$verb" "$obj")
 		)
-			(EvaluationLink
-   				(DefinedLinguisticRelationshipNode "_det")
-  			 	(ListLink
-     					(VariableNode "$subj")
-      					(VariableNode "$qVar")
-				)
-			)
+			(dependency "_det" "$subj" "$qVar")
 			(InheritanceLink
 				(VariableNode "$qVar")
 				(DefinedLinguisticConceptNode "which")

--- a/opencog/nlp/relex2logic/rules/whichsubjpobjQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichsubjpobjQ.scm
@@ -6,26 +6,11 @@
 (define whichsubjpobjQ
     (BindLink
         (VariableList
-            (TypedVariableLink
-                (VariableNode "$a-parse")
-                (TypeNode "ParseNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$subj")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$prep")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$pobj")
-                (TypeNode "WordInstanceNode")
-            )
-            (TypedVariableLink
-                (VariableNode "$qVar")
-                (TypeNode "WordInstanceNode")
-            )
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$subj" "WordInstanceNode")
+			(var-decl "$prep" "WordInstanceNode")
+			(var-decl "$pobj" "WordInstanceNode")
+			(var-decl "$qVar" "WordInstanceNode")
         )
         (AndLink
             (WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/whichsubjpobjQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichsubjpobjQ.scm
@@ -16,27 +16,9 @@
 			(word-in-parse "$subj" "$a-parse")
 			(word-in-parse "$prep" "$a-parse")
 			(word-in-parse "$pobj" "$a-parse")
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_predadj")
-                (ListLink
-                    (VariableNode "$subj")
-		    (VariableNode "$prep")
-                )
-            )
-            (EvaluationLink
-                (DefinedLinguisticRelationshipNode "_pobj")
-                (ListLink
-                    (VariableNode "$prep")
-                    (VariableNode "$pobj")
-                )
-            )
-		(EvaluationLink
-   			(DefinedLinguisticRelationshipNode "_det")
-  			 (ListLink
-   				(VariableNode "$subj")
-      				(VariableNode "$qVar")
-			)
-		)
+			(dependency "_predadj" "$subj" "$prep")
+			(dependency "_pobj" "$prep" "$pobj")
+			(dependency "_det" "$subj" "$qVar")
 		(InheritanceLink
 			(VariableNode "$qVar")
 			(DefinedLinguisticConceptNode "which")

--- a/opencog/nlp/relex2logic/rules/whichsubjpobjQ.scm
+++ b/opencog/nlp/relex2logic/rules/whichsubjpobjQ.scm
@@ -13,18 +13,9 @@
 			(var-decl "$qVar" "WordInstanceNode")
         )
         (AndLink
-            (WordInstanceLink
-                (VariableNode "$subj")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$prep")
-                (VariableNode "$a-parse")
-            )
-            (WordInstanceLink
-                (VariableNode "$pobj")
-                (VariableNode "$a-parse")
-            )
+			(word-in-parse "$subj" "$a-parse")
+			(word-in-parse "$prep" "$a-parse")
+			(word-in-parse "$pobj" "$a-parse")
             (EvaluationLink
                 (DefinedLinguisticRelationshipNode "_predadj")
                 (ListLink

--- a/opencog/nlp/relex2logic/rules/why-cop-q.scm
+++ b/opencog/nlp/relex2logic/rules/why-cop-q.scm
@@ -6,22 +6,10 @@
 (define why-cop-q
 	(BindLink
 		(VariableList
-			(TypedVariableLink
-				(VariableNode "$a-parse")
-				(TypeNode "ParseNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$verb")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$qVar")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$subj")
-				(TypeNode "WordInstanceNode")
-			)
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$verb" "WordInstanceNode")
+			(var-decl "$qVar" "WordInstanceNode")
+			(var-decl "$subj" "WordInstanceNode")
 		)
 		(AndLink
 			(WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/why-cop-q.scm
+++ b/opencog/nlp/relex2logic/rules/why-cop-q.scm
@@ -12,18 +12,9 @@
 			(var-decl "$subj" "WordInstanceNode")
 		)
 		(AndLink
-			(WordInstanceLink
-				(VariableNode "$verb")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$qVar")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$subj")
-				(VariableNode "$a-parse")
-			)
+			(word-in-parse "$verb" "$a-parse")
+			(word-in-parse "$qVar" "$a-parse")
+			(word-in-parse "$subj" "$a-parse")
 			(EvaluationLink
                 			(DefinedLinguisticRelationshipNode "_%because")
                 			(ListLink

--- a/opencog/nlp/relex2logic/rules/why-cop-q.scm
+++ b/opencog/nlp/relex2logic/rules/why-cop-q.scm
@@ -15,41 +15,17 @@
 			(word-in-parse "$verb" "$a-parse")
 			(word-in-parse "$qVar" "$a-parse")
 			(word-in-parse "$subj" "$a-parse")
-			(EvaluationLink
-                			(DefinedLinguisticRelationshipNode "_%because")
-                			(ListLink
-                    			(VariableNode "$verb")
-                    			(VariableNode "$qVar")
-                			)
-            		)
+			(dependency "_%because" "$verb" "$qVar")
 			(ChoiceLink
 				(AndLink
-					(EvaluationLink
-            	    				(DefinedLinguisticRelationshipNode "_subj")
-            	    				(ListLink
-            	        				(VariableNode "$verb")
-            	        				(VariableNode "$subj")
-            	    				)
-            				)
+			(dependency "_subj" "$verb" "$subj")
 					(LemmaLink
 						(VariableNode "$verb")
 						(WordNode "be")
 					)
 				)
-				(EvaluationLink
-					(DefinedLinguisticRelationshipNode "_predadj")
-					(ListLink
-						(VariableNode "$subj")
-						(VariableNode "$verb")
-					)
-				)
-				(EvaluationLink
-					(DefinedLinguisticRelationshipNode "_psubj")
-					(ListLink
-						(VariableNode "$verb")
-						(VariableNode "$subj")
-					)
-				)
+			(dependency "_predadj" "$verb" "$subj")
+			(dependency "_psubj" "$subj" "$verb")
 			)
 		)
 		(ExecutionOutputLink

--- a/opencog/nlp/relex2logic/rules/why-q.scm
+++ b/opencog/nlp/relex2logic/rules/why-q.scm
@@ -10,14 +10,8 @@
 			(var-decl "$qVar" "WordInstanceNode")
 		)
 		(AndLink
-			(WordInstanceLink
-				(VariableNode "$verb")
-				(VariableNode "$a-parse")
-			)
-			(WordInstanceLink
-				(VariableNode "$qVar")
-				(VariableNode "$a-parse")
-			)
+			(word-in-parse "$verb" "$a-parse")
+			(word-in-parse "$qVar" "$a-parse")
 			(EvaluationLink
                 			(DefinedLinguisticRelationshipNode "_%because")
                 			(ListLink

--- a/opencog/nlp/relex2logic/rules/why-q.scm
+++ b/opencog/nlp/relex2logic/rules/why-q.scm
@@ -5,18 +5,9 @@
 (define why-q
 	(BindLink
 		(VariableList
-			(TypedVariableLink
-				(VariableNode "$a-parse")
-				(TypeNode "ParseNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$verb")
-				(TypeNode "WordInstanceNode")
-			)
-			(TypedVariableLink
-				(VariableNode "$qVar")
-				(TypeNode "WordInstanceNode")
-			)
+			(var-decl "$a-parse" "ParseNode")
+			(var-decl "$verb" "WordInstanceNode")
+			(var-decl "$qVar" "WordInstanceNode")
 		)
 		(AndLink
 			(WordInstanceLink

--- a/opencog/nlp/relex2logic/rules/why-q.scm
+++ b/opencog/nlp/relex2logic/rules/why-q.scm
@@ -12,13 +12,7 @@
 		(AndLink
 			(word-in-parse "$verb" "$a-parse")
 			(word-in-parse "$qVar" "$a-parse")
-			(EvaluationLink
-                			(DefinedLinguisticRelationshipNode "_%because")
-                			(ListLink
-                    			(VariableNode "$verb")
-                    			(VariableNode "$qVar")
-                			)
-            		)
+			(dependency "_%because" "$verb" "$qVar")
 			(AbsentLink
 				(LemmaLink
 					(VariableNode "$verb")


### PR DESCRIPTION
The rule files were huge and hard-to-understand.  Make them a little shorter.