### PR TITLE
Fix R2L passive rule

### DIFF
--- a/opencog/nlp/relex2logic/rules/passive.scm
+++ b/opencog/nlp/relex2logic/rules/passive.scm
@@ -17,7 +17,7 @@
 		(AndLink
 			(word-in-parse "$verb" "$a-parse")
 			(word-in-parse "$obj" "$a-parse")
-			(InheritanceLink
+			(TenseLink
 				(VariableNode "$verb")
 				(VariableNode "$tense")
 			)

--- a/opencog/nlp/relex2logic/rules/passive.scm
+++ b/opencog/nlp/relex2logic/rules/passive.scm
@@ -11,6 +11,8 @@
 		(VariableList
 			(var-decl "$a-parse" "ParseNode")
 			(var-decl "$tense" "DefinedLinguisticConceptNode")
+			(var-decl "$verb" "WordInstanceNode")
+			(var-decl "$obj" "WordInstanceNode")
 		)
 		(AndLink
 			(word-in-parse "$verb" "$a-parse")


### PR DESCRIPTION
It is broken as it always gives me this error when executing:
```
ERROR: In procedure opencog-extension:
ERROR: Throw to key `C++-EXCEPTION' with args `("cog-bind" "Not expecting a virtual link here! (/atomspace/opencog/query/PatternMatch.cc:69)")'.
```

I've added the var-decl for the variables in the rule, and also updated it to match TenseLink instead of the InheritanceLink to make it to work, as TenseLink is the one generated by RelEx