### PR TITLE
Conditional instantiation support variables not in the implicant

### DIFF
--- a/opencog/pln/rules/implication-instantiation-rule.scm
+++ b/opencog/pln/rules/implication-instantiation-rule.scm
@@ -180,9 +180,6 @@
          (terms (if (= 0 Impl-c) ; don't try to instantiate zero
                                  ; knowledge implication
                     (cog-undefined-handle)
-                    ;; TODO: take the subset of TyVs that is free in P
-                    ;; and select the substitution term with it Rename
-                    ;; it P-TyVs and use it below instead of TyVs.
                     (select-conditioned-substitution-terms TyVs P))))
     (if (equal? terms (cog-undefined-handle))
         (cog-undefined-handle)
@@ -193,10 +190,6 @@
                (Pinst (cog-execute! Pput))
                (Pinst-s (cog-stv-strength Pinst))
                (Pinst-c (cog-stv-confidence Pinst))
-               ;; TODO: generate Q-TyVs which contains the substition
-               ;; terms compatible with P and randomly create new ones
-               ;; for the variable in Q that are missing in P. Use
-               ;; Q-TyVs instead of TyVs below.
                (Qput (PutLink (LambdaLink TyVs Q) terms))
                (Qinst (cog-execute! Qput))
                (Qinst-s (* Impl-s Pinst-s))

--- a/opencog/pln/rules/instantiation.scm
+++ b/opencog/pln/rules/instantiation.scm
@@ -5,6 +5,13 @@
 (use-modules (srfi srfi-1))
 (use-modules (opencog logger))
 
+;; Given a variable, typed or not, return the corresponding untyped
+;; variable, that is where its type signature has been stripped of it.
+(define (strip-type-from-variable TyV)
+  (if (equal? (cog-type TyV) 'TypedVariableLink)
+      (gar TyV)
+      (TyV)))
+
 ;; Given an atom
 ;;
 ;; (TypedVariableLink
@@ -14,7 +21,7 @@
 ;; return a random term satisfying the type constraint.
 (define (select-substitution-term TyV)
   (let* (
-         (V (gar TyV))
+         (V (strip-type-from-variable TyV))
                                         ; Build pattern matcher query
                                         ; for the subtitution term
          (query (GetLink TyV V))
@@ -73,37 +80,53 @@
     (list rnd-atom remain)))
 
 ;; Given a VariableNode V and atom A, check that V is free in A.
-(define (is-free-variable-in-atom V A)
-  (if (equal? V A)
-      #t
-      (any (lambda (c) (is-free-variable-in-atom V c)) (cog-outgoing-set A))))
+(define (variable-free? V A)
+  (if (member V (cog-free-variables A)) #t #f))
 
 ;; Given a TypedVariable V and atom A, check that V is free in A.
-(define (is-free-typed-variable-in-atom TyV A)
-  (is-free-variable-in-atom (gar TyV) A))
+(define (typed-variable-free? TyV A)
+  (variable-free? (strip-type-from-variable TyV) A))
+
+;; Given a Variable or a VariableList return a list of the variable(s)
+(define (variable-list TyVs)
+  (if (equal? (cog-type TyVs) 'VariableList)
+      (cog-outgoing-set TyVs)
+      (list TyVs)))
 
 ;; Given a variable or a variable list, check that all variables are
 ;; free in A.
-(define (is-all-typed-variables-free-in-atom TyVs A)
-  (if (equal? (cog-type TyVs) 'VariableList)
-      (every (lambda (TyV) (is-free-typed-variable-in-atom TyV A))
-             (cog-outgoing-set TyVs))
-      (is-free-typed-variable-in-atom TyVs A)))
+(define (typed-variables-free? TyVs A)
+  (every (lambda (TyV) (typed-variable-free? TyV A)) (variable-list TyVs)))
+
+;; Given a typed variable or typed variable list, return a
+;; VariableList of all typed variables free in A.
+(define (filter-free-typed-variables TyVs A)
+  (let ((typed-variable-free-in-A? (lambda (TyV) (typed-variable-free? TyV A))))
+    (VariableList (filter typed-variable-free-in-A? (variable-list TyVs)))))
+
+;; Given a typed variable or typed variable list, return a list of all
+;; variables not free in A, stripped from their types.
+(define (unfree-variables TyVs A)
+  (let* ((unfree-var-in-A? (lambda (TyV) (not (typed-variable-free? TyV A))))
+         (unfree-typed-vars (filter unfree-var-in-A? (variable-list TyVs)))
+         (unfree-vars (map strip-type-from-variable unfree-typed-vars)))
+    unfree-vars))
 
 ;; Given 2 atoms, a list of variables (or a single variable) and a
 ;; condition P, return a random term list (or a single term in case
 ;; there was just a single variable) satisfying the type constraint
-;; and the condition.
+;; and the condition. Works even if TyVs has extra variables not in P,
+;; in such a case the corresponding terms only need to satisfy the
+;; type contraints.
 (define (select-conditioned-substitution-terms TyVs P)
-  (if (is-all-typed-variables-free-in-atom TyVs P)
-      (let* (
-                                        ; Build pattern matcher query
-                                        ; for the subtitution terms
-             (query (GetLink TyVs P))
-                                        ; Fetch all possible substitution terms
-             (result (cog-execute! query)))
-        ;; Select one randomly, but first purge the query to not pollute
-        ;; the atomspace
+  (let* (
+         ;; Get all unfree variables stripped from their types
+         (unfree-vars (unfree-variables TyVs P))
+         ;; Build pattern matcher query for the subtitution terms
+         (query (GetLink TyVs (And P unfree-vars)))
+         ;; Fetch all possible substitution terms
+         (results (cog-execute! query)))
+        ;; Select one randomly, but first purge the query to not
+        ;; pollute the atomspace
         (extract-hypergraph query)
-        (select-rnd-outgoing result))
-      (cog-undefined-handle)))
+        (select-rnd-outgoing results)))

--- a/opencog/pln/rules/instantiation.scm
+++ b/opencog/pln/rules/instantiation.scm
@@ -123,7 +123,8 @@
          ;; Get all unfree variables stripped from their types
          (unfree-vars (unfree-variables TyVs P))
          ;; Build pattern matcher query for the subtitution terms
-         (query (GetLink TyVs (And P unfree-vars)))
+         (query-body (if (null? unfree-vars) P (And P unfree-vars)))
+         (query (GetLink TyVs query-body))
          ;; Fetch all possible substitution terms
          (results (cog-execute! query)))
         ;; Select one randomly, but first purge the query to not

--- a/tests/pln/rules/PLNRulesUTest.cxxtest
+++ b/tests/pln/rules/PLNRulesUTest.cxxtest
@@ -64,6 +64,7 @@ public:
 	void test_forall_partial_instantiation();
 	void test_forall_implication_to_higher_order();
 	void test_implication_full_instantiation();
+	void test_implication_full_instantiation_extra_variables();
 	void test_implication_partial_instantiation();
 	void test_implication_scope_distribution();
 	void test_and_lambda_distribution();
@@ -121,7 +122,7 @@ void PLNRulesUTest::test_deduction()
 	results = eval.eval_h("(cog-bind find-humans)");
 	TS_ASSERT_EQUALS(1, getarity(results));
     
-	// Apply the deduction rule
+	// Apply the rule
 	eval.eval_h("(cog-bind deduction-inheritance-rule)");
        
 	// After applying the deduction rule, it should know that all 3 of the
@@ -147,7 +148,7 @@ void PLNRulesUTest::test_and_construction()
 	             "opencog/pln/rules/and-construction-rule.scm");
 	load_scm_files_from_config(as);
 
-	// Apply the and rule
+	// Apply the rule
 	Handle results = eval.eval_h("(cog-bind-af and-construction-rule)");
 
 	// It should contain 1 groundings, and(A, B)
@@ -169,7 +170,7 @@ void PLNRulesUTest::test_or_construction()
 	             "opencog/pln/rules/or-construction-rule.scm");
 	load_scm_files_from_config(as);
 
-	// Apply the and rule
+	// Apply the rule
 	Handle results = eval.eval_h("(cog-bind-af or-construction-rule)");
 
 	// It should contain 1 groundings, or(A, B)
@@ -191,7 +192,7 @@ void PLNRulesUTest::test_not_construction()
 	             "opencog/pln/rules/not-construction-rule.scm");
 	load_scm_files_from_config(as);
 
-	// Apply the and rule
+	// Apply the rule
 	Handle results = eval.eval_h("(cog-bind-af not-construction-rule)");
 
 	// It should contain 2 groundings, not(A), not(B)
@@ -213,7 +214,7 @@ void PLNRulesUTest::test_forall_full_instantiation()
 	             "opencog/pln/rules/forall-instantiation-rule.scm");
 	load_scm_files_from_config(as);
 
-	// Apply the and rule
+	// Apply the rule
 	Handle rule = eval.eval_h("forall-full-instantiation-rule");
 	Handle results = bindlink(&as, rule);
 
@@ -252,7 +253,7 @@ void PLNRulesUTest::test_forall_partial_instantiation()
 	             "opencog/pln/rules/forall-instantiation-rule.scm");
 	load_scm_files_from_config(as);
 
-	// Apply the and rule
+	// Apply the rule
 	Handle rule = eval.eval_h("forall-partial-instantiation-rule");
 	Handle results = bindlink(&as, rule);
 
@@ -281,7 +282,7 @@ void PLNRulesUTest::test_forall_implication_to_higher_order()
 	             "opencog/pln/rules/forall-implication-to-higher-order-rule.scm");
 	load_scm_files_from_config(as);
 
