### PR TITLE
Rename purge to extract.

### DIFF
--- a/opencog/nlp/aiml2oc/aiml2oc_guile/code/ErrTest1.scm
+++ b/opencog/nlp/aiml2oc/aiml2oc_guile/code/ErrTest1.scm
@@ -114,7 +114,7 @@
 (define (answerInput input)
  (push-atomspace)
  (pretty-print (generateReply input))
- (cog-delete-recursive (mapConceptualizeString input))
+ (cog-extract-recursive (mapConceptualizeString input))
  (pop-atomspace)
 )
 
@@ -291,5 +291,3 @@
 ;;TEST CASE THREE
 ;; (answerInput "I REMEMBER LAST WEEK")
 ;; Same result as TEST CASE ONE
-
-	

--- a/opencog/nlp/aiml2oc/aiml2oc_guile/code/OpenCogAimlPre2.scm
+++ b/opencog/nlp/aiml2oc/aiml2oc_guile/code/OpenCogAimlPre2.scm
@@ -99,7 +99,7 @@
 (define (answerInput input)
  (push-atomspace)
  (pretty-print (generateReply input))
- (cog-delete-recursive (mapConceptualizeString input))
+ (cog-extract-recursive (mapConceptualizeString input))
  (pop-atomspace)
 )
 

--- a/opencog/nlp/aiml2oc/aiml2oc_guile/code/OpenCogAimlReply1.scm
+++ b/opencog/nlp/aiml2oc/aiml2oc_guile/code/OpenCogAimlReply1.scm
@@ -131,7 +131,7 @@
 (define (answerInput input)
  (push-atomspace)
  (pretty-print (generateReply input))
- ;;(cog-delete-recursive (mapConceptualizeString input))
+ ;;(cog-extract-recursive (mapConceptualizeString input))
  (pop-atomspace)
 )
 

--- a/opencog/nlp/chatbot-eva/imperative.scm
+++ b/opencog/nlp/chatbot-eva/imperative.scm
@@ -114,7 +114,7 @@
 		; At this time, a ListLink is used to anchor suggested
 		; actions to the current-action anchor. Wipe these out.
 		(for-each (lambda (x)
-			(cog-delete-recursive (ListLink current-action x)))
+			(cog-extract-recursive (ListLink current-action x)))
 				action-list)
 
 		; XXX replace this by AIML or something.

--- a/opencog/nlp/chatbot-old/pln/symmetric-relation.scm
+++ b/opencog/nlp/chatbot-old/pln/symmetric-relation.scm
@@ -83,11 +83,11 @@
 	cnt
 )
 
