### PR TITLE
Check the truth value of the psi-rule before evaluating the context

### DIFF
--- a/opencog/openpsi/action-selector.scm
+++ b/opencog/openpsi/action-selector.scm
@@ -244,7 +244,7 @@
         ; FIXME; Replace by
         ; (psi-most-weighted-rules (psi-get-satisfiable-rules demand))
         ;(if (or (equal? 0 (cog-af-boundary)) (equal? 1 (cog-af-boundary)))
-            (most-weighted-atoms (psi-get-satisfiable-rules demand))
+            (most-weighted-atoms (psi-get-weighted-satisfiable-rules demand))
             ;(most-important-weighted-atoms (psi-get-all-satisfiable-rules))
         ;)
     )

--- a/opencog/openpsi/rule.scm
+++ b/opencog/openpsi/rule.scm
@@ -283,10 +283,34 @@ there are 100K rules!
 )
 
 ; --------------------------------------------------------------
+(define-public (psi-get-weighted-satisfiable-rules demand-node)
+"
+  Returns a list of all the psi-rules that are satisfiable and
+  have a non-zero strength
+"
+    (filter
+        (lambda (x) (and (> (cog-stv-strength x) 0)
+            (equal? (stv 1 1) (psi-satisfiable? x))))
+        (psi-get-rules demand-node))
+)
+
+; --------------------------------------------------------------
 (define-public (psi-get-all-satisfiable-rules)
 "
   Returns a list of all the psi-rules that are satisfiable.
 "
     (filter  (lambda (x) (equal? (stv 1 1) (psi-satisfiable? x)))
+        (psi-get-all-rules))
+)
+
+; --------------------------------------------------------------
+(define-public (psi-get-all-weighted-satisfiable-rules)
+"
+  Returns a list of all the psi-rules that are satisfiable and
+  have a non-zero strength
+"
+    (filter
+        (lambda (x) (and (> (cog-stv-strength x) 0)
+            (equal? (stv 1 1) (psi-satisfiable? x))))
         (psi-get-all-rules))
 )


### PR DESCRIPTION
It should save some cpu time if we skip evaluating the contexts of the rules in each psi-step that are having zero tv-strength (e.g. turned off by using the sliders)