### PR TITLE
Proposal: Standardizing how new scheme modules are added.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -486,6 +486,7 @@ SET (MAN_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/share/man")
 
 # include custom opencog cmake macros
 INCLUDE("${CMAKE_SOURCE_DIR}/lib/OpenCogMacros.cmake")
+INCLUDE("${CMAKE_SOURCE_DIR}/lib/OpenCogFunctions.cmake")
 
 # small hack to handle unixes that use "/usr/lib64" instead of "/usr/lib" as the
 # default lib path on 64 bit archs

--- a/lib/OpenCogFunctions.cmake
+++ b/lib/OpenCogFunctions.cmake
@@ -1,0 +1,43 @@
+# 1. The name of the directory is the name of the module
+# 2. There must be a .scm file in the same directory as the module. This file
+#    on installation will be copied one directory above its current directory.
+# Types of scm modules
+# 1. Modules that doen't have any c++ code like the nlp modules can
+#    exist in their separte directory and the directory structure implies the
+#    module structure.
+# 2. If there is a c++ code then the scheme moduel will be under `scm/`
+#    directory. And on installation or symlinking the `scm/` directory is
+#    escaped.
+# 3. The same logic would apply for python
+# 4. Everything should be explicit
+
+FUNCTION(ADD_GUILE_MODULE MODULE_FILE)
+    # MODULE_FILE = The name of the file that defines the module
+    MESSAGE("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^")
+
+    # Check if the file exists
+    IF(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${MODULE_FILE})
+        MESSAGE(FATAL_ERROR "${MODULE_FILE} file does not exist in"
+            ${CMAKE_CURRENT_SOURCE_DIR})
+    ENDIF()
+
+    # Get current and parent cmake source directory names.
+    STRING(REGEX MATCH "([a-z0-9-]+)/([^/.]+$)" "" ${CMAKE_CURRENT_SOURCE_DIR})
+    SET(PARENT_SOURCE_DIR_NAME ${CMAKE_MATCH_1})
+    SET(CURRENT_SOURCE_DIR_NAME ${CMAKE_MATCH_2})
+
+    # Module name is equal to the current directory name, or the current
+    # directory's parent-directory name if the current directory is scm.
+    IF (${CURRENT_SOURCE_DIR_NAME} STREQUAL "scm")
+        SET(MODULE_NAME ${PARENT_SOURCE_DIR_NAME})
+    ELSE()
+        SET(MODULE_NAME ${CURRENT_SOURCE_DIR_NAME})
+    ENDIF()
+
+    # Check if the file has the same name as the module_name
+    IF ("${MODULE_NAME}.scm" STREQUAL "${MODULE_FILE}")
+        MESSAGE("they are equal time to symlink------------")
+    ENDIF()
+
+    MESSAGE("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^")
+ENDFUNCTION(ADD_GUILE_MODULE)

--- a/lib/OpenCogFunctions.cmake
+++ b/lib/OpenCogFunctions.cmake
@@ -12,79 +12,77 @@
 # 4. Everything should be explicit
 
 FUNCTION(ADD_GUILE_MODULE SCHEME_FILE)
-# MODULE_FILE: The name of the file that defines the module. It has the same
-#       name as the directory it is in, or the name of the parent directory of
-#       current directory if it is in a folder named 'scm' and used to define
-#       the module.
+    FOREACH(FILE_NAME ${ARGV})
+        # NOTE: Directory paths are not allowed as module names.
+        STRING(REGEX MATCH "([a-z0-9/-]+)/([a-z0-9/-]*)" "" ${FILE_NAME})
+        IF(CMAKE_MATCH_2)
+            MESSAGE(FATAL_ERROR "Only files found in "
+                "${CMAKE_CURRENT_SOURCE_DIR} are allowed")
+        ENDIF()
+        # MODULE_FILE: The name of the file that defines the module. It has
+        #   the same name as the directory it is in, or the name of the parent
+        #   directory of current directory if it is in a folder named 'scm'
+        #   and used to define the module.
+        SET(MODULE_FILE ${FILE_NAME})
 
-FOREACH(FILE_NAME ${ARGV})
-    # NOTE: Directory paths are not allowed as module names.
-    STRING(REGEX MATCH "([a-z0-9/-]+)/([a-z0-9/-]*)" "" ${FILE_NAME})
-    IF(CMAKE_MATCH_2)
-        MESSAGE(FATAL_ERROR "Only files found in "
-            "${CMAKE_CURRENT_SOURCE_DIR} are allowed")
-    ENDIF()
-    SET(MODULE_FILE ${FILE_NAME})
+        # Check if the file exists
+        IF(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${MODULE_FILE})
+            MESSAGE(FATAL_ERROR "${MODULE_FILE} file does not exist in "
+                ${CMAKE_CURRENT_SOURCE_DIR})
+        ENDIF()
 
-    # Check if the file exists
-    IF(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${MODULE_FILE})
-        MESSAGE(FATAL_ERROR "${MODULE_FILE} file does not exist in "
+        # Clean path for specifying module paths
+        # NOTE: Names of modules should be small-letters.
+        # TODO: There can only be 1 folder named `scm` in path but there is no
+        # check for that add it.
+        STRING(REGEX MATCH
+            "^(${CMAKE_HOME_DIRECTORY})/([a-z0-9/-]+)/(scm?)([a-z0-9/-]*)" ""
             ${CMAKE_CURRENT_SOURCE_DIR})
-    ENDIF()
 
-    # Clean path for specifying module paths
-    # NOTE: Names of modules should be small-letters.
-    # TODO: There can only be 1 folder named `scm` in path but there is no
-    # check for that add it.
-    STRING(REGEX MATCH
-        "^(${CMAKE_HOME_DIRECTORY})/([a-z0-9/-]+)/(scm?)([a-z0-9/-]*)" ""
-        ${CMAKE_CURRENT_SOURCE_DIR})
+        IF(CMAKE_MATCH_0)
+            SET(CLEAN_PATH "${CMAKE_HOME_DIRECTORY}/${CMAKE_MATCH_2}${CMAKE_MATCH_4}")
+        ELSE()
+            SET(CLEAN_PATH ${CMAKE_CURRENT_SOURCE_DIR})
+        ENDIF()
 
-    IF(CMAKE_MATCH_0)
-        SET(CLEAN_PATH "${CMAKE_HOME_DIRECTORY}/${CMAKE_MATCH_2}${CMAKE_MATCH_4}")
-    ELSE()
-        SET(CLEAN_PATH ${CMAKE_CURRENT_SOURCE_DIR})
-    ENDIF()
+        # Specify the module paths.
+        STRING(REGEX MATCH
+            "^(${CMAKE_HOME_DIRECTORY})/([a-z0-9/-]+)+/([a-z0-9-]+)" ""
+            ${CLEAN_PATH})
 
-    # Specify the module paths.
-    STRING(REGEX MATCH
-        "^(${CMAKE_HOME_DIRECTORY})/([a-z0-9/-]+)+/([a-z0-9-]+)" ""
-        ${CLEAN_PATH})
+        # MODULE_NAME: it is equal to the current directory name, or the current
+        #   directory's parent-directory name if the current directory is scm.
+        # MODULE_FILE_DIR_PATH: the directory path where the MODULE_FILE is
+        #   installed.
+        # MODULE_FILES_DIR_PATH: the directory path where the files associated
+        #   with the module are installed/symlinked at, with the exception of
+        #   the MODULE_FILE.
+        SET(MODULE_NAME ${CMAKE_MATCH_3})
+        SET(MODULE_FILE_DIR_PATH ${CMAKE_MATCH_2})
+        SET(MODULE_FILES_DIR_PATH ${CMAKE_MATCH_2}/${CMAKE_MATCH_3})
+        SET(GUILE_SYMLINK_DIR "${CMAKE_BINARY_DIR}/opencog/scm")
+        SET(GUILE_INSTALL_DIR "${DATADIR}/scm")
 
-    # MODULE_NAME: it is equal to the current directory name, or the current
-    #       directory's parent-directory name if the current directory is scm.
-    # MODULE_FILE_DIR_PATH: the directory path where the MODULE_FILE is
-    #       installed.
-    # MODULE_FILES_DIR_PATH: the directory path where the files associated
-    #       with the module are installed/symlinked at, with the exception of
-    #       the MODULE_FILE.
-    SET(MODULE_NAME ${CMAKE_MATCH_3})
-    SET(MODULE_FILE_DIR_PATH ${CMAKE_MATCH_2})
-    SET(MODULE_FILES_DIR_PATH ${CMAKE_MATCH_2}/${CMAKE_MATCH_3})
-    SET(GUILE_SYMLINK_DIR "${CMAKE_BINARY_DIR}/opencog/scm")
-    SET(GUILE_INSTALL_DIR "${DATADIR}/scm")
-
-    # Create symlinks in build directory mirroring the install path structure.
-    # Also configure for install.
-    IF ("${MODULE_NAME}.scm" STREQUAL "${MODULE_FILE}")
-        EXECUTE_PROCESS(
-            COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/opencog/scm/${MODULE_FILE_DIR_PATH}
-            COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE_FILE}" "${GUILE_SYMLINK_DIR}/${MODULE_FILE_DIR_PATH}/${MODULE_FILE}"
-        )
-        INSTALL(FILES
-            ${MODULE_FILE}
-            DESTINATION "${GUILE_INSTALL_DIR}/${MODULE_FILE_DIR_PATH}"
-        )
-    ELSE()
-        EXECUTE_PROCESS(
-            COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/opencog/scm/${MODULE_FILES_DIR_PATH}
-            COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE_FILE}" "${GUILE_SYMLINK_DIR}/${MODULE_FILES_DIR_PATH}/${MODULE_FILE}"
-        )
-        INSTALL (FILES
-            ${MODULE_FILE}
-            DESTINATION "${GUILE_INSTALL_DIR}/${MODULE_FILES_DIR_PATH}"
-        )
-    ENDIF()
-ENDFOREACH(FILE_NAME)
-
+        # Create symlinks in build directory mirroring the install path structure.
+        # Also configure for install.
+        IF ("${MODULE_NAME}.scm" STREQUAL "${MODULE_FILE}")
+            EXECUTE_PROCESS(
+                COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/opencog/scm/${MODULE_FILE_DIR_PATH}
+                COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE_FILE}" "${GUILE_SYMLINK_DIR}/${MODULE_FILE_DIR_PATH}/${MODULE_FILE}"
+            )
+            INSTALL(FILES
+                ${MODULE_FILE}
+                DESTINATION "${GUILE_INSTALL_DIR}/${MODULE_FILE_DIR_PATH}"
+            )
+        ELSE()
+            EXECUTE_PROCESS(
+                COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/opencog/scm/${MODULE_FILES_DIR_PATH}
+                COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE_FILE}" "${GUILE_SYMLINK_DIR}/${MODULE_FILES_DIR_PATH}/${MODULE_FILE}"
+            )
+            INSTALL (FILES
+                ${MODULE_FILE}
+                DESTINATION "${GUILE_INSTALL_DIR}/${MODULE_FILES_DIR_PATH}"
+            )
+        ENDIF()
+    ENDFOREACH(FILE_NAME)
 ENDFUNCTION(ADD_GUILE_MODULE)

