### PR TITLE
Fix for bug #2328

### DIFF
--- a/opencog/cogserver/server/ServerSocket.cc
+++ b/opencog/cogserver/server/ServerSocket.cc
@@ -57,8 +57,8 @@ void ServerSocket::Send(const std::string& cmd)
     // I beleive this is a ENOTCON errno, maybe its another one as well.
     // Don't log these harmless errors.
     if (error.value() != boost::system::errc::success and
-        error.value() != boost::system::errc::not_connected and
-        error.value() != boost::system::errc::bad_descriptor)
+        error.value() != boost::asio::error::not_connected and
+        error.value() != boost::asio::error::bad_descriptor)
         logger().warn("ServerSocket::Send(): %s on thread 0x%x",
              error.message().c_str(), pthread_self());
 }

--- a/opencog/cogserver/server/ServerSocket.cc
+++ b/opencog/cogserver/server/ServerSocket.cc
@@ -57,8 +57,10 @@ void ServerSocket::Send(const std::string& cmd)
     // I beleive this is a ENOTCON errno, maybe its another one as well.
     // Don't log these harmless errors.
     if (error.value() != boost::system::errc::success and
-        error.value() != boost::system::errc::not_connected)
-        logger().warn("ServerSocket::Send(): %s", error.message().c_str());
+        error.value() != boost::system::errc::not_connected and
+        error.value() != boost::system::errc::bad_descriptor)
+        logger().warn("ServerSocket::Send(): %s on thread 0x%x",
+             error.message().c_str(), pthread_self());
 }
 
 // As far as I can tell, boost::asio is not actually thread-safe,

--- a/opencog/cogserver/shell/GenericShell.h
+++ b/opencog/cogserver/shell/GenericShell.h
@@ -23,6 +23,8 @@
 #ifndef _OPENCOG_GENERIC_SHELL_H
 #define _OPENCOG_GENERIC_SHELL_H
 
+#include <condition_variable>
+#include <mutex>
 #include <string>
 #include <thread>
 
@@ -37,7 +39,7 @@
  *
  * If instead a module has only a small number of simple commands that
  * need to be implemented, then the DECLARE_CMD_REQUEST function, defined
- * in Request.h, provides a simpler and easier way implementing comands.
+ * in Request.h, provides a simpler and easier way implementing commands.
  */
 
 namespace opencog {
@@ -66,13 +68,20 @@ class GenericShell
 		std::thread* evalthr;
 		std::thread* pollthr;
 
+		// Concurrency handling
+		bool _eval_done;
+		std::condition_variable _cv;
+		std::mutex _mtx;
+		void start_eval();
+		void finish_eval();
+		void while_not_done();
+
 		virtual void thread_init(void);
 		virtual void line_discipline(const std::string &expr);
 		virtual void do_eval(const std::string &expr);
 
 		// Output handling.
 		bool poll_needed;
-		bool eval_done;
 		virtual void put_output(const std::string&);
 		virtual std::string poll_output();
 

--- a/opencog/cogserver/shell/SchemeShell.cc
+++ b/opencog/cogserver/shell/SchemeShell.cc
@@ -48,9 +48,6 @@ SchemeShell::SchemeShell(void)
 
 	// Set the inital atomspace for this thread.
 	SchemeEval::set_scheme_as(&cogserver().getAtomSpace());
-	evaluator->begin_eval();
-	evaluator->eval_expr("(setlocale LC_CTYPE \"\")");
-	evaluator->poll_result();
 }
 
 SchemeShell::~SchemeShell()

--- a/opencog/cogserver/shell/SchemeShell.cc
+++ b/opencog/cogserver/shell/SchemeShell.cc
@@ -52,6 +52,11 @@ SchemeShell::SchemeShell(void)
 
 SchemeShell::~SchemeShell()
 {
+	// We must stall until after the evaluator has finished
+	// evaluating. Otherwise, the thread_init() method (below)
+	// might never get a chance to run, leading to a NULL
+	// atomspace, leading to a crash.  Bug #2328.
+	while_not_done();
 }
 
 /**


### PR DESCRIPTION
I believe that this should fix bug #2328, although I have not finished testing.

The core issue was this: shell was being destroyed (because netcat closed the socket) even before evaluation of the expression that was sent even started.  As a result, initialization is skipped (the shell destructor tears down the virtual function vtable; initialization was being done in c++ virtual functions).  The initialization set the atomspace; without that, the atomspace is null, leading to a crash.