### PR TITLE
Fix compile error in PyEvalUTest and PythonModuleUTest

### DIFF
--- a/tests/cython/PyEvalUTest.cxxtest
+++ b/tests/cython/PyEvalUTest.cxxtest
@@ -15,7 +15,7 @@ class StringRequestResult : public RequestResult
 {
 public:
     string result;
-    StringRequestResult(): RequestResult ("text/plain"){};
+    StringRequestResult(): RequestResult (/*"text/plain"*/){};
     ~StringRequestResult(){};
     virtual void SendResult(const std::string& res) {
         result = res;

--- a/tests/cython/PythonModuleUTest.cxxtest
+++ b/tests/cython/PythonModuleUTest.cxxtest
@@ -14,7 +14,7 @@ class StringRequestResult : public RequestResult
 {
 public:
     string result;
-    StringRequestResult(): RequestResult ("text/plain"){};
+    StringRequestResult(): RequestResult (/*"text/plain"*/){};
     ~StringRequestResult(){};
     virtual void SendResult(const std::string& res) {
         result = res;


### PR DESCRIPTION
OpenCog utests are broken, does even compile.

This fixes compiling errors.

Don't merge just yet, more is coming.