### PR TITLE
Fix Eddie's crash in bug #2093

### DIFF
--- a/lib/cogserver.conf
+++ b/lib/cogserver.conf
@@ -74,8 +74,8 @@ ANSI_ENABLED	       = true
 # Cogserver in OSX will automatically change .so extension to .dylib
 # if .so exists.
 MODULES               = opencog/modules/libbuiltinreqs.so,
+                        opencog/modules/libscheme-shell.so,
                         opencog/modules/libpy-shell.so,
-                        opencog/modules/libscheme-shell.so
 
 # Optional modules, not enabled by default
 #                        opencog/modules/libPersistZmqModule.so,
@@ -84,23 +84,6 @@ MODULES               = opencog/modules/libbuiltinreqs.so,
 #                        opencog/modules/libhebbiancreation.so
 #                        opencog/modules/libdimensionalembedding.so
 #                        opencog/modules/libviterbi.so
-
-# Uncomment if Python extensions are not stored in these locations,
-# or the binary and source directories:
-#     /usr/local/share/opencog/python
-#     /usr/share/opencog/python
-#
-# Use a comma separated list for multiple dirs
-PYTHON_EXTENSION_DIRS  = opencog/python/web/api
-
-# NOTE: If you want Python functions to be loaded at startup for acccess by
-# Python code that runs via EvaluationLink or GroundedSchemaNode, then place
-# them in the PYTHON_PRELOAD_FUNCTIONS directory. PYTHON_PRELOAD is only for
-# MindAgent and Request Python handlers.
-PYTHON_PRELOAD_FUNCTIONS = opencog/python/preload_functions
-
-# Run these python cogserver modules on start up
-PYTHON_PRELOAD = pyshell, restapi, agent_finder
 
 # IMPORTANT!
 # Database login credentials. Change these to reflect your actual setup!

--- a/lib/development.conf
+++ b/lib/development.conf
@@ -106,24 +106,6 @@ MODULES               = opencog/cogserver/server/libbuiltinreqs.so,
 SCM_PRELOAD           = cogserver/scm/config.scm
 
 
-# Uncomment if Python extensions are not stored in these locations,
-# or the binary and source directories:
-#     /usr/local/share/opencog/python
-#     /usr/share/opencog/python
-#
-# Use a comma separated list for multiple dirs
-
-PYTHON_EXTENSION_DIRS  = ../opencog/python,
-                         ../opencog/python/web/api
-
-# NOTE: If you want Python functions to be loaded at startup for acccess by
-# Python code that runs via EvaluationLink or GroundedSchemaNode, then place
-# them in the PYTHON_PRELOAD_FUNCTIONS directory. PYTHON_PRELOAD is only for
-# MindAgent and Request Python handlers.
-PYTHON_PRELOAD_FUNCTIONS = ../opencog/python/preload_functions
-
-# Run these python cogserver modules on start up
-PYTHON_PRELOAD = pyshell, restapi, agent_finder
 
 # IMPORTANT!
 # Database login credentials. Change these to reflect your actual setup!

--- a/lib/opencog-wsd.conf
+++ b/lib/opencog-wsd.conf
@@ -12,11 +12,6 @@ LOG_LEVEL             = info
 LOG_TO_STDOUT         = false
 SERVER_CYCLE_DURATION = 100
 IDLE_CYCLES_PER_TICK  = 3
-STARTING_STI_FUNDS    = 10000
-STARTING_LTI_FUNDS    = 10000
-STI_FUNDS_BUFFER      = 10000
-LTI_FUNDS_BUFFER      = 10000
-MIN_STI               = -400
 PROMPT                = "opencog> "
 MODULES               = libbuiltinreqs.so,
                         libscheme-shell.so,

--- a/lib/opencog.conf
+++ b/lib/opencog.conf
@@ -84,24 +84,6 @@ MODULES               = opencog/cogserver/server/libbuiltinreqs.so,
 #                        opencog/learning/dimensionalembedding/libdimensionalembedding.so
 #                        opencog/viterbi/libviterbi.so
 
-# Uncomment if Python extensions are not stored in these locations,
-# or the binary and source directories:
-#     /usr/local/share/opencog/python
-#     /usr/share/opencog/python
-#
-# Use a comma separated list for multiple dirs
-
-PYTHON_EXTENSION_DIRS  = ../opencog/python,
-                         ../opencog/python/web/api
-
-# NOTE: If you want Python functions to be loaded at startup for acccess by
-# Python code that runs via EvaluationLink or GroundedSchemaNode, then place
-# them in the PYTHON_PRELOAD_FUNCTIONS directory. PYTHON_PRELOAD is only for
-# MindAgent and Request Python handlers.
-PYTHON_PRELOAD_FUNCTIONS = ../opencog/python/preload_functions
-
-# Run these python cogserver modules on start up
-PYTHON_PRELOAD = pyshell, restapi, agent_finder
 
 # IMPORTANT!
 # Database login credentials. Change these to reflect your actual setup!


### PR DESCRIPTION
Python is crashing the cogserver when its misconfigured.
This cures the crash:
```
$ guile
scheme@(guile-user)> (use-modules (opencog) (opencog cogserver))
scheme@(guile-user)>  (start-cogserver)
Listening on port 17001
$1 = "Started CogServer"
```