--- a/lib/OpenCogFunctions.cmake
+++ b/lib/OpenCogFunctions.cmake
@@ -11,15 +11,24 @@
 # 3. The same logic would apply for python
 # 4. Everything should be explicit
 
-FUNCTION(ADD_GUILE_MODULE MODULE_FILE)
+FUNCTION(ADD_GUILE_MODULE SCHEME_FILE)
 # MODULE_FILE: The name of the file that defines the module. It has the same
 #       name as the directory it is in, or the name of the parent directory of
 #       current directory if it is in a folder named 'scm' and used to define
 #       the module.
 
+FOREACH(FILE_NAME ${ARGV})
+    # NOTE: Directory paths are not allowed as module names.
+    STRING(REGEX MATCH "([a-z0-9/-]+)/([a-z0-9/-]*)" "" ${FILE_NAME})
+    IF(CMAKE_MATCH_2)
+        MESSAGE(FATAL_ERROR "Only files found in "
+            "${CMAKE_CURRENT_SOURCE_DIR} are allowed")
+    ENDIF()
+    SET(MODULE_FILE ${FILE_NAME})
+
     # Check if the file exists
     IF(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${MODULE_FILE})
-        MESSAGE(FATAL_ERROR "${MODULE_FILE} file does not exist in"
+        MESSAGE(FATAL_ERROR "${MODULE_FILE} file does not exist in "
             ${CMAKE_CURRENT_SOURCE_DIR})
     ENDIF()
 
@@ -62,7 +71,7 @@ FUNCTION(ADD_GUILE_MODULE MODULE_FILE)
             COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/opencog/scm/${MODULE_FILE_DIR_PATH}
             COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE_FILE}" "${GUILE_SYMLINK_DIR}/${MODULE_FILE_DIR_PATH}/${MODULE_FILE}"
         )
