### PR TITLE
Revert "Fix module paths"

### DIFF
--- a/lib/opencog.conf
+++ b/lib/opencog.conf
@@ -73,22 +73,22 @@ ANSI_ENABLED	       = true
 # Cogserver in OSX will automatically change .so extension to .dylib
 # if .so exists.
 MODULES               = opencog/cogserver/server/libbuiltinreqs.so,
-                        opencog/cogserver/modules/libPersistModule.so,
-                        opencog/cogserver/modules/libPersistZmqModule.so,
-                        opencog/cogserver/modules/libQueryModule.so,
+                        opencog/modules/libPersistModule.so,
+                        opencog/modules/libPersistZmqModule.so,
+                        opencog/modules/libQueryModule.so,
                         opencog/cogserver/shell/libscheme-shell.so,
                         opencog/cogserver/shell/libpy-shell.so,
                         opencog/nlp/types/libnlp-types.so,
-                        opencog/cogserver/modules/libLGDictModule.so,
-                        opencog/cogserver/modules/libSuRealModule.so,
+                        opencog/modules/libLGDictModule.so,
+                        opencog/modules/libSuRealModule.so,
                         opencog/learning/pln/libPLNTypes.so,
                         opencog/attention/libattention-types.so,
                         opencog/attention/libattention.so,
                         opencog/embodiment/libembodiment-types.so,
                         opencog/spacetime/libspacetime-types.so,
-                        opencog/cogserver/modules/python/libPythonModule.so,
-                        opencog/cogserver/modules/libRuleEngineModule.so,
-                        opencog/openpsi/libOpenPsi.so
+                        opencog/modules/python/libPythonModule.so,
+                        opencog/modules/libRuleEngineModule.so,
+                        opencog/dynamics/openpsi/libOpenPsi.so
 
 
 # Optional modules, not enabled by default


### PR DESCRIPTION
This reverts commit c583d64235dc6907209864174fd359693caf5f06.

These module paths are OK for running from build tree, but not correct for installed version.