### PR TITLE
Last fix for bug #2328

### DIFF
--- a/opencog/cogserver/server/CogServer.cc
+++ b/opencog/cogserver/server/CogServer.cc
@@ -598,6 +598,7 @@ void CogServer::loadModules(std::vector<std::string> module_paths)
         for (auto p : get_module_paths()) {
             module_paths.push_back(p);
             module_paths.push_back(p + "/opencog");
+            module_paths.push_back(p + "/opencog/modules");
         }
     }
 

--- a/opencog/cogserver/server/NetworkServer.cc
+++ b/opencog/cogserver/server/NetworkServer.cc
@@ -52,12 +52,17 @@ NetworkServer::~NetworkServer()
 
 void NetworkServer::stop()
 {
+    if (not _running) return;
     _running = false;
+
+    boost::system::error_code ec;
+    _acceptor.cancel(ec);
     _io_service.stop();
 
     _listener_thread->join();
+    _listener_thread = nullptr;
     _service_thread->join();
-    // delete _service_thread;
+    _service_thread = nullptr;
 }
 
 void NetworkServer::listen()

--- a/opencog/cogserver/server/NetworkServer.cc
+++ b/opencog/cogserver/server/NetworkServer.cc
@@ -59,6 +59,8 @@ void NetworkServer::stop()
     _acceptor.cancel(ec);
     _io_service.stop();
 
+    // Booost::asio hangs, despite the above.  Brute-force it to
+    // get it's head out of it's butt, and do the right thing.
     pthread_cancel(_listener_thread->native_handle());
 
     _listener_thread->join();
@@ -93,6 +95,8 @@ void NetworkServer::listen()
 
 void NetworkServer::run()
 {
+    if (_running) return;
+
     _listener_thread = new std::thread(&NetworkServer::listen, this);
 
     while (_running)

--- a/opencog/cogserver/server/NetworkServer.cc
+++ b/opencog/cogserver/server/NetworkServer.cc
@@ -59,6 +59,8 @@ void NetworkServer::stop()
     _acceptor.cancel(ec);
     _io_service.stop();
 
+    pthread_cancel(_listener_thread->native_handle());
+
     _listener_thread->join();
     _listener_thread = nullptr;
     _service_thread->join();

--- a/opencog/cogserver/server/NetworkServer.h
+++ b/opencog/cogserver/server/NetworkServer.h
@@ -62,15 +62,10 @@ protected:
     short _port;
     boost::asio::io_service _io_service;
     boost::asio::ip::tcp::acceptor _acceptor;
-    std::thread* _service_thread;
     std::thread* _listener_thread;
 
-    /** Stops the server */
-    void stop();
-
-    /** The network server's thread main method.  */
+    /** The network server's main listener thread.  */
     void listen();
-    void run();
 
 public:
 
@@ -80,6 +75,10 @@ public:
      */
     NetworkServer(unsigned short port);
     ~NetworkServer();
+
+    /** Start and stop the server */
+    void run();
+    void stop();
 
 }; // class
 

--- a/opencog/cogserver/server/ServerSocket.cc
+++ b/opencog/cogserver/server/ServerSocket.cc
@@ -58,6 +58,7 @@ void ServerSocket::Send(const std::string& cmd)
     // Don't log these harmless errors.
     if (error.value() != boost::system::errc::success and
         error.value() != boost::asio::error::not_connected and
+        error.value() != boost::asio::error::broken_pipe and
         error.value() != boost::asio::error::bad_descriptor)
         logger().warn("ServerSocket::Send(): %s on thread 0x%x",
              error.message().c_str(), pthread_self());

--- a/opencog/cogserver/shell/GenericShell.cc
+++ b/opencog/cogserver/shell/GenericShell.cc
@@ -74,8 +74,7 @@ GenericShell::~GenericShell()
 		logger().debug("[GenericShell] dtor, wait for eval thread 0x%x.",
 		               evalthr->native_handle());
 		evalthr->join();
-		logger().debug("[GenericShell] dtor, joined eval thread 0x%x.",
-		               evalthr->native_handle());
+		logger().debug("[GenericShell] dtor, joined eval thread");
 		delete evalthr;
 		evalthr = nullptr;
 	}

--- a/opencog/cogserver/shell/GenericShell.h
+++ b/opencog/cogserver/shell/GenericShell.h
@@ -55,6 +55,10 @@ class GenericShell
 	private:
 		std::string pending_output;
 
+		ConsoleSocket* socket;
+		std::thread* evalthr;
+		std::thread* pollthr;
+
 	protected:
 		std::string abort_prompt;
 		std::string normal_prompt;
@@ -63,22 +67,19 @@ class GenericShell
 		bool show_prompt;
 		bool self_destruct;
 