-        INSTALL (FILES
+        INSTALL(FILES
             ${MODULE_FILE}
             DESTINATION "${GUILE_INSTALL_DIR}/${MODULE_FILE_DIR_PATH}"
         )
@@ -76,5 +85,6 @@ FUNCTION(ADD_GUILE_MODULE MODULE_FILE)
             DESTINATION "${GUILE_INSTALL_DIR}/${MODULE_FILES_DIR_PATH}"
         )
     ENDIF()
+ENDFOREACH(FILE_NAME)
 
 ENDFUNCTION(ADD_GUILE_MODULE)

--- a/lib/OpenCogFunctions.cmake
+++ b/lib/OpenCogFunctions.cmake
@@ -52,18 +52,28 @@ FUNCTION(ADD_GUILE_MODULE MODULE_FILE)
     SET(MODULE_NAME ${CMAKE_MATCH_3})
     SET(MODULE_FILE_DIR_PATH ${CMAKE_MATCH_2})
     SET(MODULE_FILES_DIR_PATH ${CMAKE_MATCH_2}/${CMAKE_MATCH_3})
+    SET(GUILE_SYMLINK_DIR "${CMAKE_BINARY_DIR}/opencog/scm")
+    SET(GUILE_INSTALL_DIR "${DATADIR}/scm")
 
