### PR TITLE
Update get-fuzzy-answers

### DIFF
--- a/opencog/nlp/fuzzy/fuzzy.scm
+++ b/opencog/nlp/fuzzy/fuzzy.scm
@@ -166,7 +166,8 @@
                (results '()))
             (for-each (lambda (s)
                 (let ( (score (string->number (cog-name (cadr (cog-outgoing-set s))))))
-                    (if (>= score max-score)
+                    ; Make sure it can be used to generate a sentence by sureal
+                    (if (and (>= score max-score) (not (equal? (sureal (car (cog-outgoing-set s))) '())))
                         (begin
                             (set! results (append results (list (car (cog-outgoing-set s)))))
                             (set! max-score score))


### PR DESCRIPTION
To skip the results that can't be used to generate valid sentences