### PR TITLE
AIML, OpenPsi: update README's, misc cleanup

### DIFF
--- a/opencog/nlp/aiml/README.md
+++ b/opencog/nlp/aiml/README.md
@@ -314,10 +314,12 @@ to a BindLink approach for ease-of-use.
 
 
 ### TODO
-* OpenPsi duallink is returning too much -- i.e. it includes matches to
+* OpenPsi DualLink is returning too much -- i.e. it includes matches to
   the action.  We really only want matches to the context only.
   An extended version of the `get-pattern-rules` tool could do this
   kind of filtering.  Review with Amen, maybe open bug report.
+* AIML -- implicit * at end of sentence, can be NULL.
+  (I guess globbing should wrk with that...?)
 * AIML -- thatstar and topicstar not handled.
 * AIML HR -- in a session, never say the same thing twice!
   Done -- for just one sentence .. ask Vytas about more.
@@ -499,8 +501,8 @@ functioning normally. <think><set name=\"matched\">true</set></think>
 (aiml-get-response-wl (string-words "call me joob"))
 
 =================================
-General demo instructions
 
+OpenPsi predicate/schema issues!
 
 (Define (DefinedPredicate "pblorf")
 (SequentialAnd
@@ -513,5 +515,7 @@ General demo instructions
 
 (cog-execute! (DefinedPredicate "pblorf"))
 
-
+=================================
+(aiml-get-response-wl (string-words "what are you doing tonight?"))
+(define SENT (string-words "what are you doing tonight?"))
 

--- a/opencog/nlp/aiml/README.md
+++ b/opencog/nlp/aiml/README.md
@@ -526,3 +526,29 @@ OpenPsi predicate/schema issues!
 (aiml-get-response-wl (string-words "what are you doing tonight?"))
 (define SENT (string-words "what are you doing tonight?"))
 
+
+(use-modules (opencog) (opencog exec) (opencog nlp))
+(Define (DefinedSchema "wtf")
+(GroundedSchemaNode "scm: fart"))
+(define (fart x) (display "duuude fart") (display x)(newline))
+
+(define maplk
+(MapLink
+   (ImplicationLink
+      (ListLink (WordNode "what") (GlobNode "$star-1"))
+      (ListLink
+         (ExecutionOutputLink
+            (DefinedSchemaNode "AIML-tag srai")
+            ; (DefinedSchemaNode "wtf")
+            (ListLink
+               (ListLink (WordNode "xfind") (GlobNode "$star-1"))))))
+   (SetLink
+      (ListLink
+         (WordNode "what")
+         (WordNode "are")
+         (WordNode "you")
+         (WordNode "doing")
+         (WordNode "tonight?"))))
+)
+
+(cog-execute! maplk)

--- a/opencog/nlp/aiml/README.md
+++ b/opencog/nlp/aiml/README.md
@@ -318,6 +318,13 @@ to a BindLink approach for ease-of-use.
   the action.  We really only want matches to the context only.
   An extended version of the `get-pattern-rules` tool could do this
   kind of filtering.  Review with Amen, maybe open bug report.
+* OpenPsi rule deisgn is kind-of broken -- in two ways:
+  (1) the action should be imeidately obtainable from the rule,
+  instead of fishing around for it via the psi-action? utility.
+  (2) If an action is a schema, it should not appear in and AndLink,
+  because its not evaluatable.
+  (3) Actions are naturally ordered sequences, and that means
+  SequentialAnd and that meands a predicate, not a schema.
 * AIML -- implicit * at end of sentence, can be NULL.
   (I guess globbing should wrk with that...?)
 * AIML -- thatstar and topicstar not handled.

--- a/opencog/nlp/aiml/README.md
+++ b/opencog/nlp/aiml/README.md
@@ -499,36 +499,17 @@ functioning normally. <think><set name=\"matched\">true</set></think>
 =================================
 General demo instructions
 
-scm: dispatch-text  in btree.scm
-(State heard-sound
 
-py: say_text -- single string atom
+(Define (DefinedPredicate "pblorf")
+(SequentialAnd
+(Evaluation (GroundedPredicate "scm: print-msg-face")
+         (ListLink (Node "--boaty")))`
+(Evaluation (GroundedPredicate "scm: print-msg")
+         (ListLink (Node "--mcboat")))
+(True)
+))
 
-(psi-run)
-
-(cog-execute! (DefinedSchemaNode "Listening ongoing"))
-
-(cog-evaluate!   (Put (DefinedPredicateNode "Show random expression")
-                (ConceptNode "neutral-listen")))
+(cog-execute! (DefinedPredicate "pblorf"))
 
 
-(DefinedSchemaNode "New arrival sequence")
 
-(cog-evaluate! (DefinedPredicate  "New arrival sequence"))
-(cog-evaluate!  (DefinedPredicate "Respond to new arrival"))o
-(DefinedPredicate "Was Empty Sequence")
-(DefinedPredicate "interact with new person")
-
-(DefinedPredicateNode "Did someone arrive?")
-
---------------------
- (DefinedPredicate "Respond to new arrival")
-(DefinedPredicate "Interacting Sequence")
-
-(DefinedSchema "glance at new person") -- again
-
-id someone lea
-
-map::at -- is this DefineLink.cc arity check???? (at line 81)
-
-do_eval_scratch(as, DefineLink::get_definition(evelnk), scratch);

--- a/opencog/nlp/aiml/README.md
+++ b/opencog/nlp/aiml/README.md
@@ -14,12 +14,8 @@ human-created and hard-coded, as are the relex and relex2logic rules.
 Alas. So perhaps using AIML is no real crime.
 
 ## Status
-Beta.  The code is done, its probably buggy. It attempts to support the
-most commonly used features of AIML version 2.1
-
-The mixed-mode operation of AIML with other verbal and non-verbal
-subsystems is in development (alpha stage).
-
+Beta.  Most things work. There are known bugs. See TODO list below.
+It attempts to support the most commonly used features of AIML version 2.1
 
 ## Using
 There are two steps to this process: The import of standard AIML markup
@@ -33,14 +29,15 @@ perform. The goal is NOT to re-invent an AIML interpreter in OpenCog!
 ... although, de-facto, that's what the end-result is: an AIML
 interpreter running in the AtomSpace.
 
-The current importer generates OpenPsi-compatible rules, so that the
-OpenPsi rule engine can process these.  This should allow AIML to be
-intermixed with other chat systems, as well as non-verbal behaviors.
-This mixed-mode operation is in development.
+The current importer generates OpenPsi rules, so that the selection
+and execution of the AIML rules is performed by OpenPsi (see the
+[OpenPsi directory](../../openpsi) for details.) This allows
+the AIML chat subsystem to be inter-operated together with other
+subsystems (for example, the on-verbal robot behavviors).
 
 ## Running AIML in OpenCog
 AIML files need to be converted into Atomese, using the perl script
-provided in the `import` directory.  This  can be done as:
+provided in the [`import`](import) directory.  This  can be done as:
 ```
 import/aiml2psi.pl --dir /where/the/aiml/files/are
 cp aiml-rules.scm /tmp
@@ -51,13 +48,18 @@ Then do this:
 (use-modules (opencog) (opencog nlp) (opencog nlp aiml) (opencog openpsi))
 (primitive-load "/tmp/aiml-rules.scm")
 ```
-For basic debugging, the `strring-words` utility can be used to tokenize
+For basic debugging, the `string-words` utility can be used to tokenize
 a string into words; its very low-brow and basic:
 ```
 (aiml-get-response-wl (string-words "call me ishmael"))
 ```
+Proper integration with the normal language pipeline requires the use
+of the `token-seq-of-parse` and `token-seq-of-sent` functions, which
+get the word-sequence as determined by the link-grammar parser (i.e.
+obtain the word sequence from the normal OpennCog NLP ppipeline.)
 
-The various sections below provide additional under-the-cover details.
+The various sections below provide additional details about how the
+system is implemented and how it works.
 
 
 ## Lightning reivew of AIML

--- a/opencog/nlp/aiml/README.md
+++ b/opencog/nlp/aiml/README.md
@@ -526,29 +526,19 @@ OpenPsi predicate/schema issues!
 (aiml-get-response-wl (string-words "what are you doing tonight?"))
 (define SENT (string-words "what are you doing tonight?"))
 
-
 (use-modules (opencog) (opencog exec) (opencog nlp))
-(Define (DefinedSchema "wtf")
-(GroundedSchemaNode "scm: fart"))
-(define (fart x) (display "duuude fart") (display x)(newline))
 
-(define maplk
-(MapLink
-   (ImplicationLink
-      (ListLink (WordNode "what") (GlobNode "$star-1"))
-      (ListLink
-         (ExecutionOutputLink
-            (DefinedSchemaNode "AIML-tag srai")
-            ; (DefinedSchemaNode "wtf")
-            (ListLink
-               (ListLink (WordNode "xfind") (GlobNode "$star-1"))))))
-   (SetLink
-      (ListLink
-         (WordNode "what")
-         (WordNode "are")
-         (WordNode "you")
-         (WordNode "doing")
-         (WordNode "tonight?"))))
-)
+(aiml-get-response-wl (string-words "what was that sound?"))
+(aiml-get-response-wl (string-words "what is a bludgeon?"))
+(aiml-get-response-wl (string-words "what do you think?"))
+(aiml-get-response-wl (string-words "where is the ball?"))
+(aiml-get-response-wl (string-words "when will you know?"))
+(aiml-get-response-wl (string-words "How is it going?"))
 
-(cog-execute! maplk)
+test topic:
+set topic:
+(aiml-get-response-wl (string-words "when will you astronaut body"))
+(do-aiml-get (Concept "topic"))
+(do-aiml-set (Concept "topic") (ListLink (WordNode "astronaut")))
+
+(aiml-get-response-wl (string-words "I am an astronaut"))

--- a/opencog/nlp/aiml/aiml.scm
+++ b/opencog/nlp/aiml/aiml.scm
@@ -6,8 +6,8 @@
 (use-modules (srfi srfi-1))
 (use-modules (opencog) (opencog nlp) (opencog exec) (opencog openpsi))
 
-; (load "aiml/bot.scm")
-(load "aiml/gender.scm")
+(load "aiml/bot.scm")
+; (load "aiml/gender.scm")
 
 ; ==============================================================
 
@@ -138,6 +138,8 @@
 ; Given an AIML rule, return a scheme list holding the context
 ; followed by the action.  Given a rule, (gar r) is the AndLink.
 ; Either gaar or gadr is the context; the other is the action.
+; We identify the action by using the `psi-action?` utility.
+; XXX FIXME. This is yucky, something prettier is needed.
 (define (get-ctxt-act r)
 	(define andy (gar r))
 	(define pa (gar andy))
@@ -209,7 +211,7 @@
 )
 
 ; Given a pattern-based rule, run it. Given that it has variables
-; in it, accomplish this by creating and running a BindLink.
+; in it, accomplish this by creating and running a MapLink.
 ; XXX Need to handle that, topic rules as appropriate.
 (define (run-pattern-rule RULE SENT)
 	(define maplk (MapLink
@@ -389,7 +391,7 @@
 					response
 				))))
 
-	(define response (do-while-same SENT 5))
+	(define response (word-list-flatten (do-while-same SENT 5)))
 
 	; The robots response is the current "that".
 	(if (valid-response? response)
@@ -408,9 +410,9 @@
 	(GroundedSchemaNode "scm: do-aiml-srai"))
 
 (define-public (do-aiml-srai x)
-	(display "duuude srai recurse\n") (display x) (newline)
+	(display "perform srai recursion\n") (display x) (newline)
 	(let ((resp (get-response-step (word-list-flatten x))))
-		(display "duuude srai result is\n") (display resp) (newline)
+		(display "srai result is\n") (display resp) (newline)
 		resp
 	)
 )

--- a/opencog/nlp/aiml/aiml.scm
+++ b/opencog/nlp/aiml/aiml.scm
@@ -264,24 +264,33 @@
   aiml-select-rule RULE-LIST - Given a list of AIML rules,
   select one to run.
 "
-	;; Total up all of the confidence values on all of the rules
+	;; XXX FIXME crazy hacky weight-adjusting formula. This makes
+	;; no sense at all, but is a hacky hack designed to pick more
+	;; desirable rules more often.  Someone should figure out
+	;; some weighting formula that makes more sense tahn this.
+	;; Currently, the square of the confidence.
+	(define (get-weight ATOM)
+		(define w (tv-conf (cog-tv ATOM)))
+		(* w w)
+	)
+
+	;; Total up all of the weights on all of the rules
 	;; in the RULE-LIST.
 	(define sum 0.0)
 	(define (add-to-sum ATOM)
-		(set! sum (+ sum (tv-conf (cog-tv ATOM)))))
+		(set! sum (+ sum (get-weight ATOM))))
 
 	;; Return #t for the first rule in the RULE-LIST for which the
 	;; accumulated weight is above THRESH.
-	(define accum 0.0001)
+	(define accum 0.000000001)
 	(define (pick-first ATOM THRESH)
-		(set! accum (+ accum (tv-conf (cog-tv ATOM))))
+		(set! accum (+ accum (get-weight ATOM)))
 		(< THRESH accum))
 
-	; OK, so actually yoyal up the weights
+	; OK, so actually total up the weights
 	(for-each add-to-sum RULE-LIST)
 
-	; Randomly pick one, using the TV-confidence from above) as a
-	; weighting.
+	; Randomly pick one, using the weighting above.
 	(let ((thresh (random sum)))
 		(if (null? RULE-LIST)
 			'()

--- a/opencog/nlp/aiml/aiml.scm
+++ b/opencog/nlp/aiml/aiml.scm
@@ -6,8 +6,8 @@
 (use-modules (srfi srfi-1))
 (use-modules (opencog) (opencog nlp) (opencog exec) (opencog openpsi))
 
-(load "aiml/bot.scm")
-; (load "aiml/gender.scm")
+; (load "aiml/bot.scm")
+(load "aiml/gender.scm")
 
 ; ==============================================================
 
@@ -357,17 +357,17 @@
 					(do-while-null SENT (- CNT 1))
 				))))
 
-	(define response (do-while-null SENT 10))
+	(let ((response (do-while-null SENT 10)))
+		; Deal with a null list...
+		(if (null? response) (set! response (ListLink)))
 
-	; Deal with a null list...
-	(if (null? response) (set! response (ListLink)))
+		; Strip out the SetLink, if any.
+		(if (equal? 'SetLink (cog-type response))
+			(set! response (gar response)))
 
-	; Strip out the SetLink, if any.
-	(if (equal? 'SetLink (cog-type response))
-		(set! response (gar response)))
-
-	; Return the response.
-	(word-list-flatten response)
+		; Return the response.
+		(word-list-flatten response)
+	)
 )
 
 (define-public (aiml-get-response-wl SENT)
@@ -391,14 +391,15 @@
 					response
 				))))
 
-	(define response (word-list-flatten (do-while-same SENT 5)))
+	(let ((response (word-list-flatten (do-while-same SENT 5))))
 
-	; The robots response is the current "that".
-	(if (valid-response? response)
-		(do-aiml-set (Concept "that") response))
+		; The robots response is the current "that".
+		(if (valid-response? response)
+			(do-aiml-set (Concept "that") response))
 
-	; Return the response.
-	response
+		; Return the response.
+		response
+	)
 )
 
 ; --------------------------------------------------------------
@@ -427,7 +428,7 @@
 ; do with the argument, when we get here.  Don't return anything
 ; (be silent).
 (define-public (do-aiml-think x)
-	; (display "duuude think\n") (display x) (newline)
+	; (display "Perform think\n") (display x) (newline)
 	; 'think' never returns anything
 	'()
 )
@@ -439,8 +440,8 @@
 
 (define-public (do-aiml-set KEY VALUE)
 	(define flat-val (word-list-flatten VALUE))
-	; (display "duuude set key=") (display KEY) (newline)
-	; (display "duuude set value=") (display flat-val) (newline)
+	; (display "Perform AIML set key=") (display KEY) (newline)
+	; (display "set value=") (display flat-val) (newline)
 	(define rekey (Concept (string-append "AIML state " (cog-name KEY))))
 	(State rekey flat-val)
 	flat-val

--- a/opencog/nlp/aiml/import/aiml2psi.pl
+++ b/opencog/nlp/aiml/import/aiml2psi.pl
@@ -859,8 +859,20 @@ sub psi_tail
 	my $demand = "   (psi-demand \"AIML chat demand\" 0.97)\n";
 
 	# Stupid hack for rule priority, for lack of something better.
+	# Adjust weights so that more than one star is strongly punished.
+	# That's in order to supress the pattern "* are *" which matches
+	# any sentence with the word "are" in it. Skanky rule, maybe
+	# it should be ditched.  More generally, some kind of weighting
+	# formula should be developed, one that is more "scientifically"
+	# motivated.  Of course, this breaks the AIML spec, which does
+	# not use randomness or weighting in it; however, we want to avoid
+	# strict determinism here, as its not very realistic.  Note that
+	# this kind of randomness will break any sort of customer-support
+	# system that insists on eexactly a given fixed answer to a given
+	# situation.  Oh well; that's not what we're after, here.
+	#`
 	my $weight = 1.0 / (0.5 + $word_count);
-	$weight = $base_priority / (1.0 + $num_stars + $weight);
+	$weight = $base_priority / (1.0 + $num_stars * $num_stars + $weight);
 	# my $goal_truth = "   (stv 1 0.8)\n";
 	my $goal_truth = "   (stv 1 $weight)\n";
 	my $rule_tail = $chat_goal . $goal_truth . $demand;

--- a/opencog/openpsi/README.md
+++ b/opencog/openpsi/README.md
@@ -1,9 +1,42 @@
 # OpenPsi
 
-OpenPsi is an implementation of Jscha Bach's MicroPsi. It is designed
-in such a way that it works well with the OpenCog atomspace
-architecture.  It is intended to provide top-level control for robot
-behaviors.
+OpenPsi is a rule-selection framework intended to provide provide
+the top-level behavior control mechanism for robots.  It is loosely
+inspired by Joscha Bach's MicroPsi.
+
+Each rule takes the form of if(context) then take(action).  These are
+classified into different goals (demands) theat they can fullfil. The
+main loop is an action-selection mechanism, examining the context to
+see if any of the current demands/goals can be fullfilled, and then
+taking apropriate action.
+
+## Status and TODO List
+
+The code currently works at a basic level, and is used to control the
+Hanson Robotics robot, coordinating both verbal and non-verbal behavior.
+Contexts can be crisp conjunctions of patterns containing variables;
+the variables can appear within the actions (where thier grounded values
+are used).
+
+## TODO:
+* Some of the context-matching code in the nlp/aiml directory should
+  be cleaned up, generalized, and moved here.  It attempts to handle
+  crisp-valued conjunctions of context with variables.
+
+* If no exact match to a context can be found, fuzzy matching should
+  be performed, to find a context that most closely applies to the
+  current situation.
+
+* If no fuzzy match can be found, then a MOSES-inspired mechanism
+  should kick in to create new rules.  This includes the selective
+  pruning of existing contexts (called "knob-turning" in MOSES),
+  exploration of minor elaborations to contexts (also controlled
+  by knob-turning) and genetic cross-over.
+
+* The above learning mechanism needs to be elaborated into a
+  "small-data" learning system, so that the robot can learn
+  from only a handful of situations/examples.
+
 
 ### References
 * OpenCog Wiki - [OpenPsi](http://wiki.opencog.org/w/OpenPsi)
@@ -12,11 +45,13 @@ behaviors.
 * [MicroPsi source code]()
 * Joscha Bach's book -- [Principles of Synthetic Intelligence](http://wiki.humanobs.org/_media/public:events:agi-summerschool-2012:psi-oup-version-draft-jan-08.pdf) (2008 ed.)
 * Joscha Bach's book -- [Principles of Synthetic Intelligence](http://micropsi.com/publications/assets/Draft-MicroPsi-JBach-07-03-30.pdf) (2007 ed.)
-* Wikipedia - [Belief–desire–intention software model](https://en.wikipedia.org/wiki/Belief%E2%80%93desire%E2%80%93intention_software_model) has some similarities with respect to demand, goals and actions,
-that is,  the cognitive schematic `Context + Procedure/Actions ==> Goal`
-is similar to `Belief + Intention ==> Desire`.
+* Wikipedia - [Belief–desire–intention software model](https://en.wikipedia.org/wiki/Belief%E2%80%93desire%E2%80%93intention_software_model) has some
+  similarities with respect to demand, goals and actions, that is, has
+  the cognitive schematic `Belief + Intention ==> Desire, which is
+  similar to the Context + Procedure/Actions ==> Goal`which is used
+  here.
 
-### OpenPsi components
+## OpenPsi components
 1. Psi-rule:
   * A rule is an ImplicationLink structured as
     ```scheme
@@ -26,22 +61,23 @@ is similar to `Belief + Intention ==> Desire`.
                     (action))
                 (demand-goal))
     ```
-    An ImplicationLink was choosen because it allows us to reason and build
-    action plans dealing with uncertainty, using PLN rules.
+    An ImplicationLink was choosen because it allows PLN to be employed
+    to perform reasoning in the face of uncertan contexts.
   * The function `psi-rule` that is defined [here](main.scm). Is to be used
     in adding new rules.
 
 2. Context:
-  * These are atoms that should be evaluated to return TRUE_TV/FASLE_TV. Should
-    all the atoms in the context evaluate to TRUE_TV, then only the actions are
-    executed and the goals are evaluated.
+  * The context must be in the form of a set of predicates, i.e. when
+    evaluated, these return true/false to indicate if the context
+    applies. A conjunction is taken, so that the action is performed
+    only if the entire context applies.
 
 3. Action:
-  * An action is an `ExecutionOutputLink` or any atom that could be executed by
-    running `(cog-execute! your-action)`. An action is the means for interacting
-    with the atomspace or other systems.
+  * An action is an `ExecutionOutputLink` or any atom that could be
+    executed by running `(cog-execute! your-action)`. An action is the
+    means for interacting with the atomspace or other systems.
 
-    XXX FIXME the action should be TV-valued, e.g. should probobably be
+XXX FIXME the action should be TV-valued, e.g. should probobably be
 wrapped inside a TrueLink.  That is because the SequentaialAndLink
 assumes that all of its elements are evaluatable; i.e. are TV-valued.
 Either that, or we need some other mechanism for grabbing the TV
@@ -53,63 +89,75 @@ and second elements!
 
 4. Goal/Demand-goal:
   * A goal is an `EvaluationLink` or any atom that could be evaluated by
-    running `(cog-evaluate! your-goal)`. A goal is the means for manipulating
-    the demand-values so as to model emotions/feelings.
+    running `(cog-evaluate! your-goal)`.  The goal indicates the degree
+    to which the action, if taken, can satisfy the demand or meet the goal.
 
 5. Demand:
-  * A demand is one of the intermediate constructs that are used to model
-    emotion/behaviors.
-  * The representation is specified in the function `psi-demand` that is
-    defined [here](demand.scm). Use this function to create a demand.
-  * The demand-value is the stregth of the stv of the ConceptNode. This is used
-    for measurement purposes.
+  * A demand is collection of state that must be maximized during
+    operation.  That is, the system selects goals (and thus actions)
+    in order to maximize the demands placed on the system.
+  * Demands can be created using the function `psi-demand`, defined
+    [here](demand.scm).
+  * The demand-value is the stregth of the TruthValue on the demand
+    atom (currently, a ConceptNode by default).
 
 6. Modulator and Feeling representation:
 Coming soon :smile:
 
-### OpenPsi algorithm
-1. psi-step:
-  * It wraps all the logic that is described below. And is run once per cycle.
-    See function `(psi-step)` which is the entry point [here](main.scm).
+## OpenPsi algorithm
+1. `psi-step`:
+  * A function that performs a single iteration of the system. It wraps
+    the proceedures described below. It is implemented [here](main.scm).
 
 2. choose action-selector:
-  * If you have defined an action selector then it will be used else the
+  * If you have defined an action selector then it will be used; else the
     default action selector is used. See function `(psi-select-rules)`
     [here](main.scm).
-  * Only one action-selector is used in each step for all the demands. See
+  * Only one action-selector is used in each step, for all demands. See
     `psi-add-action-selector` and `psi-action-selector-set!`
     [here](action-selector.scm) for adding and setting your an action-selector.
 
 3. default action selector:
   * Most-weighted-satisfiable psi-rules of each demand are filtered out. If
-    there are more than one of them then one is randomly selected.
+    there are more than one of them, then one is randomly selected.
   * The weight is calculated as the product of strength and confidence of the
     psi-rule.
-  * A rule is checked if is satisfiable by extracting the context and wrapping
-    it in a `SatisfactionLink` before evaluating it. If TRUE_TV is returned
-    it means that is it satisifiable. See function `psi-satisfiable?`
+  * The satsifiability of a rule is checked by extracting the context and
+    wrapping it in a `SatisfactionLink` before evaluating it. If TRUE_TV is
+    returned it means that is it satisifiable. See function `psi-satisfiable?`
     [here](main.scm).
+
+XXX FIXME -- this needs fixing, as contexts may contain variables whose
+groundings can carry over into the action.  In addition, it is extremely
+inefficient if there are many rules; thus the DualLink can be (should
+be) used to narrow down the search for contextts.  A crude prototype of
+this has been implemented in the nlp/aiml subsysgtem, and needs to be
+generalized and ported over here.
 
 4. action execution and goal evaluation:
-  * After the rules are choosen then the action and goals are extracted. During
-    the goal extraction, every goal that is related through the action are
-    choosen.
-  * Related/associated goals are those that are the implicand of the psi-rules
-    that have the given action in the implicant, that is, if more than one rule
-    has the same action helping achieve different goals then those goals are
-    related/associated. Thus, the execution of the given action should result
-    in achiving those goals as well, regardless of whether the rules that
-    resulted in the association are selected or not. See `psi-related-goals`
-    [here](main.scm).
-  * Then actions are executed followed by the evaluation of the goals. No check
-    is made before evaluating of goals to see if the action has been executed.
-    It is assumed that if the context is satisfied then there is nothing that
-    prevents the action from executing. __This assumption might not work when
-    ecan or some other process that modifys the context is running in
-    parallel.__
+  * After the rules are selected, then the action and goals are extracted.
+    During the goal extraction, every goal that is related through the
+    action are choosen.
 
-<!--
-See [here](../../examples/openpsi) for some sample implementations of the
-framework. -->
-### OpenPsi examples
-Coming soon :smile:
+  * Related/associated goals are those that are the implicand of the
+    psi-rules that have the given action in the implicand. That is, if
+    more than one rule has the same action, helping achieve different
+    goals, then those goals are related/associated. Thus, the execution
+    of the given action should result in acheiving those goals as well,
+    regardless of whether the rules that resulted in the association
+    are selected or not. See `psi-related-goals` [here](main.scm).
+
+  * Then actions are executed followed by the evaluation of the goals.
+    No check is made before evaluating of goals to see if the action
+    has suceeded.  That is because it is assumed that if the context
+    is satisfied, then there is nothing that prevents the action from
+    executing.  _This assumption might not work when ECAN or some other
+    process that modifies the context is running in parallel.__
+
+## OpenPsi examples
+* The examples [here](../../examples/openpsi) are currently broken.
+* The AIML interpreter [here](../nlpe/aiml) uses Opensi and currently
+  works.
+* The ROS behavior scripts
+  [here](http://github.com/opencog/ros-behavior-scripting) use OpenPsi
+  and are currently wrking.


### PR DESCRIPTION
The biggest technical changeis to alter the ad-hoc weighting of the AIML rules, so that the generic, matches-everything rules will be much less likely to be chosen.

It would be nice if the weighting was less ad-hoc and more based on some natural theory of the frequency of utterances.

It would be nice if there was some learning system to adjust the weights: e.g. "people smiled/frowned when I said that, therefore, I will/will-not say that again"