-    # Create symlinks in build directory mirroring what the install path
-    # structure.
+    # Create symlinks in build directory mirroring the install path structure.
+    # Also configure for install.
     IF ("${MODULE_NAME}.scm" STREQUAL "${MODULE_FILE}")
         EXECUTE_PROCESS(
             COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/opencog/scm/${MODULE_FILE_DIR_PATH}
-            COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE_FILE}" "${CMAKE_BINARY_DIR}/opencog/scm/${MODULE_FILE_DIR_PATH}/${MODULE_FILE}"
+            COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE_FILE}" "${GUILE_SYMLINK_DIR}/${MODULE_FILE_DIR_PATH}/${MODULE_FILE}"
+        )
+        INSTALL (FILES
+            ${MODULE_FILE}
+            DESTINATION "${GUILE_INSTALL_DIR}/${MODULE_FILE_DIR_PATH}"
         )
     ELSE()
         EXECUTE_PROCESS(
             COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/opencog/scm/${MODULE_FILES_DIR_PATH}
-            COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE_FILE}" "${CMAKE_BINARY_DIR}/opencog/scm/${MODULE_FILES_DIR_PATH}/${MODULE_FILE}"
+            COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE_FILE}" "${GUILE_SYMLINK_DIR}/${MODULE_FILES_DIR_PATH}/${MODULE_FILE}"
+        )
+        INSTALL (FILES
+            ${MODULE_FILE}
+            DESTINATION "${GUILE_INSTALL_DIR}/${MODULE_FILES_DIR_PATH}"
         )
     ENDIF()
 

--- a/lib/OpenCogFunctions.cmake
+++ b/lib/OpenCogFunctions.cmake
@@ -1,15 +1,35 @@
-# 1. The name of the directory is the name of the module
+# Copyright (C) 2016 OpenCog Foundation
+#
+# 1. The name of the directory and the name is the name of the module
 # 2. There must be a .scm file in the same directory as the module. This file
 #    on installation will be copied one directory above its current directory.
-# Types of scm modules
-# 1. Modules that doen't have any c++ code like the nlp modules can
-#    exist in their separte directory and the directory structure implies the
-#    module structure.
-# 2. If there is a c++ code then the scheme moduel will be under `scm/`
+#
+# Types of scm module directory structures
+# 1. Modules that doen't have any c++ code modules can exist in their separate
+#    directory. Examples,
+#    * `/repo-name/opencog/some-module/some-module.scm` is imported by
+#      `(use-modules (opencog some-module ))` if `some-module.scm` has an
+#      expression `(define-module (opencog some-module))`
+#    * `/repo-name/opencog/some-module/sub-module/sub-module.scm` is imported
+#      by `(use-modules (opencog some-module sub-module))` if `sub-module.scm`
+#      has an expression `(define-module (opencog some-module sub-module))`
+# 2. If there is a c++ code then the scheme module should be under `scm/`
 #    directory. And on installation or symlinking the `scm/` directory is