-(cog-map-type (lambda (x) (cog-delete-recursive x) #f) 'FWVariableNode)
-(cog-map-type (lambda (x) (cog-delete-recursive x) #f) 'OrderedLink)
+(cog-map-type (lambda (x) (cog-extract-recursive x) #f) 'FWVariableNode)
+(cog-map-type (lambda (x) (cog-extract-recursive x) #f) 'OrderedLink)
 (cog-map-type prt-atom 'FWVariableNode)
 
-(cog-delete-recursive (ConceptNode "___PLN___"))
+(cog-extract-recursive (ConceptNode "___PLN___"))
 
 
 

--- a/opencog/nlp/chatbot-old/seme/seme-process.scm
+++ b/opencog/nlp/chatbot-old/seme/seme-process.scm
@@ -626,7 +626,7 @@
 		; Delete upwards ... this deletes the link to the document,
 		; and also the link to the new-parsed-sentences anchor.
 		; XXX but it leaves a DocumentNode with nothing pointing to it.
-		(cog-delete-recursive sent)
+		(cog-extract-recursive sent)
 	)
 
 	(for-each do-one-sentence (get-new-parsed-sentences))

--- a/opencog/nlp/chatbot-old/seme/seme-process.scm
+++ b/opencog/nlp/chatbot-old/seme/seme-process.scm
@@ -617,7 +617,7 @@
 			; Delete the links to the recently generated triples,
 			; and then delete the triples themselves.
 			(release-result-triples)
-			(for-each purge-hypergraph trip-list)
+			(for-each extract-hypergraph trip-list)
 		)
 
 		; Delete the sentence, its parses, and the word-instances

--- a/opencog/nlp/chatbot/chat-utils.scm
+++ b/opencog/nlp/chatbot/chat-utils.scm
@@ -34,7 +34,7 @@
 
   SENT must be a SentenceNode.
 "
-    (define (cog-delete-parent a-link is-from-fc)
+    (define (cog-extract-parent a-link is-from-fc)
         ; Many rules return a ListLink of results that they
         ; generated. Some rules return singletons. And the
         ; Forward Chainer uses a SetLink to wrap all these
@@ -45,7 +45,7 @@
         ; XXX maybe this should be part of the ure module??
         (if (or (equal? 'ListLink (cog-type a-link)) is-from-fc)
             (let ((returned-list (cog-outgoing-set a-link)))
-                    (cog-delete a-link)
+                    (cog-extract a-link)
                     returned-list)
             (list a-link))
     )
@@ -60,9 +60,9 @@
         (define focus-set
             (SetLink (parse-get-relex-outputs parse-node) interp-link))
         (define outputs
-            (cog-delete-parent (cog-fc (SetLink) r2l-rules focus-set) #t))
+            (cog-extract-parent (cog-fc (SetLink) r2l-rules focus-set) #t))
 
-        (append-map (lambda (o) (cog-delete-parent o #f)) outputs)
+        (append-map (lambda (o) (cog-extract-parent o #f)) outputs)
     )
 
     (define (interpret parse-node)

--- a/opencog/nlp/fuzzy/fuzzy.scm
+++ b/opencog/nlp/fuzzy/fuzzy.scm
@@ -172,7 +172,7 @@
                             (set! max-score score))
                         #f)))
             (cog-outgoing-set fset))
-            (cog-purge fset)
+            (cog-extract fset)
             results))
 
     (let* ( ; List of setence types to not consider

--- a/opencog/nlp/learn/compute-mi.scm
+++ b/opencog/nlp/learn/compute-mi.scm
@@ -559,12 +559,12 @@
 
 			; And now ... delete some of the crap we created.
 			; Don't want to pollute the atomspace.
-			(purge-hypergraph left-bind-link)
-			(purge-hypergraph right-bind-link)
-			; Note that cog-purge only goes one level deep, it does not
+			(extract-hypergraph left-bind-link)
+			(extract-hypergraph right-bind-link)
+			; Note that cog-extract only goes one level deep, it does not
 			; recurse; so the below only delete the ListLink at the top.
-			(cog-purge left-list)
-			(cog-purge right-list)
+			(cog-extract left-list)
+			(cog-extract right-list)
 
 			; What the hell, return the two things
 			(list left-star right-star)
@@ -595,7 +595,7 @@
 		)
 		(begin
 			; Now, delete all the crap that we fetched.
-			; OK, we want to do this: (for-each cog-purge relset)
+			; OK, we want to do this: (for-each cog-extract relset)
 			; but we can't, because this would also delete the wildcard
 			; evaluation links. We want to keep those around. So ugly
 			; filter.
@@ -608,12 +608,12 @@
 						(if (zany (gadr evl)) #t (zany (gddr evl)))
 					)
 
-					(if (not (is-any? x)) (cog-purge x))
+					(if (not (is-any? x)) (cog-extract x))
 				)
 				relset
 			)
 
-			(for-each cog-purge inset)
+			(for-each cog-extract inset)
 			result
 		)
 	)
@@ -940,10 +940,10 @@
 
 			; And now ... delete some of the crap we created.
 			; Don't want to pollute the atomspace.
-			(purge-hypergraph left-bind-link)
-			; Note that cog-purge only goes one level deep, it does not
+			(extract-hypergraph left-bind-link)
+			; Note that cog-extract only goes one level deep, it does not
 			; recurse; so the below only delete the ListLink at the top.
-			(cog-purge left-list)
+			(cog-extract left-list)
 		)
 	)
 )

--- a/opencog/nlp/microplanning/anaphora.scm
+++ b/opencog/nlp/microplanning/anaphora.scm
@@ -68,7 +68,7 @@
 							      )
 								; do not want a copy of the link for every changes to the node, just want one
 								(if (not (equal? (get-orig-link ni) old-link))
-									(cog-purge old-link)
+									(cog-extract old-link)
 								)
 							      
 								(mod-link results-set (get-chunk-index ni) (get-link-index ni) new-link)
@@ -92,7 +92,7 @@
 						(mod-chunk results-set index (get-chunk inputs-set index))
 					)
 				
-					(cog-purge temp-set-link)
+					(cog-extract temp-set-link)
 				)
 			)
 		)

--- a/opencog/nlp/microplanning/main.scm
+++ b/opencog/nlp/microplanning/main.scm
@@ -505,7 +505,7 @@
 	(define say-able (not (null? (sureal temp-set-link))))
 
 	; remove the temporary SetLink
-	(cog-purge temp-set-link)
+	(cog-extract temp-set-link)
 
 	(cond
 		; not long/complex but sayable

--- a/opencog/nlp/relex2logic/post-processing.scm
+++ b/opencog/nlp/relex2logic/post-processing.scm
@@ -268,7 +268,7 @@
 	)
 
 	; delete old rebuilt links
-	(for-each purge-hypergraph clean-links)
+	(for-each extract-hypergraph clean-links)
 
 	results-list
 )
@@ -318,7 +318,7 @@
 		; call helper function to process them
 		(define results-list (append-map helper marker-list))
 		; delete the markers links and the marker itself
-		(for-each purge-hypergraph marker-list)
+		(for-each extract-hypergraph marker-list)
 		(cog-delete marker)
 		; return the results
 		results-list

--- a/opencog/nlp/relex2logic/post-processing.scm
+++ b/opencog/nlp/relex2logic/post-processing.scm
@@ -319,7 +319,7 @@
 		(define results-list (append-map helper marker-list))
 		; delete the markers links and the marker itself
 		(for-each extract-hypergraph marker-list)
-		(cog-delete marker)
+		(cog-extract marker)
 		; return the results
 		results-list
 	)

--- a/opencog/nlp/scm/nlp-utils.scm
+++ b/opencog/nlp/scm/nlp-utils.scm
@@ -722,8 +722,8 @@
          SentenceNode
 "
 	; Purge stuff associated with a single LgLinkInstanceNode
-	(define (purge-link-instance li)
-		(cog-purge-recursive li)
+	(define (extract-link-instance li)
+		(cog-extract-recursive li)
 	)
 
 	; Purge stuff associated with a single word-instance
@@ -736,28 +736,28 @@
 	;               WordInstanceNode
 	;               WordInstanceNode
 	;
-	; and so we have to track those down and purge them.
+	; and so we have to track those down and extract them.
 	; They also appear in WordSequenceLinks:
 	;     WordSequenceLink
 	;         WordInstanceNode
 	;         NumberNode
 	; and so we need to get rid of the NumberNodes too.
 
-	(define (purge-word-instance wi)
+	(define (extract-word-instance wi)
 		(for-each
 			(lambda (x)
-				; purge the NumberNode
+				; extract the NumberNode
 				(if (eq? 'WordSequenceLink (cog-type x))
-					(cog-purge (cadr (cog-outgoing-set x)))
+					(cog-extract (cadr (cog-outgoing-set x)))
 				)
 				(if (eq? 'ListLink (cog-type x))
-					(purge-link-instance
+					(extract-link-instance
 						(cog-chase-link 'EvaluationLink 'LgLinkInstanceNode x))
 				)
 			)
 			(cog-incoming-set wi)
 		)
-		(cog-purge-recursive wi)
+		(cog-extract-recursive wi)
 	)
 
 	; Purge, recusively, all of the word-instances in the parse.
@@ -767,19 +767,19 @@
 	;           WordInstanceNode
 	;           ParseNode
 	;
-	(define (purge-parse parse)
+	(define (extract-parse parse)
 		(for-each
 			(lambda (x)
 				(if (eq? 'WordInstanceLink (cog-type x))
-					(purge-word-instance (car (cog-outgoing-set x)))
+					(extract-word-instance (car (cog-outgoing-set x)))
 				)
 			)
 			(cog-incoming-set parse)
 		)
-		(cog-purge-recursive parse)
+		(cog-extract-recursive parse)
 	)
 
-	; For each parse of the sentence, purge the parse
+	; For each parse of the sentence, extract the parse
 	; This is expecting a structure
 	;     ParseLink
 	;         ParseNode     car of the outgoing set
@@ -788,7 +788,7 @@
 		(lambda (x)
 			(if (eq? 'ParseLink (cog-type x))
 				; The car will be a ParseNode
-				(purge-parse (car (cog-outgoing-set x)))
+				(extract-parse (car (cog-outgoing-set x)))
 			)
 		)
 		(cog-incoming-set sent)
@@ -796,7 +796,7 @@
 
 	; This delete will fail if there are still incoming links ...
 	; this is intentional. Its up to the caller to cleanup.
-	(cog-purge sent)
+	(cog-extract sent)
 )
 
 ; ---------------------------------------------------------------------
@@ -820,12 +820,12 @@
 "
 	(let ((n 0))
 	; (define (delit atom) (set! n (+ n 1)) #f)
-	; (define (delit atom) (cog-purge-recursive atom) #f)
-	(define (delit atom) (cog-purge-recursive atom) (set! n (+ n 1)) #f)
+	; (define (delit atom) (cog-extract-recursive atom) #f)
+	(define (delit atom) (cog-extract-recursive atom) (set! n (+ n 1)) #f)
 
-	; (define (delone atom) (cog-purge atom) #f)
-	; (define (delone atom) (cog-purge atom) (set! n (+ n 1)) #f)
-	(define (delone atom) (purge-hypergraph atom) (set! n (+ n 1)) #f)
+	; (define (delone atom) (cog-extract atom) #f)
+	; (define (delone atom) (cog-extract atom) (set! n (+ n 1)) #f)
+	(define (delone atom) (extract-hypergraph atom) (set! n (+ n 1)) #f)
 
 	; Can't delete InheritanceLink, its used to mark wsd completed...
 	; (cog-map-type delone 'InheritanceLink)

--- a/opencog/nlp/scm/processing-utils.scm
+++ b/opencog/nlp/scm/processing-utils.scm
@@ -27,8 +27,8 @@
 	; Arghh Some bit of asshole code is wrapping the anchor in
 	; a SetLink. Basically, someone somewhere is running a
 	; badly-scoped search pattern.  However, we need this to work,
-	; so break out using cog-purge-recursive not cog-purge.
-	(for-each (lambda (x) (cog-purge-recursive x))
+	; so break out using cog-extract-recursive not cog-extract.
+	(for-each (lambda (x) (cog-extract-recursive x))
 		(cog-incoming-set anchor)
 	)
 )

--- a/opencog/nlp/viterbi/parser.cc
+++ b/opencog/nlp/viterbi/parser.cc
@@ -104,7 +104,7 @@ void Parser::initialize_state()
 	// connector set any more, so delete it.  It bugs me that we
 	// need to do this .. it should disappear on its own ...
 	stringstream clean;
-	clean << "(cog-delete (cog-atom " << wall_conset_h << "))";
+	clean << "(cog-extract (cog-atom " << wall_conset_h << "))";
 	_scm_eval->eval(clean);
 
 	// Print out the atomspace contents

--- a/opencog/openpsi/active-schema-pool.scm
+++ b/opencog/openpsi/active-schema-pool.scm
@@ -59,7 +59,7 @@
   - A list of action-rule nodes. The nodes are the alias nodes for the
     action-rules.
 "
-    (define (remove-node node) (cog-delete-recursive (MemberLink node asp)))
+    (define (remove-node node) (cog-extract-recursive (MemberLink node asp)))
     (define (add-node node) (begin (MemberLink node asp) node))
 
     (let* ((current-actions (ure-rbs-rules asp))

--- a/opencog/openpsi/demand.scm
+++ b/opencog/openpsi/demand.scm
@@ -313,7 +313,7 @@
     (let* ((set-link (get-psi-goal))
            (result (cog-outgoing-set set-link)))
 
-          (cog-delete set-link)
+          (cog-extract set-link)
           (if (null? result) result  (car result))
     )
 )
@@ -439,7 +439,7 @@
               ((= 0 (length node))
                (create-psi-action-rule))
               (else ; cleanup TODO: Make exaustive
-                  (cog-delete (rule))
+                  (cog-extract (rule))
                   (error "The rule has been defined multiple times"))
         )
     )
@@ -488,7 +488,7 @@
     (let* ((set-link (get-psi-action-type))
           (result (cog-outgoing-set set-link)))
 
-          (cog-delete set-link)
+          (cog-extract set-link)
 
           (if (null? result)
               "Default"

--- a/opencog/pln/rules/implication-instantiation-rule.scm
+++ b/opencog/pln/rules/implication-instantiation-rule.scm
@@ -90,7 +90,7 @@
         (let* ((put (PutLink (LambdaLink TyVs Q) terms))
                (inst (cog-execute! put)))
           ;; Remove the PutLink to not pollute the atomspace
-          (purge-hypergraph put)
+          (extract-hypergraph put)
           (cog-set-tv! inst (cog-tv Impl))))))
 
 ;; Name the rule
@@ -181,8 +181,8 @@
                                  (gar TyVs-remain)
                                  TyVs-remain)))
            ;; Remove the put links to not populate the atomspace
-           (purge-hypergraph P-put)
-           (purge-hypergraph Q-put)
+           (extract-hypergraph P-put)
+           (extract-hypergraph Q-put)
            (if (> TyVs-remain-len 0)
                                         ; If there are some variables
                                         ; left, rebuild the

--- a/opencog/pln/rules/instantiation.scm
+++ b/opencog/pln/rules/instantiation.scm
@@ -19,7 +19,7 @@
          (result (cog-execute! query)))
     ;; Select one randomly, but first purge the query to not pollute
     ;; the atomspace
-    (purge-hypergraph query)
+    (extract-hypergraph query)
     (select-rnd-outgoing result)))
 
 ;; Given an atom
@@ -82,5 +82,5 @@
          (result (cog-execute! query)))
     ;; Select one randomly, but first purge the query to not pollute
     ;; the atomspace
-    (purge-hypergraph query)
+    (extract-hypergraph query)
     (select-rnd-outgoing result)))


### PR DESCRIPTION
Maybe this will lessen the continuing confusion, as seen on the mailing list?

Naming it "purge" seems to have been a mistake, as that seems to conflict with common database usage.

Depends on pull request opencog/atomspace#750