-		ConsoleSocket* socket;
-		GenericEval* evaluator;
-		std::thread* evalthr;
-		std::thread* pollthr;
+		virtual GenericEval* get_evaluator(void) = 0;
+		virtual void thread_init(void);
+		virtual void line_discipline(const std::string &expr);
+		virtual void do_eval(const std::string &expr);
 
 		// Concurrency handling
 		bool _eval_done;
 		std::condition_variable _cv;
 		std::mutex _mtx;
+		GenericEval* _evaluator;
 		void start_eval();
 		void finish_eval();
 		void while_not_done();
-
-		virtual void thread_init(void);
-		virtual void line_discipline(const std::string &expr);
-		virtual void do_eval(const std::string &expr);
 
 		// Output handling.
 		bool poll_needed;

--- a/opencog/cogserver/shell/PythonShell.cc
+++ b/opencog/cogserver/shell/PythonShell.cc
@@ -57,18 +57,13 @@ PythonShell::~PythonShell()
     //	if (evaluator) delete evaluator;
 }
 
-/**
- * Register this shell with the console.
- */
-void PythonShell::set_socket(ConsoleSocket *s)
+GenericEval* PythonShell::get_evaluator(void)
 {
-    // Let the generic shell do the basic work.
-    GenericShell::set_socket(s);
-
     // We are using a singlton instance here, because the current
     // Python evaluator isn't thread safe.  If/when it does become
     // thread-safe, we should probably go multi-threaed, instead.
     if (!evaluator) evaluator = &PythonEval::instance();
+    return evaluator;
 }
 
 void PythonShell::eval(const std::string &expr)

--- a/opencog/cogserver/shell/PythonShell.h
+++ b/opencog/cogserver/shell/PythonShell.h
@@ -44,10 +44,12 @@ namespace opencog
 
 class PythonShell: public GenericShell
 {
+private:
+    GenericEval* evaluator;
 public:
     PythonShell(void);
     virtual ~PythonShell();
-    virtual void set_socket(ConsoleSocket *);
+    virtual GenericEval* get_evaluator(void);
     virtual void eval(const std::string &);
 };
 

--- a/opencog/cogserver/shell/SchemeShell.cc
+++ b/opencog/cogserver/shell/SchemeShell.cc
@@ -44,8 +44,6 @@ SchemeShell::SchemeShell(void)
 
 	pending_prompt = "... ";
 
-	evaluator = SchemeEval::get_evaluator();
-
 	// Set the inital atomspace for this thread.
 	SchemeEval::set_scheme_as(&cogserver().getAtomSpace());
 }
@@ -57,6 +55,11 @@ SchemeShell::~SchemeShell()
 	// might never get a chance to run, leading to a NULL
 	// atomspace, leading to a crash.  Bug #2328.
 	while_not_done();
+}
+
+GenericEval* SchemeShell::get_evaluator(void)
+{
+	return SchemeEval::get_evaluator();
 }
 
 /**

--- a/opencog/cogserver/shell/SchemeShell.h
+++ b/opencog/cogserver/shell/SchemeShell.h
@@ -42,6 +42,7 @@ class SchemeShell : public GenericShell
 	public:
 		SchemeShell(void);
 		virtual ~SchemeShell();
+		virtual GenericEval* get_evaluator(void);
 };
 
 /** @}*/

--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -9,9 +9,10 @@ LINK_DIRECTORIES(
 	${PROJECT_BINARY_DIR}/opencog/cogserver/server
 )
 
