### PR TITLE
Add more GIL locks

### DIFF
--- a/opencog/cogserver/modules/python/PythonModule.cc
+++ b/opencog/cogserver/modules/python/PythonModule.cc
@@ -50,15 +50,25 @@ DECLARE_MODULE(PythonModule);
 
 Agent* PythonAgentFactory::create(CogServer& cs) const
 {
+    PyGILState_STATE gstate;
+    gstate = PyGILState_Ensure();
+
     logger().info() << "Creating python agent " << _pySrcModuleName << "." << _pyClassName;
     PyMindAgent* pma = new PyMindAgent(cs, _pySrcModuleName, _pyClassName);
+
+    PyGILState_Release(gstate);
     return pma;
 }
 
 Request* PythonRequestFactory::create(CogServer& cs) const
 {
+    PyGILState_STATE gstate;
+    gstate = PyGILState_Ensure();
+
     logger().info() << "Creating python request " << _pySrcModuleName << "." << _pyClassName;
     PyRequest* pma = new PyRequest(cs, _pySrcModuleName, _pyClassName, _cci);
+
+    PyGILState_Release(gstate);
     return pma;
 }
 


### PR DESCRIPTION
continueing fallout from bug opencog/atomspace#671.  That single line-of-code change,  using  PyEval_SaveThread(); instead of PyEval_ReleaseLock()  has uncovered several locations where the GIL was needed and was missing.