-	// Apply the and rule
+	// Apply the rule
 	Handle rule = eval.eval_h("forall-implication-to-higher-order-rule");
 	Handle results = bindlink(&as, rule);
 	Handle expected = eval.eval_h
@@ -323,7 +324,7 @@ void PLNRulesUTest::test_implication_full_instantiation()
 	             "opencog/pln/rules/implication-instantiation-rule.scm");
 	load_scm_files_from_config(as);
 
-	// Apply the and rule
+	// Apply the rule
 	Handle rule = eval.eval_h("implication-full-instantiation-rule");
 	Handle results = bindlink(&as, rule);
 	Handle expected = eval.eval_h
@@ -336,6 +337,38 @@ void PLNRulesUTest::test_implication_full_instantiation()
 		 "   (EvaluationLink"
 		 "      (PredicateNode \"Q\")"
 		 "      (ConceptNode \"A\")))");
+
+	logger().debug() << "results = " << results->toString();
+	logger().debug() << "expected = " << expected->toString();
+
+	TS_ASSERT_EQUALS(results, expected);
+}
+
+/**
+ * Test implication-full-instantiation-rule defined in:
+ * opencog/pln/rules/implication-instantiation-rule.scm
+ */
+void PLNRulesUTest::test_implication_full_instantiation_extra_variables()
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	as.clear();
+
+	config().set("SCM_PRELOAD",
+	             "tests/pln/rules/implication-extra-variables.scm, "
+	             "opencog/pln/rules/implication-instantiation-rule.scm");
+	load_scm_files_from_config(as);
+
+	// Apply the rule
+	Handle rule = eval.eval_h("implication-full-instantiation-rule");
+	Handle results = bindlink(&as, rule);
+	Handle expected = eval.eval_h
+		("(SetLink"
+		 "   (EvaluationLink"
+		 "      (PredicateNode \"Q\")"
+		 "      (ListLink"
+		 "         (ConceptNode \"A\")"
+		 "         (ConceptNode \"A\"))))");
 
 	logger().debug() << "results = " << results->toString();
 	logger().debug() << "expected = " << expected->toString();
