### PR TITLE
Cogserver get module paths

### DIFF
--- a/opencog/cogserver/server/CogServer.cc
+++ b/opencog/cogserver/server/CogServer.cc
@@ -602,7 +602,7 @@ void CogServer::loadModules(std::vector<std::string> module_paths)
 {
     if (module_paths.empty()) {
         // Sometimes paths are given without the "opencog" part.
-        for (auto p : DEFAULT_MODULE_PATHS) {
+        for (auto p : get_module_paths()) {
             module_paths.push_back(p);
             module_paths.push_back(p + "/opencog");
         }
@@ -643,7 +643,7 @@ void CogServer::loadSCMModules(std::vector<std::string> module_paths)
 #ifdef HAVE_GUILE
     if (module_paths.empty()) {
         // Sometimes paths are given without the "opencog" part.
-        for (auto p : DEFAULT_MODULE_PATHS) {
+        for (auto p : get_module_paths()) {
             module_paths.push_back(p);
             module_paths.push_back(p + "/opencog");
         }

--- a/scripts/run_cogserver.sh
+++ b/scripts/run_cogserver.sh
@@ -5,7 +5,6 @@
 # It assumes by default that the building directory name is 'build`
 # otherwise the first command argument can be given to overwrite it
 
-set -u
 # set -x
 
 prg_path="$(readlink -f "$0")"
@@ -21,6 +20,7 @@ else # More than one command line arguments
 fi
 
 build_dir="${branch_dir}/${build_dir_name}"
+export OPENCOG_MODULE_PATHS="${OPENCOG_MODULE_PATHS}:${build_dir}"
 
 "${build_dir}/opencog/cogserver/server/cogserver" \
     -c "${branch_dir}/lib/opencog.conf"


### PR DESCRIPTION
Cousin PR of https://github.com/opencog/cogutils/pull/49. That way one can run the cogserver outside of the repo as long as the path is defined with OPENCOG_MODULE_PATHS and thus run_cogserver.sh.