### PR TITLE
Avoid boost ASIO crash

### DIFF
--- a/opencog/cogserver/server/BuiltinRequestsModule.cc
+++ b/opencog/cogserver/server/BuiltinRequestsModule.cc
@@ -64,6 +64,7 @@ void BuiltinRequestsModule::registerAgentRequests()
     do_quit_register();
     do_q_register();
     do_ctrld_register();
+    do_dot_register();
 
     do_startAgents_register();
     do_stopAgents_register();
@@ -83,6 +84,7 @@ void BuiltinRequestsModule::unregisterAgentRequests()
     do_quit_unregister();
     do_q_unregister();
     do_ctrld_unregister();
+    do_dot_unregister();
 
     do_startAgents_unregister();
     do_stopAgents_unregister();
@@ -120,6 +122,11 @@ std::string BuiltinRequestsModule::do_q(Request *req, std::list<std::string> arg
 }
 
 std::string BuiltinRequestsModule::do_ctrld(Request *req, std::list<std::string> args)
+{
+    return do_exit(req, args);
+}
+
+std::string BuiltinRequestsModule::do_dot(Request *req, std::list<std::string> args)
 {
     return do_exit(req, args);
 }

--- a/opencog/cogserver/server/BuiltinRequestsModule.h
+++ b/opencog/cogserver/server/BuiltinRequestsModule.h
@@ -79,6 +79,12 @@ DECLARE_CMD_REQUEST(BuiltinRequestsModule, "", do_ctrld,
        "Close the shell TCP/IP connection.\n",
        false, true)
 
+DECLARE_CMD_REQUEST(BuiltinRequestsModule, ".", do_dot,
+       "Close the shell connection",
+       "Usage: .\n\n"
+       "Close the shell TCP/IP connection.\n",
+       false, true)
+
 DECLARE_CMD_REQUEST(BuiltinRequestsModule, "help", do_help,
        "List the available commands or print the help for a specific command",
        "Usage: help [<command>]\n\n"


### PR DESCRIPTION
Apparently, the boost asio library is not thread-safe.  Use a lock to serialize access.