@@ -358,7 +391,7 @@ void PLNRulesUTest::test_implication_partial_instantiation()
 	             "opencog/pln/rules/implication-instantiation-rule.scm");
 	load_scm_files_from_config(as);
 
-	// Apply the and rule
+	// Apply the rule
 	Handle rule = eval.eval_h("implication-partial-instantiation-rule");
 	Handle results = bindlink(&as, rule);
 
@@ -416,7 +449,7 @@ void PLNRulesUTest::test_implication_scope_distribution()
 	             "opencog/pln/rules/implication-scope-distribution-rule.scm");
 	load_scm_files_from_config(as);
 
-	// Apply the and rule
+	// Apply the rule
 	Handle rule = eval.eval_h("implication-scope-distribution-rule");
 	Handle results = bindlink(&as, rule);
 	Handle expected = eval.eval_h
@@ -500,7 +533,7 @@ void PLNRulesUTest::test_and_lambda_distribution()
 	             "opencog/pln/rules/and-lambda-distribution-rule.scm");
 	load_scm_files_from_config(as);
 
-	// Apply the and rule
+	// Apply the rule
 	Handle rule = eval.eval_h("and-lambda-distribution-rule");
 	Handle results = bindlink(&as, rule);
 	Handle expected = eval.eval_h
@@ -538,7 +571,7 @@ void PLNRulesUTest::test_implication_implicant_distribution()
 	             "opencog/pln/rules/implication-implicant-distribution-rule.scm");
 	load_scm_files_from_config(as);
 