-LINK_LIBRARIES(#CogServerUTest
+LINK_LIBRARIES(
 	server
 )
 
 ADD_CXXTEST(CogServerUTest)
+ADD_CXXTEST(ShellUTest)
 ADD_CXXTEST(AgentUTest)

--- a/tests/server/ShellUTest.cxxtest
+++ b/tests/server/ShellUTest.cxxtest
@@ -21,11 +21,34 @@
  */
 
 #include <thread>
+#include <unistd.h>
 
 #include <opencog/util/Config.h>
+#include <opencog/util/oc_assert.h>
 #include <opencog/cogserver/server/CogServer.h>
 
 using namespace opencog;
+
+void gargleblast(int secs)
+{
+	for (int i=0; i<secs; i++)
+	{
+		char buf[1000];
+		sprintf(buf, "echo '(Evaluation (Predicate \"visible face\") (List (Number %d)))\n' | nc localhost 17333", i);
+		int rc = system(buf);
+		OC_ASSERT(rc==0, "system call failure");
+		usleep(500000);
+
+		if (20 <= i)
+		{
+			sprintf(buf, "echo '(cog-delete (Evaluation (Predicate \"visible face\") (List (Number %d))))\n' | nc localhost 17333", i-20);
+			rc = system(buf);
+			OC_ASSERT(rc==0, "system call failure");
+
+		}
+		usleep(500000);
+	}
+}
 
 class ShellUTest :  public CxxTest::TestSuite
 {
@@ -59,8 +82,20 @@ public:
 	void testMessaging()
 	{
 		csrv = new CogServer();
-		std::thread * main_loop = new std::thread(&CogServer::serverLoop, csrv);
-		sleep(10);
+		std::thread* main_loop = new std::thread(&CogServer::serverLoop, csrv);
+
+#define NT 20
+		std::thread* pangalactic[NT];
+		int j;
+		for (j=0; j<NT; j++)
+		{
+			pangalactic[j] = new std::thread(&gargleblast, 60);
+		}
+		for (j=0; j<NT; j++)
+		{
+			pangalactic[j]->join();
+		}
+		sleep(3);
 		csrv->stop();
 		main_loop->join();
 		delete csrv;

--- a/tests/server/ShellUTest.cxxtest
+++ b/tests/server/ShellUTest.cxxtest
@@ -34,14 +34,14 @@ void gargleblast(int tid, int secs)
 	for (int i=0; i<secs; i++)
 	{
 		char buf[1000];
-		sprintf(buf, "echo '(Evaluation (Predicate \"visible face\") (List (Number %d)))\n' | nc localhost 17333", i);
+		sprintf(buf, "echo '(Evaluation (Predicate \"visible face\") (List (Number %d)))\n' | nc -q 1 localhost 17333", i);
 		int rc = system(buf);
 		OC_ASSERT(rc==0, "system call failure");
 		usleep(500000);
 
 		if (20 <= i)
 		{
-			sprintf(buf, "echo '(cog-delete (Evaluation (Predicate \"visible face\") (List (Number %d))))\n' | nc localhost 17333", i-20);
+			sprintf(buf, "echo '(cog-delete (Evaluation (Predicate \"visible face\") (List (Number %d))))\n' | nc -q 1 localhost 17333", i-20);
 			rc = system(buf);
 			OC_ASSERT(rc==0, "system call failure");
 

--- a/tests/server/ShellUTest.cxxtest
+++ b/tests/server/ShellUTest.cxxtest
@@ -29,7 +29,7 @@
 
 using namespace opencog;
 
-void gargleblast(int secs)
+void gargleblast(int tid, int secs)
 {
 	for (int i=0; i<secs; i++)
 	{
@@ -82,6 +82,9 @@ public:
 	void testMessaging()
 	{
 		csrv = new CogServer();
+		csrv->loadModules();
+		csrv->loadModule("libscheme-shell.so");
+		csrv->enableNetworkServer();
 		std::thread* main_loop = new std::thread(&CogServer::serverLoop, csrv);
 
 #define NT 20
@@ -89,7 +92,7 @@ public:
 		int j;
 		for (j=0; j<NT; j++)
 		{
-			pangalactic[j] = new std::thread(&gargleblast, 60);
+			pangalactic[j] = new std::thread(&gargleblast, j, 60);
 		}
 		for (j=0; j<NT; j++)
 		{

--- a/tests/server/ShellUTest.cxxtest
+++ b/tests/server/ShellUTest.cxxtest
@@ -1,0 +1,68 @@
+/*
+ * tests/server/ShellUTest.cxxtest
+ *
+ * Copyright (C) 2016 Linas Vepstas
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <thread>
+
+#include <opencog/util/Config.h>
+#include <opencog/cogserver/server/CogServer.h>
+
+using namespace opencog;
+
+class ShellUTest :  public CxxTest::TestSuite
+{
+private:
+	CogServer* csrv;
+
+public:
+
+	ShellUTest()
+	{
+		logger().set_level(Logger::DEBUG);
+		//logger().set_print_to_stdout_flag(true);
+	}
+
+	~ShellUTest()
+	{
+		// erase the log file if no assertions failed
+		if (!CxxTest::TestTracker::tracker().suiteFailed())
+			std::remove(logger().get_filename().c_str());
+	}
+
+	void setUp()
+	{
+		config().set("SERVER_PORT", "17333");
+	}
+
+	void tearDown()
+	{
+	}
+
+	void testMessaging()
+	{
+		csrv = new CogServer();
+		std::thread * main_loop = new std::thread(&CogServer::serverLoop, csrv);
+		sleep(10);
+		csrv->stop();
+		main_loop->join();
+		delete csrv;
+	}
+};


### PR DESCRIPTION
This fix contained here should resolve the stack trace starting with 
```
#2  0x00007f85a047766a in scm_gc_unprotect_object ()   from /usr/lib/libguile-2.0.so.22
#3  0x00007f859dbe59c0 in opencog::SchemeEval::do_poll_result() ( this=this@entry=0x7f84c40145d0)    at /home/nil
```
reported in bug #2328 

The issue was that multiple different threads were all using the same scheme evaluator, thus garbling it's internal state.  The design had always been that each thread get its own evaluator, but ... that wasn't actually happening.

Add a unit test for this.