### PR TITLE
Change psi-do-run-loop default value to #f

### DIFF
--- a/opencog/openpsi/main.scm
+++ b/opencog/openpsi/main.scm
@@ -369,7 +369,7 @@ there are 100K rules!
 ; --------------------------------------------------------------
 ; Main loop control
 ; --------------------------------------------------------------
-(define psi-do-run-loop #t)
+(define psi-do-run-loop #f)
 
 (define-public (psi-running?)
 "


### PR DESCRIPTION
Otherwise `(psi-running?)` always returns #t even if no one has called `(psi-run)`