### PR TITLE
Wrap boost::asio::write in a conditional

### DIFF
--- a/opencog/cogserver/server/ServerSocket.cc
+++ b/opencog/cogserver/server/ServerSocket.cc
@@ -42,15 +42,21 @@ ServerSocket::~ServerSocket()
 
 void ServerSocket::Send(const std::string& cmd)
 {
-    boost::system::error_code error;
-    boost::asio::write(*_socket, boost::asio::buffer(cmd),
-                       boost::asio::transfer_all(), error);
+    if (_socket)
+    {
+        boost::system::error_code error;
+        boost::asio::write(*_socket, boost::asio::buffer(cmd),
+                           boost::asio::transfer_all(), error);
 
-    // The most likely cause of an error is that the remote side has
-    // closed the socket, and we just don't know it yet.  We should
-    // maybe not log those errors?
-    if (error)
-        logger().warn("ServerSocket::Send(): %s", error.message().c_str());
+        // The most likely cause of an error is that the remote side has
+        // closed the socket, and we just don't know it yet.  We should
+        // maybe not log those errors?
+        if (error)
+            logger().warn("ServerSocket::Send(): %s", error.message().c_str());
+    }
+    else
+        logger().warn("ServerSocket::Send(): cannot send '%s' "
+                      "because _socket is nullptr", cmd.c_str());
 }
 
 // As far as I can tell, boost::asio is not actually thread-safe,


### PR DESCRIPTION
Based on Mandeep and Misgana finding. There's no doubt that something
else is going wrong because this should not be called on a null
_socket, but it doesn't hurt to have this conditional.