-#    escaped.
-# 3. The same logic would apply for python
-# 4. Everything should be explicit
+#    escaped. If there are more than one `scm/` directories only the first in
+#    the hierarchy is escaped. As the need arises multiple `scm/` directory
+#    escpaes maybe be added in the future. Examples,
+#    * `/repo-name/opencog/some-module/scm/some-module.scm` is imported by
+#      `(use-modules (opencog some-module ))` if `some-module.scm` has an
+#      expression `(define-module (opencog some-module))`
+#    * `/repo-name/opencog/some-module/scm/sub-module/sub-module.scm` is
+#      imported by `(use-modules (opencog some-module sub-module))` if
+#      `sub-module.scm` has an expression `(define-module (opencog some-module
+#      sub-module))`
+
+# References:
+# https://www.gnu.org/software/guile/manual/guile.html#Modules-and-the-File-System
+# https://www.gnu.org/software/guile/manual/guile.html#Creating-Guile-Modules
+
 
 FUNCTION(ADD_GUILE_MODULE SCHEME_FILE)
     FOREACH(FILE_NAME ${ARGV})
@@ -21,8 +41,10 @@ FUNCTION(ADD_GUILE_MODULE SCHEME_FILE)
         ENDIF()
         # MODULE_FILE: The name of the file that defines the module. It has
         #   the same name as the directory it is in, or the name of the parent
-        #   directory of current directory if it is in a folder named 'scm'
-        #   and used to define the module.
+        #   directory of current directory if it is in a folder named 'scm'.
+        #   In addition this file shoule have a define-module expression
+        #   for it be importable, as per guile's specification. See reference
+        #   links above.
         SET(MODULE_FILE ${FILE_NAME})
 
         # Check if the file exists
@@ -67,7 +89,7 @@ FUNCTION(ADD_GUILE_MODULE SCHEME_FILE)
         # Also configure for install.
         IF ("${MODULE_NAME}.scm" STREQUAL "${MODULE_FILE}")
             EXECUTE_PROCESS(
-                COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/opencog/scm/${MODULE_FILE_DIR_PATH}
+                COMMAND ${CMAKE_COMMAND} -E make_directory ${GUILE_SYMLINK_DIR}/${MODULE_FILE_DIR_PATH}
                 COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE_FILE}" "${GUILE_SYMLINK_DIR}/${MODULE_FILE_DIR_PATH}/${MODULE_FILE}"
             )
             INSTALL(FILES
@@ -76,7 +98,7 @@ FUNCTION(ADD_GUILE_MODULE SCHEME_FILE)
             )
         ELSE()
             EXECUTE_PROCESS(
-                COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/opencog/scm/${MODULE_FILES_DIR_PATH}
+                COMMAND ${CMAKE_COMMAND} -E make_directory ${GUILE_SYMLINK_DIR}/${MODULE_FILES_DIR_PATH}
                 COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE_FILE}" "${GUILE_SYMLINK_DIR}/${MODULE_FILES_DIR_PATH}/${MODULE_FILE}"
             )
             INSTALL (FILES

--- a/lib/OpenCogFunctions.cmake
+++ b/lib/OpenCogFunctions.cmake
@@ -53,11 +53,18 @@ FUNCTION(ADD_GUILE_MODULE MODULE_FILE)
     SET(MODULE_FILE_DIR_PATH ${CMAKE_MATCH_2})
     SET(MODULE_FILES_DIR_PATH ${CMAKE_MATCH_2}/${CMAKE_MATCH_3})
 
-    # Check if the file has the same name as the module_name
+    # Create symlinks in build directory mirroring what the install path
+    # structure.
     IF ("${MODULE_NAME}.scm" STREQUAL "${MODULE_FILE}")
-        MESSAGE("they are equal time to symlink------------")
+        EXECUTE_PROCESS(
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/opencog/scm/${MODULE_FILE_DIR_PATH}
+            COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE_FILE}" "${CMAKE_BINARY_DIR}/opencog/scm/${MODULE_FILE_DIR_PATH}/${MODULE_FILE}"
+        )
     ELSE()
