### PR TITLE
Fix definite-rule, do not generate an empty ListLink

### DIFF
--- a/opencog/nlp/relex2logic/rule-helpers.scm
+++ b/opencog/nlp/relex2logic/rule-helpers.scm
@@ -657,8 +657,7 @@
 	; Names of things (AN links) will get concatenated by Relex,
 	; leaving some of the words that make up the name without a lemma.
 	; Ignore those.
-	(if (equal? "" word)
-		(ListLink)
+	(if (not (equal? "" word))
 		(ListLink
 			(Inheritance (Concept word_instance) (Concept word))
 			(r2l-wordinst-concept word_instance)


### PR DESCRIPTION
I got this error:
```
ERROR: In procedure cog-type:
ERROR: In procedure cog-type: Wrong type argument in position 1 (expecting opencog atom): #<Invalid handle>
```
when doing `(nlp-parse "His guide runner for the two races was Joaquin de la Vega.")`

The problem is that `definite-rule` generates an empty ListLink if the lemma of a word is having a name "", which causes some problem when `run-fc` in chat-utils tries to call `cog-delete-parent` the second time