### PR TITLE
Fix MicroplanningUTest by using include instead of load.

### DIFF
--- a/opencog/nlp/microplanning/anaphora-noun-item.scm
+++ b/opencog/nlp/microplanning/anaphora-noun-item.scm
@@ -2,7 +2,13 @@
 (use-modules (oop goops))
 (use-modules (ice-9 receive))
 
-(load "helpers.scm")
+; Attention: cannot use load, must use include, because the helpers.scm
+; file has a set-values! macro which borks with a load.  Well, it
+; actually works fine, if `helpers.scm` is installed, but the unit tests
+; are run before the install step, and these fail when the set-values!
+; macro is used, below.
+; (load "helpers.scm")
+(include "helpers.scm")
 
 ; -----------------------------------------------------------------------
 ; <noun-item> -- A class containing information on a noun

--- a/opencog/nlp/microplanning/anaphora.scm
+++ b/opencog/nlp/microplanning/anaphora.scm
@@ -1,5 +1,13 @@
-; loading additional dependency
-(load "helpers.scm")
+;
+;
+; Loading additional dependencies
+; Attention: we need to `include`, not `load` helpers.scm because it
+; contains a macro definition. This macro causes unit-test failures,
+; ... Hmm ... because the file compile step is broken? is this due to
+; a guile bug??  Anyway, for guile-2.1, taken from git, as of March
+; 2016, saying `load` here fails.  Its tied to the set-values! macro.
+;
+(include "helpers.scm")
 (load "anaphora-nouns-list.scm")
 
 ; =======================================================================

--- a/tests/nlp/microplanning/MicroplanningUTest.cxxtest
+++ b/tests/nlp/microplanning/MicroplanningUTest.cxxtest
@@ -117,7 +117,8 @@ void MicroplanningUTest::test_declarative(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    _evaluator->eval("(define m-result (microplanning test-declarative-sal \"declarative\" *default_chunks_option* #f))");
+    std::string mdef = _evaluator->eval("(define m-result (microplanning test-declarative-sal \"declarative\" *default_chunks_option* #f))");
+    printf("test_declarative default m-result=%s\n", mdef.c_str());
     bool eval_err = _evaluator->eval_error();
     _evaluator->clear_pending();
     TSM_ASSERT("Failed to run microplanning without anaphora!", !eval_err);

--- a/tests/nlp/microplanning/MicroplanningUTest.cxxtest
+++ b/tests/nlp/microplanning/MicroplanningUTest.cxxtest
@@ -117,16 +117,25 @@ void MicroplanningUTest::test_declarative(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    std::string mdef = _evaluator->eval("(define m-result (microplanning test-declarative-sal \"declarative\" *default_chunks_option* #f))");
+    std::string mdef = _evaluator->eval(
+        "(define m-result (microplanning test-declarative-sal \"declarative\" *default_chunks_option* #f))");
     printf("test_declarative default m-result=%s\n", mdef.c_str());
     bool eval_err = _evaluator->eval_error();
     _evaluator->clear_pending();
     TSM_ASSERT("Failed to run microplanning without anaphora!", !eval_err);
 
-    std::string result = _evaluator->eval("(equal? m-result (declarative-without-anaphora))");
-    TSM_ASSERT("Failed to generate the correct result without anaphora!", result == "#t\n");
+    std::string got = _evaluator->eval("m-result");
+    std::string exp = _evaluator->eval("(declarative-without-anaphora)");
+    printf("got=%s expected=%s\n", got.c_str(), exp.c_str());
 
-    std::string mres = _evaluator->eval("(define m-result (microplanning test-declarative-sal \"declarative\"))");
+    std::string result = _evaluator->eval(
+        "(equal? m-result (declarative-without-anaphora))");
+    printf("equality result=%s\n", result.c_str());
+    TSM_ASSERT("Failed to generate the correct result without anaphora!",
+        result == "#t\n");
+
+    std::string mres = _evaluator->eval(
+        "(define m-result (microplanning test-declarative-sal \"declarative\"))");
     printf("test_declarative m-result=%s\n", mres.c_str());
     eval_err = _evaluator->eval_error();
     _evaluator->clear_pending();


### PR DESCRIPTION
The macro definition in helpers.scm fails when `load` is used, but it works when `include` is used.  I suspect that this may be a guile-2.1-git bug ...  I am running `guile (GNU Guile) 2.1.1.29-13edc`