### PR TITLE
Fix "text file busy" error of Docker image building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get -y install software-properties-common wget rlwrap \
 # Use the ocpkg tool to install repositories and dependencies.
 ADD https://raw.githubusercontent.com/opencog/ocpkg/master/ocpkg \
     /tmp/octool
-RUN chmod 755 /tmp/octool && /tmp/octool -rdpcalv
+RUN chmod 755 /tmp/octool && sleep 1 && /tmp/octool -rdpcalv
 
 # Environment Variables
 ## Set Locale


### PR DESCRIPTION
It's probably [a Docker issue.](https://github.com/docker/docker/issues/9547)

When I try to build image, I get this error:

```
Step 7 : RUN chmod 755 /tmp/octool && /tmp/octool -rdpcalv
 ---> Running in 5a0d0fb045d4
/bin/sh: 1: /tmp/octool: Text file busy
The command '/bin/sh -c chmod 755 /tmp/octool && /tmp/octool -rdpcalv' returned a non-zero code: 2
```

[Workaround](https://github.com/docker/docker/issues/9547#issuecomment-75893101) is that putting "sleep 1" between chmod and execution of script. It's installing in my computer now.