-        MESSAGE(WARNING "they are not equal symlinking anyways")
+        EXECUTE_PROCESS(
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/opencog/scm/${MODULE_FILES_DIR_PATH}
+            COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE_FILE}" "${CMAKE_BINARY_DIR}/opencog/scm/${MODULE_FILES_DIR_PATH}/${MODULE_FILE}"
+        )
     ENDIF()
 
 ENDFUNCTION(ADD_GUILE_MODULE)

--- a/opencog/nlp/relex2logic/CMakeLists.txt
+++ b/opencog/nlp/relex2logic/CMakeLists.txt
@@ -1,16 +1,9 @@
-INSTALL (FILES
-	relex2logic.scm
-	DESTINATION "${DATADIR}/scm/opencog/nlp/"
-)
-
-INSTALL (FILES
-	post-processing.scm
-	rule-helpers.scm
-	rule-utils.scm
-	r2l-utilities.scm
-	DESTINATION "${DATADIR}/scm/opencog/nlp/relex2logic"
+ADD_GUILE_MODULE(relex2logic.scm
+                 post-processing.scm
+                 rule-helpers.scm
+                 rule-utils.scm
+                 r2l-utilities.scm
 )
 
 ADD_SUBDIRECTORY (loader)
 ADD_SUBDIRECTORY (rules)
-

--- a/opencog/nlp/relex2logic/loader/CMakeLists.txt
+++ b/opencog/nlp/relex2logic/loader/CMakeLists.txt
@@ -1,5 +1,3 @@
-INSTALL (FILES
-	gen-r2l-en-rulebase.scm
-	load-rules.scm
-	DESTINATION "${DATADIR}/scm/opencog/nlp/relex2logic/loader"
+ADD_GUILE_MODULE(load-rules.scm
+                 gen-r2l-en-rulebase.scm
 )

--- a/opencog/nlp/relex2logic/rules/CMakeLists.txt
+++ b/opencog/nlp/relex2logic/rules/CMakeLists.txt
@@ -1,4 +1,4 @@
-INSTALL (FILES
+ADD_GUILE_MODULE (
 	adverbialpp.scm
 	advmod.scm
 	amod.scm
@@ -59,5 +59,4 @@ INSTALL (FILES
 	whichsubjSVQ.scm
 	why-cop-q.scm
 	why-q.scm
-	DESTINATION "${DATADIR}/scm/opencog/nlp/relex2logic/rules"
 )


### PR DESCRIPTION
**Why?** 
1. To avoid having to install modulerized scheme code for every change during developement
2. To avoid having to choose between two ways of defining modules (specifically their installation path)
  * in `/repo-name/openocg/scm/some-module.scm`, or
  * in `/repo-name/opencog/some-module/some-module.scm` .


3 To start using `(use-modules (opencog some-module))` for loading scheme code instead of having [this](https://github.com/AmeBel/opencog/blob/master/lib/development.conf#L114-L142). (Note: this doesn't address https://github.com/opencog/atomspace/issues/508)

**Solution Overivew**
1. Roses standardeized way of defining new packages was used as an example approach.
2. Directory structure for defining new scheme module have two options
  * `/repo-name/opencog/some-module/some-module.scm` imported by `(use-modules (opencog some-module ))`
  * `/repo-name/opencog/some-module/scm/some-module.scm` imported by `(use-modules (opencog some-module))`. 
  * `/repo-name/opencog/some-module/some-module/sub-module.scm` imported by `(use-modules (opencog some-module sub-module))`
  * `/repo-name/opencog/some-module/scm/some-module/sub-module.scm` imported by `(use-modules (opencog some-module sub-module))`. This approach is basically for cases where there are python/c++ modules. If the `sub-module` has a python/c++ code adding`scm` directory under it isn't supported, because we don't many levels deep of submodules.

3 During cmake  configuration stage, the files added as modules are,
  * symlinked in the build directory such that it would have the directory structure to allow import from the cogserver scheme-shell after running `(add-to-load-path "/path/to/build/directory/opencog/scm")` as if the they were installed.
  * configured for installation in the appropriate directory depending on their names

4 The relex2logic module have been used as an example case.

**If accepted then what?**
* Restructure the rest of the scheme modules in this and atomspace repo.
* Do the same for python modules.
* Document it on the wiki and add examples.



