### PR TITLE
Remove deprecated atomspace get_outgoing and get_incoming functions

### DIFF
--- a/opencog/attention/HebbianUpdatingAgent.cc
+++ b/opencog/attention/HebbianUpdatingAgent.cc
@@ -110,7 +110,7 @@ void HebbianUpdatingAgent::hebbianUpdatingUpdate()
 		bool isDifferent = false;
 
         // get out going set
-        HandleSeq outgoing = a->get_outgoing(h);
+        HandleSeq outgoing = h->getOutgoingSet();
         new_tc = targetConjunction(outgoing);
         // old link strength decays
         old_tc = h->getTruthValue()->getMean();

--- a/opencog/attention/ImportanceDiffusionAgent.cc
+++ b/opencog/attention/ImportanceDiffusionAgent.cc
@@ -152,7 +152,7 @@ int ImportanceDiffusionAgent::makeDiffusionAtomsMap(std::map<Handle,int> &diffus
             continue;
         }
 
-        targets = a->get_outgoing(linkHandle);
+        targets = linkHandle->getOutgoingSet();
 
         for (targetItr = targets.begin(); targetItr != targets.end();
                 ++targetItr) {
@@ -235,7 +235,7 @@ void ImportanceDiffusionAgent::makeConnectionMatrix(bmatrix* &connections_,
         //val *= diffuseTemperature;
         type = a->get_type(*hi); 
 
-        targets = a->get_outgoing(*hi);
+        targets = (*hi)->getOutgoingSet();
         if (classserver().isA(type,ORDERED_LINK)) {
             Handle sourceHandle;
 

--- a/opencog/attention/ImportanceSpreadingAgent.cc
+++ b/opencog/attention/ImportanceSpreadingAgent.cc
@@ -155,7 +155,7 @@ int ImportanceSpreadingAgent::sumDifference(Handle source, Handle link)
     // Get outgoing set and sum difference for all non source atoms
     linkWeight = a->get_TV(link)->toFloat();
     sourceSTI = a->get_STI(source);
-    targets = a->get_outgoing(link);
+    targets = link->getOutgoingSet();
 
     if (a->get_type(link) == INVERSE_HEBBIAN_LINK) {
         for (t = targets.begin(); t != targets.end(); ++t) {
@@ -230,7 +230,7 @@ void ImportanceSpreadingAgent::spreadAtomImportance(Handle h)
 
     log->fine("+Spreading importance for atom %s", a->atom_as_string(h, false).c_str());
 
-    linksVector = a->get_incoming(h);
+    h->getIncomingSet(back_inserter(linksVector));
     IsHebbianLink isHLPred(a);
     if (allLinksSpread) {
         log->fine("  +Spreading across all links. Found %d", linksVector.size());
@@ -271,7 +271,7 @@ void ImportanceSpreadingAgent::spreadAtomImportance(Handle h)
             continue;
         }
 
-        targets = a->get_outgoing(lh);
+        targets = lh->getOutgoingSet();
         transferWeight = linkTV->toFloat();
 
         log->fine("  +Link %s", a->atom_as_string(lh).c_str() );

--- a/opencog/attention/ImportanceUpdatingAgent.cc
+++ b/opencog/attention/ImportanceUpdatingAgent.cc
@@ -810,11 +810,11 @@ void ImportanceUpdatingAgent::updateRentAndWages(AtomSpace* a)
     if (wage.size() > 0) {
         // Given the PredicateNode, walk to the NumberNode
         Handle h = wage.front();
-        wage = a->get_incoming(h);
+        h->getIncomingSet(back_inserter(wage));
         h = wage.front();
-        wage = a->get_outgoing(h);
+        wage = h->getOutgoingSet();
         h = wage.back();
-        wage = a->get_outgoing(h);
+        wage = h->getOutgoingSet();
         h = wage.front();
         int value = std::stoi(a->get_name(h));
 
@@ -834,11 +834,11 @@ void ImportanceUpdatingAgent::updateRentAndWages(AtomSpace* a)
     if (rent.size() > 0) {
         // Given the PredicateNode, walk to the NumberNode
         Handle h = rent.front();
-        rent = a->get_incoming(h);
+        h->getIncomingSet(back_inserter(rent));
         h = rent.front();
-        rent = a->get_outgoing(h);
+        rent = h->getOutgoingSet();
         h = rent.back();
-        rent = a->get_outgoing(h);
+        rent = h->getOutgoingSet();
         h = rent.front();
         int value = std::stoi(a->get_name(h));
 

--- a/opencog/attention/SimpleHebbianUpdatingAgent.cc
+++ b/opencog/attention/SimpleHebbianUpdatingAgent.cc
@@ -56,7 +56,7 @@ void SimpleHebbianUpdatingAgent::hebbianUpdatingUpdate()
     // that into truthvalue change. the change should be based on existing TV.
     for (const Handle& h : links) {
         // get out going set
-        HandleSeq outgoing = a->get_outgoing(h);
+        HandleSeq outgoing = h->getOutgoingSet();
         new_tc = targetConjunction(outgoing);
 
         // old link strength decays

--- a/opencog/attention/SimpleImportanceDiffusionAgent.cc
+++ b/opencog/attention/SimpleImportanceDiffusionAgent.cc
@@ -98,11 +98,11 @@ void SimpleImportanceDiffusionAgent::updateMaxSpreadPercentage() {
     if (resultSet.size() > 0) {
         // Given the PredicateNode, walk to the NumberNode
         Handle h = resultSet.front();
-        resultSet = as->get_incoming(h);
+        h->getIncomingSet(back_inserter(resultSet));
         h = resultSet.front();
-        resultSet = as->get_outgoing(h);
+        resultSet = h->getOutgoingSet();
         h = resultSet.back();
-        resultSet = as->get_outgoing(h);
+        resultSet = h->getOutgoingSet();
         h = resultSet.front();
         float value = std::atof(as->get_name(h).c_str());
         setMaxSpreadPercentage(value);
@@ -398,10 +398,10 @@ HandleSeq SimpleImportanceDiffusionAgent::incidentAtoms(Handle h)
     HandleSeq resultSet;
     
     // Add the incoming set
-    resultSet = as->get_incoming(h);
+    h->getIncomingSet(back_inserter(resultSet));
     
     // Calculate and append the outgoing set
-    HandleSeq outgoing = as->get_outgoing(h);
+    HandleSeq outgoing = h->getOutgoingSet();
     resultSet.insert(resultSet.end(), outgoing.begin(), outgoing.end());
     
     return resultSet;

--- a/opencog/cogserver/modules/events/AtomSpacePublisherModule.cc
+++ b/opencog/cogserver/modules/events/AtomSpacePublisherModule.cc
@@ -300,14 +300,15 @@ Object AtomSpacePublisherModule::atomToJSON(Handle h)
     jsonTV = tvToJSON(tvp);
 
     // Incoming set
-    HandleSeq incomingHandles = as->get_incoming(h);
+    HandleSeq incomingHandles;
+    h->getIncomingSet(back_inserter(incomingHandles));
     Array incoming;
     for (uint i = 0; i < incomingHandles.size(); i++) {
         incoming.push_back(std::to_string(incomingHandles[i].value()));
     }
 
     // Outgoing set
-    HandleSeq outgoingHandles = as->get_outgoing(h);
+    HandleSeq outgoingHandles = h->getOutgoingSet();
     Array outgoing;
     for (uint i = 0; i < outgoingHandles.size(); i++) {
         outgoing.push_back(std::to_string(outgoingHandles[i].value()));

--- a/opencog/learning/PatternMiner/PatternMiner.cc
+++ b/opencog/learning/PatternMiner/PatternMiner.cc
@@ -52,7 +52,7 @@ const string PatternMiner::ignoreKeyWords[] = {"this", "that","these","those","i
 
 void PatternMiner::generateIndexesOfSharedVars(Handle& link, vector<Handle>& orderedHandles, vector < vector<int> >& indexes)
 {
-    HandleSeq outgoingLinks = atomSpace->get_outgoing(link);
+    HandleSeq outgoingLinks = link->getOutgoingSet();
     for (Handle h : outgoingLinks)
     {
         if (atomSpace->is_node(h))
@@ -86,7 +86,7 @@ void PatternMiner::generateIndexesOfSharedVars(Handle& link, vector<Handle>& ord
 void PatternMiner::findAndRenameVariablesForOneLink(Handle link, map<Handle,Handle>& varNameMap, HandleSeq& renameOutgoingLinks)
 {
 
-    HandleSeq outgoingLinks = atomSpace->get_outgoing(link);
+    HandleSeq outgoingLinks = link->getOutgoingSet();
 
     for (Handle h : outgoingLinks)
     {
@@ -357,7 +357,7 @@ unsigned int combinationCalculate(int r, int n)
  // valueToVarMap:  the ground value node in the orginal Atomspace to the variable handle in pattenmining Atomspace
 void PatternMiner::generateALinkByChosenVariables(Handle& originalLink, map<Handle,Handle>& valueToVarMap,  HandleSeq& outputOutgoings,AtomSpace *_fromAtomSpace)
 {
-    HandleSeq outgoingLinks = _fromAtomSpace->get_outgoing(originalLink);
+    HandleSeq outgoingLinks = originalLink->getOutgoingSet();
 
     for (Handle h : outgoingLinks)
     {
@@ -393,7 +393,7 @@ void PatternMiner::generateALinkByChosenVariables(Handle& originalLink, map<Hand
 // _fromAtomSpace: where is input link from
 void PatternMiner::extractAllNodesInLink(Handle link, map<Handle,Handle>& valueToVarMap, AtomSpace* _fromAtomSpace)
 {
-    HandleSeq outgoingLinks = _fromAtomSpace->get_outgoing(link);
+    HandleSeq outgoingLinks = link->getOutgoingSet();
 
     for (Handle h : outgoingLinks)
     {
@@ -420,8 +420,8 @@ void PatternMiner::extractAllNodesInLink(Handle link, map<Handle,Handle>& valueT
 void PatternMiner::extractAllVariableNodesInAnInstanceLink(Handle& instanceLink, Handle& patternLink, set<Handle>& allVarNodes)
 {
 
-    HandleSeq ioutgoingLinks = originalAtomSpace->get_outgoing(instanceLink);
-    HandleSeq poutgoingLinks = atomSpace->get_outgoing(patternLink);
+    HandleSeq ioutgoingLinks = instanceLink->getOutgoingSet();
+    HandleSeq poutgoingLinks = patternLink->getOutgoingSet();
 
     HandleSeq::iterator pit = poutgoingLinks.begin();
 
@@ -451,8 +451,8 @@ void PatternMiner::extractAllVariableNodesInAnInstanceLink(Handle& instanceLink,
 void PatternMiner::extractAllVariableNodesInAnInstanceLink(Handle& instanceLink, Handle& patternLink, map<Handle, unsigned int>& allVarNodes, unsigned index)
 {
 
-    HandleSeq ioutgoingLinks = originalAtomSpace->get_outgoing(instanceLink);
-    HandleSeq poutgoingLinks = atomSpace->get_outgoing(patternLink);
+    HandleSeq ioutgoingLinks = instanceLink->getOutgoingSet();
+    HandleSeq poutgoingLinks = patternLink->getOutgoingSet();
 
     HandleSeq::iterator pit = poutgoingLinks.begin();
 
@@ -481,7 +481,7 @@ void PatternMiner::extractAllVariableNodesInAnInstanceLink(Handle& instanceLink,
 // map<Handle, unsigned> allNodes  , unsigned is the index the first link this node belongs to
 void PatternMiner::extractAllNodesInLink(Handle link, map<Handle, unsigned int>& allNodes, AtomSpace* _fromAtomSpace, unsigned index)
 {
-    HandleSeq outgoingLinks = _fromAtomSpace->get_outgoing(link);
+    HandleSeq outgoingLinks = link->getOutgoingSet();
 
     for (Handle h : outgoingLinks)
     {
@@ -501,7 +501,7 @@ void PatternMiner::extractAllNodesInLink(Handle link, map<Handle, unsigned int>&
 
 void PatternMiner::extractAllNodesInLink(Handle link, set<Handle>& allNodes, AtomSpace* _fromAtomSpace)
 {
-    HandleSeq outgoingLinks = _fromAtomSpace->get_outgoing(link);
+    HandleSeq outgoingLinks = link->getOutgoingSet();
 
     for (Handle h : outgoingLinks)
     {
@@ -521,7 +521,7 @@ void PatternMiner::extractAllNodesInLink(Handle link, set<Handle>& allNodes, Ato
 
 void PatternMiner::extractAllVariableNodesInLink(Handle link, set<Handle>& allNodes, AtomSpace* _atomSpace)
 {
-    HandleSeq outgoingLinks = _atomSpace->get_outgoing(link);
+    HandleSeq outgoingLinks = link->getOutgoingSet();
 
     for (Handle h : outgoingLinks)
     {
@@ -541,7 +541,7 @@ void PatternMiner::extractAllVariableNodesInLink(Handle link, set<Handle>& allNo
 
 bool PatternMiner::onlyContainVariableNodes(Handle link, AtomSpace* _atomSpace)
 {
-    HandleSeq outgoingLinks = _atomSpace->get_outgoing(link);
+    HandleSeq outgoingLinks = link->getOutgoingSet();
 
     for (Handle h : outgoingLinks)
     {
@@ -568,7 +568,7 @@ bool PatternMiner::onlyContainVariableNodes(Handle link, AtomSpace* _atomSpace)
 void PatternMiner::swapOneLinkBetweenTwoAtomSpace(AtomSpace* fromAtomSpace, AtomSpace* toAtomSpace, Handle& fromLink, HandleSeq& outgoings,
                                                   HandleSeq &outVariableNodes )
 {
-    HandleSeq outgoingLinks = fromAtomSpace->get_outgoing(fromLink);
+    HandleSeq outgoingLinks = fromLink->getOutgoingSet();
 
     for (Handle h : outgoingLinks)
     {
@@ -698,7 +698,7 @@ void PatternMiner::findAllInstancesForGivenPatternInNestedAtomSpace(HTreeNode* H
 
     // Get result
     // Note: Don't forget to remove the hResultListLink and BindLink
-    HandleSeq resultSet = atomSpace->get_outgoing(hResultListLink);
+    HandleSeq resultSet = hResultListLink->getOutgoingSet();
 
 //     std::cout << toString(resultSet.size())  << " instances found!" << std::endl ;
 
@@ -709,7 +709,7 @@ void PatternMiner::findAllInstancesForGivenPatternInNestedAtomSpace(HTreeNode* H
 
     for (Handle listH  : resultSet)
     {
-        HandleSeq instanceLinks = atomSpace->get_outgoing(listH);
+        HandleSeq instanceLinks = listH->getOutgoingSet();
 
         if (cur_gram == 1)
         {
@@ -742,7 +742,7 @@ void PatternMiner::removeLinkAndItsAllSubLinks(AtomSpace* _atomspace, Handle lin
 //    //debug
 //    std::cout << "Remove atom: " << _atomspace->atom_as_string(link) << std::endl;
 
-    HandleSeq Outgoings = _atomspace->get_outgoing(link);
+    HandleSeq Outgoings = link->getOutgoingSet();
     for (Handle h : Outgoings)
     {
         if (_atomspace->is_link(h))
@@ -810,7 +810,8 @@ Handle PatternMiner::getFirstNonIgnoredIncomingLink(AtomSpace *atomspace, Handle
     Handle cur_h = handle;
     while(true)
     {
-        HandleSeq incomings = atomspace->get_incoming(cur_h);
+        HandleSeq incomings;
+        cur_h->getIncomingSet(back_inserter(incomings));
         if (incomings.size() == 0)
             return Handle::UNDEFINED;
 
@@ -1335,7 +1336,7 @@ bool PatternMiner::filters(HandleSeq& inputLinks, HandleSeqSeq& oneOfEachSeqShou
             // filter: Any two InheritanceLinks should not share their secondary outgoing nodes
             if (_atomSpace->get_type(inputLinks[i]) == INHERITANCE_LINK)
             {
-                Handle secondOutgoing = _atomSpace->get_outgoing(inputLinks[i], 1);
+                Handle secondOutgoing = inputLinks[i]->getOutgoingSet()[1];
                 if (all2ndOutgoingsOfInherlinks.find(secondOutgoing) == all2ndOutgoingsOfInherlinks.end())
                     all2ndOutgoingsOfInherlinks.insert(secondOutgoing);
                 else
@@ -1348,11 +1349,11 @@ bool PatternMiner::filters(HandleSeq& inputLinks, HandleSeqSeq& oneOfEachSeqShou
             // this filter: Any two EvaluationLinks with the same predicate should not share the same secondary outgoing nodes
             if (_atomSpace->get_type(inputLinks[i]) == EVALUATION_LINK)
             {
-                HandleSeq outgoings = _atomSpace->get_outgoing(inputLinks[i]);
+                HandleSeq outgoings = inputLinks[i]->getOutgoingSet();
                 Handle predicateNode = outgoings[0];
 
                 // value node is the last node of the list link
-                HandleSeq outgoings2 = _atomSpace->get_outgoing(outgoings[1]);
+                HandleSeq outgoings2 = outgoings[1]->getOutgoingSet();
                 Handle valueNode = outgoings2[outgoings2.size() - 1];
 
                 if (enable_filter_not_same_var_from_same_predicate)
@@ -1867,8 +1868,8 @@ bool PatternMiner::isALinkOneInstanceOfGivenPattern(Handle &instanceLink, Handle
     if (instanceLinkAtomSpace->get_type(instanceLink) != atomSpace->get_type(patternLink))
         return false;
 
-    HandleSeq outComingsOfPattern = atomSpace->get_outgoing(patternLink);
-    HandleSeq outComingsOfInstance = instanceLinkAtomSpace->get_outgoing(instanceLink);
+    HandleSeq outComingsOfPattern = patternLink->getOutgoingSet();
+    HandleSeq outComingsOfInstance = instanceLink->getOutgoingSet();
 
     if (outComingsOfPattern.size() != outComingsOfInstance.size())
         return false;
@@ -1913,7 +1914,7 @@ bool PatternMiner::isALinkOneInstanceOfGivenPattern(Handle &instanceLink, Handle
 void PatternMiner::reNameNodesForALink(Handle& inputLink, Handle& nodeToBeRenamed, Handle& newNamedNode,HandleSeq& renameOutgoingLinks,
                                        AtomSpace* _fromAtomSpace, AtomSpace* _toAtomSpace)
 {
-    HandleSeq outgoingLinks = _fromAtomSpace->get_outgoing(inputLink);
+    HandleSeq outgoingLinks = inputLink->getOutgoingSet();
 
     for (Handle h : outgoingLinks)
     {
@@ -1949,7 +1950,8 @@ void PatternMiner::reNameNodesForALink(Handle& inputLink, Handle& nodeToBeRename
 void PatternMiner::getOneMoreGramExtendedLinksFromGivenLeaf(Handle& toBeExtendedLink, Handle& leaf, Handle& varNode,
                                                             HandleSeq& outPutExtendedPatternLinks, AtomSpace* _fromAtomSpace)
 {
-    HandleSeq incomings = _fromAtomSpace->get_incoming(leaf);
+    HandleSeq incomings;
+    leaf->getIncomingSet(back_inserter(incomings));
 
     for (Handle incomingHandle : incomings)
     {
@@ -2563,7 +2565,7 @@ std::string PatternMiner::Link2keyString(Handle& h, std::string indent, const At
 
     if (atomspace->is_link(h))
     {
-        HandleSeq outgoings = atomspace->get_outgoing(h);
+        HandleSeq outgoings = h->getOutgoingSet();
         for (Handle outgoing : outgoings)
             answer << Link2keyString(outgoing, more_indent, atomspace);
     }
@@ -2688,7 +2690,7 @@ void PatternMiner::testPatternMatcher1()
 
     // Get result
     // Note: Don't forget to remove the hResultListLink and BindLink
-    HandleSeq resultSet = originalAtomSpace->get_outgoing(hResultListLink);
+    HandleSeq resultSet = hResultListLink->getOutgoingSet();
 
     std::cout << toString(resultSet.size())  << " instances found:" << std::endl ;
 
@@ -2826,7 +2828,7 @@ void PatternMiner::testPatternMatcher2()
 
     // Get result
     // Note: Don't forget to remove the hResultListLink and BindLink
-    HandleSeq resultSet = originalAtomSpace->get_outgoing(hResultListLink);
+    HandleSeq resultSet = hResultListLink->getOutgoingSet();
 
     std::cout << toString(resultSet.size())  << " instances found:" << std::endl ;
 
@@ -2842,7 +2844,8 @@ void PatternMiner::testPatternMatcher2()
 set<Handle> PatternMiner::_getAllNonIgnoredLinksForGivenNode(Handle keywordNode, set<Handle>& allSubsetLinks)
 {
     set<Handle> newHandles;
-    HandleSeq incomings = originalAtomSpace->get_incoming(keywordNode);
+    HandleSeq incomings;
+    keywordNode->getIncomingSet(back_inserter(incomings));
 
     for (Handle incomingHandle : incomings)
     {

--- a/opencog/learning/PatternMiner/PatternMinerBF.cc
+++ b/opencog/learning/PatternMiner/PatternMinerBF.cc
@@ -78,7 +78,9 @@ void PatternMiner::extendAllPossiblePatternsForOneMoreGramBF(HandleSeq &instance
     for(varIt = allVarNodes.begin(); varIt != allVarNodes.end(); ++ varIt)
     {
         // find what are the other links in the original Atomspace contain this variable
-        HandleSeq incomings = originalAtomSpace->get_incoming( ((Handle)(*varIt)));
+        HandleSeq incomings;
+        ((Handle)(*varIt))->getIncomingSet(back_inserter(incomings));
+
         // debug
         string curvarstr = originalAtomSpace->atom_as_string((Handle)(*varIt));
 
@@ -568,7 +570,7 @@ void PatternMiner::swapOneLinkBetweenTwoAtomSpaceBF(AtomSpace* fromAtomSpace, At
                                                   HandleSeq &outVariableNodes, HandleSeq& linksWillBeDel, bool& containVar )
 {
     containVar = false;
-    HandleSeq outgoingLinks = fromAtomSpace->get_outgoing(fromLink);
+    HandleSeq outgoingLinks = fromLink->getOutgoingSet();
 
     for (Handle h : outgoingLinks)
     {
@@ -687,7 +689,7 @@ void PatternMiner::findAllInstancesForGivenPatternBF(HTreeNode* HNode)
 
    // Get result
    // Note: Don't forget to remove the hResultListLink and BindLink
-   HandleSeq resultSet = originalAtomSpace->get_outgoing(hResultListLink);
+   HandleSeq resultSet = hResultListLink->getOutgoingSet();
 
 //     std::cout << toString(resultSet.size())  << " instances found!" << std::endl ;
 
@@ -696,7 +698,7 @@ void PatternMiner::findAllInstancesForGivenPatternBF(HTreeNode* HNode)
 
    for (Handle listH  : resultSet)
    {
-       HandleSeq instanceLinks = originalAtomSpace->get_outgoing(listH);
+       HandleSeq instanceLinks = listH->getOutgoingSet();
 
        if (cur_gram == 1)
        {

--- a/opencog/learning/PatternMiner/PatternMinerDF.cc
+++ b/opencog/learning/PatternMiner/PatternMinerDF.cc
@@ -769,7 +769,8 @@ void PatternMiner::extendAPatternForOneMoreGramRecursively(const Handle &extende
                     }
 
                     // find what are the other links in the original Atomspace contain this variable
-                    HandleSeq incomings = _fromAtomSpace->get_incoming( (extendNode));
+                    HandleSeq incomings;
+                    extendNode->getIncomingSet(back_inserter(incomings));
 
                     // debug
                     // string curvarstr = _fromAtomSpace->atomAsString(extendNode);
@@ -883,7 +884,9 @@ void PatternMiner::extendAllPossiblePatternsForOneMoreGramDF(HandleSeq &instance
         }
 
         // find what are the other links in the original Atomspace contain this variable
-        HandleSeq incomings = _fromAtomSpace->get_incoming( (extendNode));
+        HandleSeq incomings;
+        extendNode->getIncomingSet(back_inserter(incomings));
+
         // debug
         // string curvarstr = _fromAtomSpace->atomAsString((Handle)(*varIt));
 

--- a/opencog/learning/dimensionalembedding/DimEmbedModule.cc
+++ b/opencog/learning/dimensionalembedding/DimEmbedModule.cc
@@ -260,12 +260,13 @@ void DimEmbedModule::addPivot(Handle h, Type linkType, bool fanin)
         pQueue.erase(--erase_it);
 
         if (distMap[u]==0) { break;}
-        HandleSeq newLinks = as->get_incoming(u);
+        HandleSeq newLinks;
+        u->getIncomingSet(back_inserter(newLinks));
         for (HandleSeq::iterator it=newLinks.begin(); it!=newLinks.end(); ++it){
             //ignore links that aren't a subtype of linkType
             if (!classserver().isA(as->get_type(*it),linkType)) continue;
             TruthValuePtr linkTV = as->get_TV(*it);
-            HandleSeq newNodes = as->get_outgoing(*it);
+            HandleSeq newNodes = (*it)->getOutgoingSet();
             HandleSeq::iterator it2=newNodes.begin();
             //if !fanin, we're following the "outward" links, so it's only a
             //valid link if u is the source

--- a/opencog/python/blending/src/connector/connect_conflict_interaction_information.py
+++ b/opencog/python/blending/src/connector/connect_conflict_interaction_information.py
@@ -343,7 +343,7 @@ class ConnectConflictInteractionInformation(BaseConnector):
         # Make the links between source nodes and newly blended node.
         # TODO: Give proper truth value, not average of truthvalue.
         for merged_atom in self.ret:
-            weighted_tv = get_weighted_tv(self.a.get_incoming(merged_atom.h))
+            weighted_tv = get_weighted_tv(merged_atom.incoming)
             for decided_atom in decided_atoms:
                 self.a.add_link(
                     types.AssociativeLink,

--- a/opencog/python/blending/src/connector/connect_conflict_random.py
+++ b/opencog/python/blending/src/connector/connect_conflict_random.py
@@ -89,7 +89,7 @@ class ConnectConflictRandom(BaseConnector):
         # Make the links between source nodes and newly blended node.
         # TODO: Give proper truth value, not average of truthvalue.
         for merged_atom in self.ret:
-            weighted_tv = get_weighted_tv(self.a.get_incoming(merged_atom.h))
+            weighted_tv = get_weighted_tv(merged_atom.incoming)
             for decided_atom in decided_atoms:
                 self.a.add_link(
                     types.AssociativeLink,

--- a/opencog/python/blending/src/connector/connect_conflict_viable.py
+++ b/opencog/python/blending/src/connector/connect_conflict_viable.py
@@ -116,7 +116,7 @@ class ConnectConflictAllViable(BaseConnector):
         # Make the links between source nodes and newly blended node.
         # TODO: Give proper truth value, not average of truthvalue.
         for merged_atom in self.ret:
-            weighted_tv = get_weighted_tv(self.a.get_incoming(merged_atom.h))
+            weighted_tv = get_weighted_tv(merged_atom.incoming)
             for decided_atom in decided_atoms:
                 self.a.add_link(
                     types.AssociativeLink,

--- a/opencog/python/blending/src/connector/connect_simple.py
+++ b/opencog/python/blending/src/connector/connect_simple.py
@@ -56,7 +56,7 @@ class ConnectSimple(BaseConnector):
         # Make the links between source nodes and newly blended node.
         # TODO: Give proper truth value, not average of truthvalue.
         for merged_atom in self.ret:
-            weighted_tv = get_weighted_tv(self.a.get_incoming(merged_atom.h))
+            weighted_tv = get_weighted_tv(merged_atom.incoming)
             for decided_atom in decided_atoms:
                 self.a.add_link(
                     types.AssociativeLink,

--- a/opencog/python/conceptnet/writer.py
+++ b/opencog/python/conceptnet/writer.py
@@ -29,7 +29,7 @@ class ConceptNetWriter:
 
     def __write_py_file(self, output_atom, pre_space):
         if output_atom.is_link():
-            outgoing = self.a.get_outgoing(output_atom.h)
+            outgoing = output_atom.out
             self.__write_space(pre_space)
             self.output_file.write(
                 'a.add_link(\n'
@@ -79,7 +79,7 @@ class ConceptNetWriter:
     # This is more beautiful than above, but can't load in python file...
     def __write_py_beautiful_file(self, output_atom, pre_space):
         if output_atom.is_link():
-            outgoing = self.a.get_outgoing(output_atom.h)
+            outgoing = output_atom.out
             self.__write_space(pre_space)
             self.output_file.write(
                 '%s(\n' % output_atom.type_name

--- a/opencog/python/monitor_changes.py
+++ b/opencog/python/monitor_changes.py
@@ -35,8 +35,8 @@ def monitor_changes(atomspace):
 
     for latest in at_times_latest:
         for previous in at_times_previous:
-            eval_latest = atomspace.get_outgoing(latest.h)[1]
-            eval_previous = atomspace.get_outgoing(previous.h)[1]
+            eval_latest = latest.out[1]
+            eval_previous = previous.out[1]
             if eval_latest.t != t.EvaluationLink or eval_previous.t != t.EvaluationLink: 
                 continue
 
@@ -53,13 +53,13 @@ def monitor_changes(atomspace):
 
     old_changes_with_tv = pred_change_with_tv.incoming_by_type(t.ReferenceLink, subtype = False)
     for old_change_with_tv in old_changes_with_tv:
-        list_link = atomspace.get_outgoing(old_change_with_tv.h)[1]
+        list_link = old_change_with_tv.out[1]
         atomspace.remove(old_change_with_tv, recursive = False)
         atomspace.remove(list_link, recursive = False)
 
     old_changes_with_arg = pred_change_with_arg.incoming_by_type(t.ReferenceLink, subtype = False)
     for old_change_with_arg in old_changes_with_arg:
-        list_link = atomspace.get_outgoing(old_change_with_arg.h)[1]
+        list_link = old_change_with_arg.out[1]
         atomspace.remove(old_change_with_arg, recursive = False)
         atomspace.remove(list_link, recursive = False)
 

--- a/opencog/python/pln_old/examples/attentionallocation/socrates_attention_agent.py
+++ b/opencog/python/pln_old/examples/attentionallocation/socrates_attention_agent.py
@@ -58,7 +58,7 @@ def check_result(atomspace):
     eval_links = atomspace.get_atoms_by_type(types.EvaluationLink)
 
     for eval_link in eval_links:
-        out = atomspace.get_outgoing(eval_link.h)
+        out = eval_link.out
         if out[0].is_a(types.PredicateNode) and "breathe" in out[0].name\
             and out[1].is_a(types.ListLink)\
             and "Socrates" in out[1].out[0].name\

--- a/opencog/python/pln_old/examples/backward_chaining/backward_agent.py
+++ b/opencog/python/pln_old/examples/backward_chaining/backward_agent.py
@@ -43,7 +43,7 @@ def check_result(atomspace):
     result_found = False
 
     for inh_link in inh_links:
-        args = atomspace.get_outgoing(inh_link.h)
+        args = inh_link.out
         if args[0].is_a(types.ConceptNode) and args[1].name == "criminal":
             criminal = args[0].name
             evidence = inh_link

--- a/opencog/python/pln_old/examples/tuffy/class/class_agent.py
+++ b/opencog/python/pln_old/examples/tuffy/class/class_agent.py
@@ -39,8 +39,7 @@ class InferenceAgent(MindAgent):
 
             implications = atomspace.get_atoms_by_type(types.ImplicationLink)
             for implication in implications:
-                outgoing = atomspace.get_outgoing(implication.h)
-                and_link = outgoing[0]
+                and_link = implication.out[0]
                 self.antecedents.append(and_link)
 
             return
@@ -54,7 +53,7 @@ class InferenceAgent(MindAgent):
         # of the antecedents of the defined "domain rules" so as to
         # successfully ground the variables.
         for antecedent in self.antecedents:
-            num_predicates = len(atomspace.get_outgoing(antecedent.h))
+            num_predicates = len(antecedent.out)
             self.chainer.backward_step(
                 AndCreationRule(self.chainer, num_predicates), [antecedent])
 

--- a/opencog/python/pln_old/examples/tuffy/smokes/smokes_agent.py
+++ b/opencog/python/pln_old/examples/tuffy/smokes/smokes_agent.py
@@ -96,10 +96,10 @@ class InferenceAgent(MindAgent):
                     types.PredicateNode, "CONFIG-StimulusAmount")
                 if list is not None:
                     # Given the PredicateNode, walk to the NumberNode
-                    list = atomspace.get_incoming(list[0].h)  # EvaluationLink
-                    list = atomspace.get_outgoing(list[0].h)  # ListLink
-                    list = atomspace.get_outgoing(list[1].h)  # NumberNode
-                    value = atomspace.get_name(list[0].h)
+                    list = list[0].incoming  # EvaluationLink
+                    list = list[0].out  # ListLink
+                    list = list[1].out  # NumberNode
+                    value = list[0].name
                     TARGET_STIMULUS = int(value)
                     print "Target stimulus amount updated to {0}".\
                         format(TARGET_STIMULUS)
@@ -120,11 +120,11 @@ def check_result(atomspace):
 
     num_results = 0
     for eval_link in eval_links:
-        out = [atom for atom in atomspace.get_outgoing(eval_link.h)
+        out = [atom for atom in eval_link.out
                if atom.is_a(types.PredicateNode) and atom.name == "cancer"]
         if out:
-            list_link = atomspace.get_outgoing(eval_link.h)[1]
-            argument = atomspace.get_outgoing(list_link.h)[0]
+            list_link = eval_link.out[1]
+            argument = list_link.out[0]
             if argument.is_a(types.ConceptNode):
                 num_results += 1
 

--- a/opencog/python/pln_old/rules/direct_evaluation_rules.py
+++ b/opencog/python/pln_old/rules/direct_evaluation_rules.py
@@ -357,10 +357,8 @@ class GeneralEvaluationToMemberRule(Rule):
 
         if arg.type == types.ListLink:
             for i in arg.out:
-                # The arg.out is a list that must not be changed. If arg.out is
-                # used instead of the returned value of atomspace's get_outgoing
-                # method then the changes made to arg.out are permanent.
-                list_arg = self.chainer.atomspace.get_outgoing(arg.h)
+                # Make a copy so we don't change arg.out while iterating.
+                list_arg = arg.out
                 first_iter = True
 
                 for j in variables:

--- a/opencog/spacetime/SpaceServer.cc
+++ b/opencog/spacetime/SpaceServer.cc
@@ -313,7 +313,7 @@ std::string SpaceServer::getMapIdString(Handle mapHandle) const
 {
     // Currently the mapHandle is of AtTimeLink(TimeNode:"<timestamp>" , ConceptNode:"SpaceMap")
     // So, just get the name of the TimeNode as its string representation
-    // return atomspace->get_name(atomspace->get_outgoing(mapHandle, 0))->get_result();
+    // return atomspace->get_name(mapHandle->getOutgoingSet()[0])->get_result();
 
     return atomspace->get_name(mapHandle);
 }

--- a/opencog/visualization/tulip/TulipWriter.cc
+++ b/opencog/visualization/tulip/TulipWriter.cc
@@ -75,7 +75,7 @@ void TulipWriter::writeCluster(Handle setLink)
     // Output setLink as a cluster
     std::set<Handle> inSet;
     if (setLink != Handle::UNDEFINED) {
-        HandleSeq setLinks = a.get_outgoing(setLink);
+        HandleSeq setLinks = setLink->getOutgoingSet();
         for (Handle h : setLinks) {
             inSet.insert(h);
         }
@@ -123,7 +123,7 @@ void TulipWriter::writeEdges()
     // Output Edge numbers/ids, source, and target
     for (Handle l : linkHandles) {
         // get outgoing set, for each destination add a link
-        HandleSeq out = a.get_outgoing(l);
+        HandleSeq out = l->getOutgoingSet();
         for (Handle d : out) {
             myfile << "(edge " << l << d << " " << l << " " << d;
             myfile << ")" << endl;
@@ -193,7 +193,7 @@ void TulipWriter::writeTruthValue()
     myfile << "(default \"0.0\" \"0.0\" )" << endl;
     for (Handle h : linkHandles) {
         // get outgoing set, for each destination add a link
-        HandleSeq out = a.get_outgoing(h);
+        HandleSeq out = h->getOutgoingSet();
         for (const Handle& d : out) {
             myfile << "(edge " << h << d << " \"" << 1.0 /
               (h->getTruthValue()->getMean()+0.0000001) << "\")" << endl;

--- a/tests/cython/spacetime/test_spaceserver.py
+++ b/tests/cython/spacetime/test_spaceserver.py
@@ -15,7 +15,7 @@ class TestSpaceServer:
 
     def test_addMap(self):
         map_atom = self.space_server.add_map(123456, "testmap", 1)
-        assert self._atomspace.get_name(map_atom) == "testmap"
+        assert map_atom.name == "testmap"
     
     def test_getMap(self):
         map_atom = self.space_server.add_map(123456, "testmap", 1)

--- a/tests/cython/spacetime/test_timeserver.py
+++ b/tests/cython/spacetime/test_timeserver.py
@@ -16,4 +16,4 @@ class TestTimeServer:
     def test_addTimeInfo(self):
         objnode = self._atomspace.add_node(types.StructureNode, "object111")
         at_time_link = self._timeserver.add_time_info(objnode, 123456)
-        assert objnode in self._atomspace.get_outgoing(at_time_link)
+        assert objnode in at_time_link.out

--- a/tests/spatial/TimeServerUTest.cxxtest
+++ b/tests/spatial/TimeServerUTest.cxxtest
@@ -1261,8 +1261,8 @@ public:
         Handle atTimeLink = timeServer().addTimeInfo(node1, 1000);
         TS_ASSERT(atTimeLink != Handle::UNDEFINED);
         Handle timeNode = atomSpace.get_handle(TIME_NODE, Temporal::getTimeNodeName(1000));
-        TS_ASSERT(atomSpace.get_outgoing(atTimeLink, 0) == timeNode);
-        TS_ASSERT(atomSpace.get_outgoing(atTimeLink, 1) == node1);
+        TS_ASSERT(atTimeLink->getOutgoingSet()[0] == timeNode);
+        TS_ASSERT(atTimeLink->getOutgoingSet()[1] == node1);
         vector<HandleTemporalPair> res;
         timeServer().getTimeInfo(back_inserter(res), node1);
         TS_ASSERT(res.size() == 1);
@@ -1274,8 +1274,8 @@ public:
         atTimeLink = timeServer().addTimeInfo(node1, t2);
         TS_ASSERT(atTimeLink != Handle::UNDEFINED);
         timeNode = atomSpace.get_handle(TIME_NODE, t2.getTimeNodeName());
-        TS_ASSERT(atomSpace.get_outgoing(atTimeLink, 0) == timeNode);
-        TS_ASSERT(atomSpace.get_outgoing(atTimeLink, 1) == node1);
+        TS_ASSERT(atTimeLink->getOutgoingSet()[0] == timeNode);
+        TS_ASSERT(atTimeLink->getOutgoingSet()[1] == node1);
         res.clear();
         timeServer().getTimeInfo(back_inserter(res), node1);
         TS_ASSERT(res.size() == 2);


### PR DESCRIPTION
Note: this should be merged shortly after https://github.com/opencog/atomspace/pull/610 is merged. The CI tests won't pass until the corresponding opencog/atomspace changes are merged.