-	// Apply the and rule
+	// Apply the rule
 	Handle rule = eval.eval_h("implication-implicant-distribution-rule");
 	Handle results = bindlink(&as, rule);
 	Handle expected = eval.eval_h
@@ -570,7 +603,7 @@ void PLNRulesUTest::test_implication_construction()
 	             "opencog/pln/rules/implication-construction-rule.scm");
 	load_scm_files_from_config(as);
 
-	// Apply the and rule
+	// Apply the rule
 	Handle rule = eval.eval_h("implication-construction-rule");
 	Handle results = bindlink(&as, rule);
 	Handle expected = eval.eval_h
@@ -603,7 +636,7 @@ void PLNRulesUTest::test_lambda_grounded_construction()
 	             "opencog/pln/rules/lambda-grounded-construction-rule.scm");
 	load_scm_files_from_config(as);
 
-	// Apply the and rule
+	// Apply the rule
 	Handle rule = eval.eval_h("lambda-grounded-construction-rule");
 	Handle results = bindlink(&as, rule);
 	Handle expected = eval.eval_h
@@ -635,7 +668,7 @@ void PLNRulesUTest::test_equivalence_to_double_implication()
 	             "opencog/pln/rules/equivalence-to-double-implication-rule.scm");
 	load_scm_files_from_config(as);
 
-	// Apply the and rule
+	// Apply the rule
 	Handle rule_alias =
 		eval.eval_h("equivalence-to-double-implication-rule-name"),
 		rbs = as.add_node(CONCEPT_NODE, "dummy rbs"),
@@ -677,7 +710,7 @@ void PLNRulesUTest::test_implication_and_lambda_factorization()
 	             "opencog/pln/rules/implication-and-lambda-factorization-rule.scm");
 	load_scm_files_from_config(as);
 
-	// Apply the and rule
+	// Apply the rule
 	Handle rule = eval.eval_h("implication-and-lambda-factorization-rule");
 	Handle results = bindlink(&as, rule);
 	Handle expected = eval.eval_h
@@ -728,7 +761,7 @@ void PLNRulesUTest::test_implication_implicant_conjunction()
 	             "opencog/pln/rules/implication-implicant-conjunction-rule.scm");
 	load_scm_files_from_config(as);
 
-	// Apply the and rule
+	// Apply the rule
 	Handle rule = eval.eval_h("implication-implicant-conjunction-rule");
 	Handle results = bindlink(&as, rule);
 	Handle expected = eval.eval_h

--- a/tests/pln/rules/implication-extra-variables.scm
+++ b/tests/pln/rules/implication-extra-variables.scm
@@ -1,0 +1,22 @@
+;; Define implication with extra variable in the implicand
+
+(ImplicationLink (stv 1 1)
+   (VariableList
+      (TypedVariableLink
+        (VariableNode "$X")
+        (TypeNode "ConceptNode"))
+     (TypedVariableLink
+        (VariableNode "$Y")
+        (TypeNode "ConceptNode")))
+   (EvaluationLink (stv 0.2 0.9)
+      (PredicateNode "P")
+      (VariableNode "$X"))
+   (EvaluationLink
+      (PredicateNode "Q")
+      (List
+         (VariableNode "$X")
+         (VariableNode "$Y"))))
+
+(EvaluationLink (stv 1 1)
+   (PredicateNode "P")
+   (ConceptNode "A"))


### PR DESCRIPTION
It's all in the comment of select-conditioned-substitution-terms

```scheme
;; and the condition. Works even if TyVs has extra variables not in P,
;; in such a case the corresponding terms only need to satisfy the
;; type contraints.
```