### PR TITLE
Update det-rule to avoid generating an invalid handle

### DIFF
--- a/opencog/nlp/relex2logic/rule-helpers.scm
+++ b/opencog/nlp/relex2logic/rule-helpers.scm
@@ -641,6 +641,11 @@
 				(r2l-wordinst-concept instance)
 				(InheritanceLink (VariableNode var_name) (ConceptNode concept)))
 		)
+
+		; XXX Just to avoid getting the `#<Invalid handle>` error
+		; TODO Need to add more to the list (e.g. "the") to cover all cases
+		; or update the below to generate something reasonable
+		(else (ListLink))
 	)
 )
 


### PR DESCRIPTION
It seems to be related to the `(cond)` in some of the r2l rules, that if it hits a case that is not covered and there is no else condition, it will give this error, so looks like what I did previously in #2061 was not solving the problem at all