### PR TITLE
Fix build on Boost 1.58.0

### DIFF
--- a/opencog/spatial/Entity.cc
+++ b/opencog/spatial/Entity.cc
@@ -25,6 +25,7 @@
 #include <cstring>
 #include <cassert>
 
+#include <boost/type_traits/remove_cv.hpp>
 #include <boost/variant/get.hpp>
 
 #include <opencog/spatial/Entity.h>


### PR DESCRIPTION
Hello,

On Ubuntu 16.04 with Boost 1.58.0 OpenCog does not compile. This pull request solves the issue: https://github.com/opencog/opencog/issues/2331.

Best regards,
Samuel