### PR TITLE
Agent cleanup

### DIFF
--- a/opencog/attention/ImportanceDiffusionAgent.cc
+++ b/opencog/attention/ImportanceDiffusionAgent.cc
@@ -44,7 +44,7 @@ namespace opencog
 ImportanceDiffusionAgent::ImportanceDiffusionAgent(CogServer& cs) :
     Agent(cs)
 {
-    static const std::string defaultConfig[] = {
+    static const std::vector<std::string defaultConfig> ({
         //! Default value that normalised STI has to be above before
         //! being spread
         "ECAN_DIFFUSION_THRESHOLD","0.0",
@@ -52,17 +52,17 @@ ImportanceDiffusionAgent::ImportanceDiffusionAgent(CogServer& cs) :
         "ECAN_MAX_SPREAD_PERCENTAGE","1.0",
         "ECAN_ALL_LINKS_SPREAD","false",
         "",""
-    };
+    });
     setParameters(defaultConfig);
     spreadDecider = NULL;
 
     //! @todo won't respond to the parameters being changed later
     //! (not a problem at present, but could get awkward with, for example,
     //! automatic parameter adaptation)
-    maxSpreadPercentage = (float) (config().get_double("ECAN_MAX_SPREAD_PERCENTAGE"));
+    maxSpreadPercentage = (double) (config().get_double("ECAN_MAX_SPREAD_PERCENTAGE"));
 
     setSpreadDecider(STEP);
-    setDiffusionThreshold((float) (config().get_double("ECAN_DIFFUSION_THRESHOLD")));
+    setDiffusionThreshold((double) (config().get_double("ECAN_DIFFUSION_THRESHOLD")));
 
     allLinksSpread = config().get_bool("ECAN_ALL_LINKS_SPREAD");
 
@@ -82,7 +82,7 @@ Logger* ImportanceDiffusionAgent::getLogger()
     return log;
 }
 
-void ImportanceDiffusionAgent::setSpreadDecider(int type, float shape)
+void ImportanceDiffusionAgent::setSpreadDecider(int type, double shape)
 {
     if (spreadDecider) {
         delete spreadDecider;
@@ -107,18 +107,18 @@ ImportanceDiffusionAgent::~ImportanceDiffusionAgent()
     }
 }
 
-void ImportanceDiffusionAgent::setMaxSpreadPercentage(float p)
+void ImportanceDiffusionAgent::setMaxSpreadPercentage(double p)
 { maxSpreadPercentage = p; }
 
-float ImportanceDiffusionAgent::getMaxSpreadPercentage() const
+double ImportanceDiffusionAgent::getMaxSpreadPercentage() const
 { return maxSpreadPercentage; }
 
-void ImportanceDiffusionAgent::setDiffusionThreshold(float p)
+void ImportanceDiffusionAgent::setDiffusionThreshold(double p)
 {
     diffusionThreshold = p;
 }
 
-float ImportanceDiffusionAgent::getDiffusionThreshold() const
+double ImportanceDiffusionAgent::getDiffusionThreshold() const
 { return diffusionThreshold; }
 
 void ImportanceDiffusionAgent::run()
@@ -147,7 +147,7 @@ int ImportanceDiffusionAgent::makeDiffusionAtomsMap(std::map<Handle,int> &diffus
         HandleSeq targets;
         HandleSeq::iterator targetItr;
         Handle linkHandle = *hi;
-        float val = a->get_TV(linkHandle)->toFloat();
+        double val = a->get_TV(linkHandle)->toFloat();
         if (val == 0.0f) {
             continue;
         }
@@ -230,7 +230,7 @@ void ImportanceDiffusionAgent::makeConnectionMatrix(bmatrix* &connections_,
         int targetIndex;
         Type type;
 
-        float val = a->get_TV(*hi)->toFloat();
+        double val = a->get_TV(*hi)->toFloat();
         if (val == 0.0f) continue;
         //val *= diffuseTemperature;
         type = a->get_type(*hi); 
@@ -391,8 +391,8 @@ void ImportanceDiffusionAgent::spreadImportance()
     }*/
 
     if (log->is_fine_enabled()) {
-        float normAF;
-        normAF = (a->get_attentional_focus_boundary() - a->get_min_STI(false)) / (float) ( a->get_max_STI(false) - a->get_min_STI(false) );
+        double normAF;
+        normAF = (a->get_attentional_focus_boundary() - a->get_min_STI(false)) / (double) ( a->get_max_STI(false) - a->get_min_STI(false) );
         log->fine("Result (AF at %.3f)\n",normAF);
         printVector(&result,normAF);
 //        printVector(result,0.5f);
@@ -415,7 +415,7 @@ void ImportanceDiffusionAgent::spreadImportance()
     }
 #if 0 //def DEBUG
     if (totalSTI != totalSTI_After) {
-        // This warning is often logged because of floating point round offs
+        // This warning is often logged because of doubleing point round offs
         // when converting from normalised to actual STI values after diffusion.
         log->warn("Total STI before diffusion (%d) != Total STI after (%d)",totalSTI,totalSTI_After);
     }
@@ -430,14 +430,14 @@ void ImportanceDiffusionAgent::spreadImportance()
 //    delete result;
 }
 
-void ImportanceDiffusionAgent::setScaledSTI(Handle h, float scaledSTI)
+void ImportanceDiffusionAgent::setScaledSTI(Handle h, double scaledSTI)
 {
     AttentionValue::sti_t val;
 
     val = (AttentionValue::sti_t) (a->get_min_STI(false) + (scaledSTI * ( a->get_max_STI(false) - a->get_min_STI(false) )));
 /*
     AtomSpace *a = _cogserver.getAtomSpace();
-    float af = a->getAttentionalFocusBoundary();
+    double af = a->getAttentionalFocusBoundary();
     scaledSTI = (scaledSTI * 2) - 1;
     if (scaledSTI <= 1.0) {
         val = a->getMinSTI(false) + (scaledSTI * ( a->getMinSTI(false) - af ));
@@ -451,8 +451,8 @@ void ImportanceDiffusionAgent::setScaledSTI(Handle h, float scaledSTI)
 
 void ImportanceDiffusionAgent::printMatrix(bmatrix* m)
 {
-    typedef boost::numeric::ublas::compressed_matrix<float>::iterator1 it1_t;
-    typedef boost::numeric::ublas::compressed_matrix<float>::iterator2 it2_t;
+    typedef boost::numeric::ublas::compressed_matrix<double>::iterator1 it1_t;
+    typedef boost::numeric::ublas::compressed_matrix<double>::iterator2 it2_t;
 
     for (it1_t it1 = m->begin1(); it1 != m->end1(); it1++) {
         for (it2_t it2 = it1.begin(); it2 != it1.end(); it2++) {
@@ -461,9 +461,9 @@ void ImportanceDiffusionAgent::printMatrix(bmatrix* m)
     }
 }
 
-void ImportanceDiffusionAgent::printVector(bvector* v, float threshold)
+void ImportanceDiffusionAgent::printVector(bvector* v, double threshold)
 {
-    typedef boost::numeric::ublas::vector<float>::iterator it_t;
+    typedef boost::numeric::ublas::vector<double>::iterator it_t;
 
     for (it_t it = v->begin(); it != v->end(); ++it) {
         if (*it > threshold) {
@@ -480,7 +480,7 @@ RandGen* SpreadDecider::rng = NULL;
 
 bool SpreadDecider::spreadDecision(AttentionValue::sti_t s)
 {
-    if (getRNG()->randfloat() < function(s))
+    if (getRNG()->randdouble() < function(s))
         return true;
     else
         return false;
@@ -497,20 +497,20 @@ double HyperbolicDecider::function(AttentionValue::sti_t s)
 {
     AtomSpace& a = _cogserver.getAtomSpace();
     // Convert boundary from -1..1 to 0..1
-    float af = a.get_attentional_focus_boundary();
-    float minSTI = a.get_min_STI(false);
-    float maxSTI = a.get_max_STI(false);
-    float norm_b = focusBoundary > 0.0f ?
+    double af = a.get_attentional_focus_boundary();
+    double minSTI = a.get_min_STI(false);
+    double maxSTI = a.get_max_STI(false);
+    double norm_b = focusBoundary > 0.0f ?
         af + (focusBoundary * (maxSTI - af)) :
         af + (focusBoundary * (af - minSTI ));
     // norm_b is now the actual STI value, normalise to 0..1
-    norm_b = (norm_b - minSTI) / (float) ( maxSTI - minSTI );
+    norm_b = (norm_b - minSTI) / (double) ( maxSTI - minSTI );
     // Scale s to 0..1
-    float norm_s = (s - minSTI) / (float) ( maxSTI - minSTI );
+    double norm_s = (s - minSTI) / (double) ( maxSTI - minSTI );
     return (tanh(shape*(norm_s-norm_b))+1.0f)/2.0f;
 }
 
-void HyperbolicDecider::setFocusBoundary(float b)
+void HyperbolicDecider::setFocusBoundary(double b)
 {
     // Store as -1..1 since exact 0..1 mapping of boundary
     // will change based on min/max STI
@@ -522,11 +522,11 @@ double StepDecider::function(AttentionValue::sti_t s)
     return (s>focusBoundary ? 1.0f : 0.0f);
 }
 
-void StepDecider::setFocusBoundary(float b)
+void StepDecider::setFocusBoundary(double b)
 {
     AtomSpace& a = _cogserver.getAtomSpace();
     // Convert to an exact STI amount
-    float af = a.get_attentional_focus_boundary();
+    double af = a.get_attentional_focus_boundary();
     focusBoundary = (b > 0.0f)?
         (int) (af + (b * (a.get_max_STI(false) - af))) :
         (int) (af + (b * (af - a.get_min_STI(false))));

--- a/opencog/attention/ImportanceDiffusionAgent.cc
+++ b/opencog/attention/ImportanceDiffusionAgent.cc
@@ -44,7 +44,7 @@ namespace opencog
 ImportanceDiffusionAgent::ImportanceDiffusionAgent(CogServer& cs) :
     Agent(cs)
 {
-    static const std::vector<std::string> defaultConfig({
+    setParameters({
         //! Default value that normalised STI has to be above before
         //! being spread
         "ECAN_DIFFUSION_THRESHOLD","0.0",
@@ -53,7 +53,6 @@ ImportanceDiffusionAgent::ImportanceDiffusionAgent(CogServer& cs) :
         "ECAN_ALL_LINKS_SPREAD","false",
         "",""
     });
-    setParameters(defaultConfig);
     spreadDecider = NULL;
 
     //! @todo won't respond to the parameters being changed later

--- a/opencog/attention/ImportanceDiffusionAgent.h
+++ b/opencog/attention/ImportanceDiffusionAgent.h
@@ -40,16 +40,14 @@
 #include <opencog/util/RandGen.h>
 #include "SpreadDecider.h"
 
-typedef boost::numeric::ublas::vector<float> bvector;
-typedef boost::numeric::ublas::compressed_matrix<float> bmatrix;
+typedef boost::numeric::ublas::vector<double> bvector;
+typedef boost::numeric::ublas::compressed_matrix<double> bmatrix;
 
 namespace opencog
 {
 /** \addtogroup grp_attention
  *  @{
  */
-
-class CogServer;
 
 /** Spreads short term importance along HebbianLinks using a diffusion approach.
  *
@@ -63,19 +61,17 @@ class CogServer;
  */
 class ImportanceDiffusionAgent : public Agent
 {
-
 private:
-    AtomSpace* a;
 
     //! Total amount spread during recent runs.
     opencog::recent_val<long> amountSpread;
 
     //! Maximum percentage of importance to spread
-    float maxSpreadPercentage;
+    double maxSpreadPercentage;
 
     //! Value that normalised STI has to be above before being spread
     //! Is a normalised value from -1 to 1. 0 == AF
-    float diffusionThreshold;
+    double diffusionThreshold;
 
     //! Whether to spread STI across all types of Links and not just HebbianLinks.
     //! If there are multiple links between the same two Atoms, then it will add up their strengths.
@@ -88,10 +84,10 @@ private:
     //! print a gsl matrix to stdout
     void printMatrix(bmatrix *m);
     //! print a gsl vector to stdout
-    void printVector(bvector *m, float threshold = 1.0f);
+    void printVector(bvector *m, double threshold = 1.0f);
 
     //! Set the STI of h from a scaled 0..1 STI value
-    void setScaledSTI(Handle h, float scaledSTI);
+    void setScaledSTI(Handle h, double scaledSTI);
 
     //! Map each atom involved in important diffusion with an index
     int makeDiffusionAtomsMap(std::map<Handle,int> &i,HandleSeq links);
@@ -110,16 +106,6 @@ private:
     //! For checking that STI is conserved
     int totalSTI;
 
-    /** Set the agent's logger object
-     *
-     * Note, this will be deleted when this agent is.
-     *
-     * @param l The logger to associate with the agent.
-     */
-    void setLogger(Logger* l);
-
-    Logger *log; //!< Logger object for Agent
-
 public:
 
     virtual const ClassInfo& classinfo() const { return info(); }
@@ -129,30 +115,24 @@ public:
     }
 
     enum { HYPERBOLIC, STEP };
-    void setSpreadDecider(int type, float shape = 30);
+    void setSpreadDecider(int type, double shape = 30);
 
     ImportanceDiffusionAgent(CogServer&);
     virtual ~ImportanceDiffusionAgent();
     virtual void run();
 
-    /** Return the agent's logger object
-     *
-     * @return A logger object.
-     */
-    Logger* getLogger();
-
     /** Set the maximum percentage of importance that can be spread.
      * @param p the maximum percentage of importance that can be spread.
      */
-    void setMaxSpreadPercentage(float p);
+    void setMaxSpreadPercentage(double);
 
     /** Get the maximum percentage of importance that can be spread.
      * @return the maximum percentage of importance that can be spread.
      */
-    float getMaxSpreadPercentage() const;
+    double getMaxSpreadPercentage() const;
 
-    void setDiffusionThreshold(float p);
-    float getDiffusionThreshold() const;
+    void setDiffusionThreshold(double);
+    double getDiffusionThreshold() const;
 }; // class
 
 typedef std::shared_ptr<ImportanceDiffusionAgent> ImportanceDiffusionAgentPtr;

--- a/opencog/attention/ImportanceSpreadingAgent.cc
+++ b/opencog/attention/ImportanceSpreadingAgent.cc
@@ -39,20 +39,18 @@ using namespace opencog;
 ImportanceSpreadingAgent::ImportanceSpreadingAgent(CogServer& cs) :
     Agent(cs)
 {
-    static const std::string defaultConfig[] = {
+    static const std::vector<std::string defaultConfig>({
         "ECAN_DEFAULT_SPREAD_THRESHOLD","0",
         "ECAN_DEFAULT_SPREAD_MULTIPLIER","10.0",
         "ECAN_ALL_LINKS_SPREAD","false",
         "", ""
-    };
+    });
     setParameters(defaultConfig);
 
-    spreadThreshold = (float) (config().get_double
-                               ("ECAN_DEFAULT_SPREAD_THRESHOLD"));
+    spreadThreshold = config().get_double("ECAN_DEFAULT_SPREAD_THRESHOLD");
     allLinksSpread = config().get_bool("ECAN_ALL_LINKS_SPREAD");
 
     // Provide a logger
-    log = NULL;
     setLogger(new opencog::Logger("ImportanceSpreadingAgent.log", Logger::FINE, true));
 }
 
@@ -60,20 +58,8 @@ ImportanceSpreadingAgent::~ImportanceSpreadingAgent()
 {
 }
 
-void ImportanceSpreadingAgent::setLogger(Logger* _log)
-{
-    if (log) delete log;
-    log = _log;
-}
-
-Logger* ImportanceSpreadingAgent::getLogger()
-{
-    return log;
-}
-
 void ImportanceSpreadingAgent::run()
 {
-    a = &_cogserver.getAtomSpace();
     spreadImportance();
 }
 
@@ -86,14 +72,14 @@ void ImportanceSpreadingAgent::spreadImportance()
     HandleSeq::iterator hi;
     std::back_insert_iterator<HandleSeq> out_hi(atoms);
 
-    a->get_handles_by_type(out_hi, NODE, true);
+    _as->get_handles_by_type(out_hi, NODE, true);
     log->fine("---------- Spreading importance for atoms with threshold above %d", spreadThreshold);
 
     hi = atoms.begin();
     while (hi != atoms.end()) {
         Handle h = *hi;
 
-        current = a->get_STI(h);
+        current = _as->get_STI(h);
         // spread if STI > spread threshold
         if (current > spreadThreshold )
             // spread fraction of importance to nodes it's linked to
@@ -139,8 +125,8 @@ static bool is_source(const Handle& source, const Handle& link)
 // For one link
 int ImportanceSpreadingAgent::sumDifference(Handle source, Handle link)
 {
-    float linkWeight;
-    float linkDifference = 0.0f;
+    double linkWeight;
+    double linkDifference = 0.0;
     HandleSeq targets;
     HandleSeq::iterator t;
     AttentionValue::sti_t sourceSTI;
@@ -153,15 +139,16 @@ int ImportanceSpreadingAgent::sumDifference(Handle source, Handle link)
     }
 
     // Get outgoing set and sum difference for all non source atoms
-    linkWeight = a->get_TV(link)->toFloat();
-    sourceSTI = a->get_STI(source);
+    linkWeight = _as->get_TV(link)->toFloat();
+    sourceSTI = _as->get_STI(source);
     targets = link->getOutgoingSet();
 
-    if (a->get_type(link) == INVERSE_HEBBIAN_LINK) {
+    if (_as->get_type(link) == INVERSE_HEBBIAN_LINK)
+    {
         for (t = targets.begin(); t != targets.end(); ++t) {
             Handle target_h = *t;
             if (target_h == source) continue;
-            targetSTI = a->get_STI(target_h);
+            targetSTI = _as->get_STI(target_h);
 
             // pylab code for playing with inverse link stealing schemes:
             // s=10; w=0.5; t= frange(-20,20,0.05x)
@@ -180,35 +167,35 @@ int ImportanceSpreadingAgent::sumDifference(Handle source, Handle link)
                 continue;
             }
 
-            log->fine("Target atom %s", a->atom_as_string(target_h, false).c_str());
+            log->fine("Target atom %s", _as->atom_as_string(target_h, false).c_str());
 
-            targetSTI = a->get_STI(target_h);  // why is it 0?
+            targetSTI = _as->get_STI(target_h);  // why is it 0?
                 
             linkDifference += calcDifference(sourceSTI,targetSTI,linkWeight);
         }
     }
-    if (a->get_type(link) == INVERSE_HEBBIAN_LINK) {
-        linkDifference *= -1.0f;
+    if (_as->get_type(link) == INVERSE_HEBBIAN_LINK) {
+        linkDifference *= -1.0;
     }
     return (int) linkDifference;
 }
 
-float ImportanceSpreadingAgent::calcInverseDifference(AttentionValue::sti_t s, AttentionValue::sti_t t, float weight)
+double ImportanceSpreadingAgent::calcInverseDifference(AttentionValue::sti_t s, AttentionValue::sti_t t, double weight)
 {
-    float amount;
+    double amount;
     amount = weight * t + (weight * weight * s);
     if (amount < 0) amount = 0;
     else if (amount > weight * s) amount = weight * s;
     return amount;
 }
 
-float ImportanceSpreadingAgent::calcDifference(AttentionValue::sti_t s, AttentionValue::sti_t t, float weight)
+double ImportanceSpreadingAgent::calcDifference(AttentionValue::sti_t s, AttentionValue::sti_t t, double weight)
 {
     // importance can't spread uphill
     if (s - t > 0) {
         return weight * (s - t);
     }
-    return 0.0f;
+    return 0.0;
 }
 
 bool ImportanceSpreadingAgent::IsHebbianLink::operator()(Handle h) {
@@ -219,16 +206,16 @@ bool ImportanceSpreadingAgent::IsHebbianLink::operator()(Handle h) {
 void ImportanceSpreadingAgent::spreadAtomImportance(Handle h)
 {
     HandleSeq links;
-    float totalDifference, differenceScaling;
+    double totalDifference, differenceScaling;
     AttentionValue::sti_t sourceSTI;
 
     HandleSeq linksVector;
     HandleSeq::iterator linksVector_i;
 
-    totalDifference = 0.0f;
-    differenceScaling = 1.0f;
+    totalDifference = 0.0;
+    differenceScaling = 1.0;
 
-    log->fine("+Spreading importance for atom %s", a->atom_as_string(h, false).c_str());
+    log->fine("+Spreading importance for atom %s", _as->atom_as_string(h, false).c_str());
 
     h->getIncomingSet(back_inserter(linksVector));
     IsHebbianLink isHLPred(a);
@@ -239,20 +226,20 @@ void ImportanceSpreadingAgent::spreadAtomImportance(Handle h)
       log->fine("  +Hebbian links found %d", linksVector.size());
     }
 
-    totalDifference = static_cast<float>(sumTotalDifference(h, linksVector));
-    sourceSTI = a->get_STI(h);
+    totalDifference = sumTotalDifference(h, linksVector);
+    sourceSTI = _as->get_STI(h);
 
     // if there is no hebbian links with > 0 weight
     // or no lower STI atoms to spread to.
-    if (totalDifference == 0.0f) {
+    if (totalDifference == 0.0) {
         log->fine("  |totalDifference = 0, spreading nothing");
         return;
     }
 
     // Find out the scaling factor required on totalDifference
     // to prevent moving the atom below the spreadThreshold
-    if (a->get_STI(h) - totalDifference < spreadThreshold) {
-        differenceScaling = (a->get_STI(h) - spreadThreshold) / totalDifference;
+    if (_as->get_STI(h) - totalDifference < spreadThreshold) {
+        differenceScaling = (_as->get_STI(h) - spreadThreshold) / totalDifference;
     }
     log->fine("  +totaldifference %.2f, scaling %.2f", totalDifference,
             differenceScaling);
@@ -263,7 +250,7 @@ void ImportanceSpreadingAgent::spreadAtomImportance(Handle h)
         HandleSeq targets;
         HandleSeq::iterator t;
         Handle lh = *linksVector_i;
-        TruthValuePtr linkTV = a->get_TV(lh);
+        TruthValuePtr linkTV = _as->get_TV(lh);
 
         // For the case of an asymmetric link without this atom as a source
         if (!is_source(h, lh)) {
@@ -274,7 +261,7 @@ void ImportanceSpreadingAgent::spreadAtomImportance(Handle h)
         targets = lh->getOutgoingSet();
         transferWeight = linkTV->toFloat();
 
-        log->fine("  +Link %s", a->atom_as_string(lh).c_str() );
+        log->fine("  +Link %s", _as->atom_as_string(lh).c_str() );
         //log->fine("    |weight %f, quanta %.2f, size %d",
         log->fine("    |weight %f, size %d", \
                 transferWeight, targets.size());
@@ -289,10 +276,10 @@ void ImportanceSpreadingAgent::spreadAtomImportance(Handle h)
             // Then for each target of link except source...
             if ( target_h == h ) continue;
 
-            targetSTI = a->get_STI(target_h);
+            targetSTI = _as->get_STI(target_h);
 
             // calculate amount to transfer, based on difference and scaling
-            if (a->get_type(lh) == INVERSE_HEBBIAN_LINK) {
+            if (_as->get_type(lh) == INVERSE_HEBBIAN_LINK) {
                 // if the link is inverse, then scaling is unnecessary
                 // note the negative sign
                 transferAmount = -calcInverseDifference(sourceSTI,targetSTI, \
@@ -304,10 +291,10 @@ void ImportanceSpreadingAgent::spreadAtomImportance(Handle h)
                         linkTV->toFloat()) * differenceScaling;
             }
 
-            a->set_STI( h, a->get_STI(h) - (AttentionValue::sti_t) transferAmount );
-            a->set_STI( target_h, a->get_STI(target_h) + (AttentionValue::sti_t) transferAmount );
+            _as->set_STI( h, _as->get_STI(h) - (AttentionValue::sti_t) transferAmount );
+            _as->set_STI( target_h, _as->get_STI(target_h) + (AttentionValue::sti_t) transferAmount );
             log->fine("    |%d sti from %s to %s", (int) transferAmount,
-                    a->atom_as_string(h).c_str(), a->atom_as_string(target_h).c_str() );
+                    _as->atom_as_string(h).c_str(), _as->atom_as_string(target_h).c_str() );
         }
     }
 

--- a/opencog/attention/ImportanceSpreadingAgent.h
+++ b/opencog/attention/ImportanceSpreadingAgent.h
@@ -39,8 +39,6 @@ namespace opencog
  *  @{
  */
 
-class CogServer;
-
 /** Spreads short term importance along HebbianLinks.
  *
  * Currently only spreads along Symmetric and Inverse HebbianLinks.
@@ -51,16 +49,13 @@ class CogServer;
  */
 class ImportanceSpreadingAgent : public Agent
 {
-
 private:
-    AtomSpace* a;
-
     //! Minimal amount of STI necessary for an atom to have before it spreads
     //! STI.
     AttentionValue::sti_t spreadThreshold;
 
     //! How much to multiply the HebbianLink TruthValue to convert to STI.
-    float importanceSpreadingMultiplier;
+    double importanceSpreadingMultiplier;
 
     //! Whether to spread STI across all types of Links and not just HebbianLinks
     bool allLinksSpread;
@@ -87,22 +82,12 @@ private:
     int sumDifference(Handle source, Handle link);
 
     //! Calculate the difference for an inverse link
-    float calcInverseDifference(AttentionValue::sti_t s, AttentionValue::sti_t t, \
-            float weight);
+    double calcInverseDifference(AttentionValue::sti_t s, AttentionValue::sti_t t, \
+            double weight);
 
     //! Calculate the difference for a normal Hebbian link
-    float calcDifference(AttentionValue::sti_t s, AttentionValue::sti_t t, \
-            float weight);
-
-    /** Set the agent's logger object
-     *
-     * Note, this will be deleted when this agent is.
-     *
-     * @param l The logger to associate with the agent.
-     */
-    void setLogger(Logger* l);
-
-    Logger *log; //!< Logger object for Agent
+    double calcDifference(AttentionValue::sti_t s, AttentionValue::sti_t t, \
+            double weight);
 
 public:
 
@@ -115,12 +100,6 @@ public:
     ImportanceSpreadingAgent(CogServer&);
     virtual ~ImportanceSpreadingAgent();
     virtual void run();
-
-    /** Return the agent's logger object
-     *
-     * @return A logger object.
-     */
-    Logger* getLogger();
 
     /** Set minimal amount of STI necessary for an atom to have before it
      * spreads STI.
@@ -138,7 +117,7 @@ public:
      *
      * @param m the multiplier.
      */
-    void setImportanceSpreadingMultiplier(float m) {
+    void setImportanceSpreadingMultiplier(double m) {
         importanceSpreadingMultiplier = m;
     };
 

--- a/opencog/attention/SpreadDecider.cc
+++ b/opencog/attention/SpreadDecider.cc
@@ -31,7 +31,7 @@ RandGen* SpreadDecider::rng = NULL;
 
 bool SpreadDecider::spreadDecision(AttentionValue::sti_t s)
 {
-    if (getRNG()->randfloat() < function(s))
+    if (getRNG()->randdouble() < function(s))
         return true;
     else
         return false;
@@ -48,20 +48,20 @@ double HyperbolicDecider::function(AttentionValue::sti_t s)
 {
     AtomSpace& a = _cogserver.getAtomSpace();
     // Convert boundary from -1..1 to 0..1
-    float af = a.getAttentionalFocusBoundary();
-    float minSTI = a.getMinSTI(false);
-    float maxSTI = a.getMaxSTI(false);
-    float norm_b = focusBoundary > 0.0f ?
+    double af = a.getAttentionalFocusBoundary();
+    double minSTI = a.getMinSTI(false);
+    double maxSTI = a.getMaxSTI(false);
+    double norm_b = focusBoundary > 0.0 ?
         af + (focusBoundary * (maxSTI - af)) :
         af + (focusBoundary * (af - minSTI ));
     // norm_b is now the actual STI value, normalise to 0..1
-    norm_b = (norm_b - minSTI) / (float) ( maxSTI - minSTI );
+    norm_b = (norm_b - minSTI) / (double) ( maxSTI - minSTI );
     // Scale s to 0..1
-    float norm_s = (s - minSTI) / (float) ( maxSTI - minSTI );
-    return (tanh(shape*(norm_s-norm_b))+1.0f)/2.0f;
+    double norm_s = (s - minSTI) / (double) ( maxSTI - minSTI );
+    return (tanh(shape*(norm_s-norm_b))+1.0)/2.0;
 }
 
-void HyperbolicDecider::setFocusBoundary(float b)
+void HyperbolicDecider::setFocusBoundary(double b)
 {
     // Store as -1..1 since exact 0..1 mapping of boundary
     // will change based on min/max STI
@@ -70,15 +70,15 @@ void HyperbolicDecider::setFocusBoundary(float b)
 
 double StepDecider::function(AttentionValue::sti_t s)
 {
-    return (s>focusBoundary ? 1.0f : 0.0f);
+    return (s>focusBoundary ? 1.0 : 0.0);
 }
 
-void StepDecider::setFocusBoundary(float b)
+void StepDecider::setFocusBoundary(double b)
 {
     AtomSpace& a = _cogserver.getAtomSpace();
     // Convert to an exact STI amount
-    float af = a.getAttentionalFocusBoundary();
-    focusBoundary = (b > 0.0f)?
+    double af = a.getAttentionalFocusBoundary();
+    focusBoundary = (b > 0.0)?
         (int) (af + (b * (a.getMaxSTI(false) - af))) :
         (int) (af + (b * (af - a.getMinSTI(false))));
 

--- a/opencog/attention/SpreadDecider.h
+++ b/opencog/attention/SpreadDecider.h
@@ -40,7 +40,7 @@ class SpreadDecider
     //!
     //! @param s The STI to base the decision on.
     //! @return Probability of given STI value resulting in spread.
-    virtual double function(AttentionValue::sti_t s) = 0;
+    virtual double function(AttentionValue::sti_t) = 0;
 
 protected:
     CogServer& _cogserver;
@@ -57,7 +57,7 @@ public:
     //!
     //! @param b the -1..1 normalised boundary position. 0 = AtomSpace
     //! AttentionalFocusBoundary.
-    virtual void setFocusBoundary(float b = 0.0f) {};
+    virtual void setFocusBoundary(double b = 0.0) {};
 
     //! Get the random number generator for the SpreadDecider
     //!
@@ -93,17 +93,17 @@ class HyperbolicDecider : SpreadDecider
 
 public:
     //! Used to determine the steepness of the hyperbolic decision function.
-    float shape;
+    double shape;
 
     //! The decision focus boundary, or where the decision function is centered
     //! around.
     double focusBoundary;
 
-    HyperbolicDecider(CogServer& cs, float _s = 10.0f):
-        SpreadDecider(cs), shape(_s), focusBoundary(0.0f) {}
+    HyperbolicDecider(CogServer& cs, double _s = 10.0):
+        SpreadDecider(cs), shape(_s), focusBoundary(0.0) {}
 
     virtual ~HyperbolicDecider() {}
-    virtual void setFocusBoundary(float b = 0.0f);
+    virtual void setFocusBoundary(double b = 0.0);
 };
 
 /** A basic spread decider based on a step function.
@@ -117,7 +117,7 @@ public:
     int focusBoundary;
     StepDecider(CogServer& cs) : SpreadDecider(cs) {}
     virtual ~StepDecider() {}
-    virtual void setFocusBoundary(float b = 0.0f);
+    virtual void setFocusBoundary(double b = 0.0);
 };
 
 /** @}*/

--- a/opencog/cogserver/server/Agent.cc
+++ b/opencog/cogserver/server/Agent.cc
@@ -139,8 +139,8 @@ stim_t Agent::stimulateAtom(const Handle& h, stim_t amount)
     // update record of total stimulus given out
     totalStimulus += amount;
 
-    logger().fine("Atom %d received stimulus of %d, total now %d",
-                  h.value(), amount, totalStimulus);
+    logger().fine("Atom %s received stimulus of %d, total now %d",
+                  h->toString(), amount, totalStimulus);
 
     return totalStimulus;
 }

--- a/opencog/cogserver/server/Agent.cc
+++ b/opencog/cogserver/server/Agent.cc
@@ -135,7 +135,8 @@ long Agent::stimulateAtom(const Handle& h, stim_t amount)
         _stimulatedAtoms[h] += amount;
     }
 
-    // update record of total stimulus given out
+    // Update record of total stimulus given out.
+    // XXX FIXME: This could overflow and you'd never know it!
     _totalStimulus += amount;
 
     logger().fine("Atom %s received stimulus of %d, total now %ld",
@@ -155,7 +156,8 @@ void Agent::removeAtomStimulus(const Handle& h)
     stim_t amount = pr->second;
     _stimulatedAtoms.erase(h);
 
-    // update record of total stimulus given out
+    // Update record of total stimulus given out.
+    // XXX FIXME: This could underflow and you'd never know it!
     _totalStimulus -= amount;
 }
 

--- a/opencog/cogserver/server/Agent.cc
+++ b/opencog/cogserver/server/Agent.cc
@@ -51,7 +51,6 @@ See https://github.com/opencog/opencog/issues/2329
 
     setParameters({""});
 
-    stimulatedAtoms = new AtomStimHashMap();
     totalStimulus = 0;
 
     conn = _cogserver.getAtomSpace().removeAtomSignal(
@@ -68,7 +67,6 @@ Agent::~Agent()
 
     resetUtilizedHandleSets();
     conn.disconnect();
-    delete stimulatedAtoms;
 
     if (_log) delete _log;
 }
@@ -135,7 +133,7 @@ stim_t Agent::stimulateAtom(const Handle& h, stim_t amount)
 
         // Add atom to the map of atoms with stimulus
         // and add stimulus to it
-        (*stimulatedAtoms)[h] += amount;
+        stimulatedAtoms[h] += amount;
     }
 
     // update record of total stimulus given out
@@ -161,11 +159,11 @@ void Agent::removeAtomStimulus(const Handle& h)
     {
         std::lock_guard<std::mutex> lock(stimulatedAtomsMutex);
         // if handle not in map then return
-        if (stimulatedAtoms->find(h) == stimulatedAtoms->end())
+        if (stimulatedAtoms.find(h) == stimulatedAtoms.end())
             return;
 
-        amount = (*stimulatedAtoms)[h];
-        stimulatedAtoms->erase(h);
+        amount = stimulatedAtoms[h];
+        stimulatedAtoms.erase(h);
     }
 
     // update record of total stimulus given out
@@ -190,7 +188,7 @@ stim_t Agent::resetStimulus(void)
 {
     {
         std::lock_guard<std::mutex> lock(stimulatedAtomsMutex);
-        stimulatedAtoms->clear();
+        stimulatedAtoms.clear();
     }
     // reset stimulus counter
     totalStimulus = 0;
@@ -205,11 +203,11 @@ stim_t Agent::getTotalStimulus(void) const
 stim_t Agent::getAtomStimulus(const Handle& h) const
 {
     std::lock_guard<std::mutex> lock(stimulatedAtomsMutex);
-    if (stimulatedAtoms->find(h) == stimulatedAtoms->end()) {
+    auto pr = stimulatedAtoms.find(h);
+    if (pr == stimulatedAtoms.end())
         return 0;
-    } else {
-        return (*stimulatedAtoms)[h];
-    }
+    else
+        return pr->second;
 }
 
 void Agent::experimentalStimulateAtom(const Handle& h, double stimulus)

--- a/opencog/cogserver/server/Agent.cc
+++ b/opencog/cogserver/server/Agent.cc
@@ -31,7 +31,8 @@
 
 using namespace opencog;
 
-Agent::Agent(CogServer& cs, const unsigned int f) : _cogserver(cs), _frequency(f)
+Agent::Agent(CogServer& cs, const unsigned int f) :
+    _log(nullptr), _cogserver(cs), _frequency(f)
 {
 #if 0
 This causes the cogserver to crash!
@@ -75,22 +76,19 @@ Agent::~Agent()
     conn.disconnect();
     delete stimulatedAtoms;
 
-    if (log)
-        delete log;
+    if (_log) delete _log;
 }
 
-void Agent::setLogger(Logger* _log)
+void Agent::setLogger(Logger* l)
 {
-    if (log)
-        delete log;
-    log = _log;
+    if (_log) delete _log;
+    _log = l;
 }
 
 Logger* Agent::getLogger()
 {
-    return log;
+    return _log;
 }
-
 
 
 void Agent::setParameters(const std::string* params)

--- a/opencog/cogserver/server/Agent.cc
+++ b/opencog/cogserver/server/Agent.cc
@@ -49,13 +49,7 @@ See https://github.com/opencog/opencog/issues/2329
 
     _attentionValue = AttentionValue::DEFAULT_AV();
 
-    // an empty set of parameters and defaults (so that various
-    // methods will still work even if none are set in this or a derived
-    // class)
-    static const std::string defaultConfig[] = {
-        "", ""
-    };
-    setParameters(defaultConfig);
+    setParameters({""});
 
     stimulatedAtoms = new AtomStimHashMap();
     totalStimulus = 0;
@@ -91,14 +85,13 @@ Logger* Agent::getLogger()
 }
 
 
-void Agent::setParameters(const std::string* params)
+void Agent::setParameters(const std::vector<std::string>& params)
 {
-    PARAMETERS = params;
-
-    for (unsigned int i = 0; params[i] != ""; i += 2) {
-        if (!config().has(params[i])) {
+    _parameters = params;
+    for (unsigned int i = 0; params[i] != ""; i += 2)
+    {
+        if (!config().has(params[i]))
            config().set(params[i], params[i + 1]);
-        }
     }
 }
 
@@ -107,9 +100,9 @@ std::string Agent::to_string() const
     std::ostringstream oss;
     oss << classinfo().id;
     oss << " {\"";
-    for (unsigned int i = 0; PARAMETERS[i] != ""; i += 2) {
+    for (unsigned int i = 0; _parameters[i] != ""; i += 2) {
         if (i != 0) oss << "\", \"";
-        oss << PARAMETERS[i] << "\" => \"" << config()[PARAMETERS[i]];
+        oss << _parameters[i] << "\" => \"" << config()[_parameters[i]];
     }
     oss << "\"}";
     return oss.str();

--- a/opencog/cogserver/server/Agent.cc
+++ b/opencog/cogserver/server/Agent.cc
@@ -51,7 +51,7 @@ See https://github.com/opencog/opencog/issues/2329
 
     setParameters({""});
 
-    totalStimulus = 0;
+    _totalStimulus = 0;
 
     conn = _cogserver.getAtomSpace().removeAtomSignal(
             boost::bind(&Agent::atomRemoved, this, _1));
@@ -129,35 +129,35 @@ void Agent::resetUtilizedHandleSets(void)
 stim_t Agent::stimulateAtom(const Handle& h, stim_t amount)
 {
     {
-        std::lock_guard<std::mutex> lock(stimulatedAtomsMutex);
+        std::lock_guard<std::mutex> lock(_stimulatedAtomsMutex);
 
         // Add atom to the map of atoms with stimulus
         // and add stimulus to it
-        stimulatedAtoms[h] += amount;
+        _stimulatedAtoms[h] += amount;
     }
 
     // update record of total stimulus given out
-    totalStimulus += amount;
+    _totalStimulus += amount;
 
     logger().fine("Atom %s received stimulus of %d, total now %d",
-                  h->toString(), amount, totalStimulus);
+                  h->toString().c_str(), amount, _totalStimulus);
 
-    return totalStimulus;
+    return _totalStimulus;
 }
 
 void Agent::removeAtomStimulus(const Handle& h)
 {
-    std::lock_guard<std::mutex> lock(stimulatedAtomsMutex);
+    std::lock_guard<std::mutex> lock(_stimulatedAtomsMutex);
 
     // if handle not in map then return
-    auto pr = stimulatedAtoms.find(h);
-    if (pr == stimulatedAtoms.end()) return;
+    auto pr = _stimulatedAtoms.find(h);
+    if (pr == _stimulatedAtoms.end()) return;
 
     stim_t amount = pr->second;
-    stimulatedAtoms.erase(h);
+    _stimulatedAtoms.erase(h);
 
     // update record of total stimulus given out
-    totalStimulus -= amount;
+    _totalStimulus -= amount;
 }
 
 stim_t Agent::stimulateAtom(const HandleSeq& hs, stim_t amount)
@@ -176,24 +176,24 @@ stim_t Agent::stimulateAtom(const HandleSeq& hs, stim_t amount)
 
 stim_t Agent::resetStimulus(void)
 {
-    std::lock_guard<std::mutex> lock(stimulatedAtomsMutex);
-    stimulatedAtoms.clear();
+    std::lock_guard<std::mutex> lock(_stimulatedAtomsMutex);
+    _stimulatedAtoms.clear();
 
     // reset stimulus counter
-    totalStimulus = 0;
+    _totalStimulus = 0;
     return 0;
 }
 
 stim_t Agent::getTotalStimulus(void) const
 {
-    return totalStimulus;
+    return _totalStimulus;
 }
 
 stim_t Agent::getAtomStimulus(const Handle& h) const
 {
-    std::lock_guard<std::mutex> lock(stimulatedAtomsMutex);
-    auto pr = stimulatedAtoms.find(h);
-    if (pr == stimulatedAtoms.end())
+    std::lock_guard<std::mutex> lock(_stimulatedAtomsMutex);
+    auto pr = _stimulatedAtoms.find(h);
+    if (pr == _stimulatedAtoms.end())
         return 0;
     else
         return pr->second;
@@ -213,21 +213,21 @@ void Agent::experimentalStimulateAtom(const Handle& h, double stimulus)
 AttentionValue::sti_t Agent::calculate_STI_Wage(void)
 {
     long funds = _as->get_STI_funds();
-    double diff  = funds - targetSTI;
-    double ndiff = diff / stiFundsBuffer;
+    double diff  = funds - _targetSTI;
+    double ndiff = diff / _stiFundsBuffer;
     ndiff = std::min(ndiff, 1.0);
     ndiff = std::max(ndiff, -1.0);
 
-    return STIAtomWage + (STIAtomWage * ndiff);
+    return _STIAtomWage + _STIAtomWage * ndiff;
 }
 
 AttentionValue::lti_t Agent::calculate_LTI_Wage(void)
 {
     long funds = _as->get_LTI_funds();
-    double diff  = funds - targetLTI;
-    double ndiff = diff / ltiFundsBuffer;
+    double diff  = funds - _targetLTI;
+    double ndiff = diff / _ltiFundsBuffer;
     ndiff = std::min(ndiff, 1.0);
     ndiff = std::max(ndiff, -1.0);
 
-    return LTIAtomWage + (LTIAtomWage * ndiff);
+    return _LTIAtomWage + _LTIAtomWage * ndiff;
 }

--- a/opencog/cogserver/server/Agent.h
+++ b/opencog/cogserver/server/Agent.h
@@ -162,7 +162,7 @@ protected:
     std::atomic<stim_t> totalStimulus;
 
     /** Hash table of atoms given stimulus since reset */
-    AtomStimHashMap* stimulatedAtoms;
+    AtomStimHashMap stimulatedAtoms;
     mutable std::mutex stimulatedAtomsMutex;
 
     /** called by AtomTable via a boost::signals2::signal when an atom is removed. */

--- a/opencog/cogserver/server/Agent.h
+++ b/opencog/cogserver/server/Agent.h
@@ -167,15 +167,15 @@ protected:
     std::vector<UnorderedHandleSet> _utilizedHandleSets;
     mutable std::mutex _handleSetMutex;
 
-    /** Total stimulus given out to atoms */
-    stim_t _totalStimulus;
+    /** Total stimulus given out to atoms. */
+    long _totalStimulus;
 
-    /** Hash table of atoms given stimulus since reset */
+    /** Hash table of atoms given stimulus since reset. */
     AtomStimHashMap _stimulatedAtoms;
     mutable std::mutex _stimulatedAtomsMutex;
 
     /** called by AtomTable via a boost::signals2::signal when an atom is removed. */
-    void atomRemoved(AtomPtr);
+    void atomRemoved(const AtomPtr&);
 
     AttentionValue::sti_t _STIAtomWage;
     AttentionValue::lti_t _LTIAtomWage;
@@ -245,7 +245,7 @@ public:
      * @param amount of stimulus to give.
      * @return total stimulus given since last reset.
      */
-    stim_t stimulateAtom(const Handle&, stim_t amount);
+    long stimulateAtom(const Handle&, stim_t amount);
 
     /**
      * Stimulate all atoms in HandleSeq evenly with a given amount of stimulus.
@@ -263,20 +263,15 @@ public:
      */
     void removeAtomStimulus(const Handle&);
 
-    /**
-     * Reset stimulus.
-     *
-     * @return new stimulus since reset, usually zero unless another
-     * thread adds more.
-     */
-    stim_t resetStimulus();
+    /** Reset stimulus.  */
+    void resetStimulus(void);
 
     /**
      * Get total stimulus.
      *
      * @return total stimulus since last reset.
      */
-    stim_t getTotalStimulus() const;
+    long getTotalStimulus() const;
 
     /**
      * Get stimulus for Atom.

--- a/opencog/cogserver/server/Agent.h
+++ b/opencog/cogserver/server/Agent.h
@@ -150,9 +150,8 @@ protected:
      * them to the default values.
      * Note: it is assumed to be called only during initialization, so it is not
      * thread safe and shouldn't be called from multiple threads */
-    void setParameters(const std::string* params);
-
-    const std::string* PARAMETERS;
+    void setParameters(const std::vector<std::string>&);
+    std::vector<std::string> _parameters;
 
     /** The atoms utilized by the Agent in a single cycle, to be used by the
      *  System Activity Table to assign credit to this agent. */
@@ -204,7 +203,7 @@ public:
     virtual int frequency(void) const { return _frequency; }
 
     /** Sets the agent's frequency. */
-    virtual void setFrequency(int frequency) { _frequency=frequency; }
+    virtual void setFrequency(int freq) { _frequency = freq; }
 
     /** Returns the agent's class info. */
     virtual const ClassInfo& classinfo() const = 0;

--- a/opencog/cogserver/server/Agent.h
+++ b/opencog/cogserver/server/Agent.h
@@ -115,6 +115,18 @@ private:
     boost::signals2::connection conn;
 
 protected:
+    /**
+     * Set the agent's logger object
+     * Note, this will be deleted when this agent is.
+     * XXX FIXME This is a terrible API design! One must never use
+     * setters like this!  Let the agent own the logger, and if need be,
+     * it could be queried (e.g. to alter the debug level).
+     *
+     * @param l The logger to associate with the agent.
+     */
+    void setLogger(Logger*);
+    Logger* _log;
+
     CogServer& _cogserver;
 
     AtomSpace* _as;
@@ -165,16 +177,6 @@ protected:
 
     AttentionValue::sti_t stiFundsBuffer;
     AttentionValue::lti_t ltiFundsBuffer;
-
-    /** Set the agent's logger object
-     *
-     * Note, this will be deleted when this agent is.
-     *
-     * @param l The logger to associate with the agent.
-     */
-    void setLogger(Logger* l);
-
-    Logger *log; //!< Logger object for Agent
 
 public:
 

--- a/opencog/cogserver/server/Agent.h
+++ b/opencog/cogserver/server/Agent.h
@@ -116,8 +116,8 @@ private:
 
 protected:
     /**
-     * Set the agent's logger object
-     * Note, this will be deleted when this agent is.
+     * Set the agent's logger object.
+     * NOTE: this will be deleted when this agent is.
      * XXX FIXME This is a terrible API design! One must never use
      * setters like this!  Let the agent own the logger, and if need be,
      * it could be queried (e.g. to alter the debug level).
@@ -128,33 +128,42 @@ protected:
     Logger* _log;
 
     CogServer& _cogserver;
-
     AtomSpace* _as;
 
-    /** Note: AttentionValue itself is read-only, so no need to protect, but
-     * the pointer needs and is protected */
-    AttentionValuePtr _attentionValue;
-
+    /*
+     * Note: AttentionValue itself is read-only(!??).
+     * However, shared pointers are not thread-safe, see
+     * http://www.boost.org/doc/libs/1_53_0/libs/smart_ptr/shared_ptr.htm#ThreadSafety
+     * http://cppwisdom.quora.com/shared_ptr-is-almost-thread-safe
+     * and so the pointer itself must be protected.
+     */
 #if !defined SHARED_PTR_ATOMIC_OPS
     mutable std::mutex _attentionValueMutex;
 #endif
+    AttentionValuePtr _attentionValue;
 
-    /** The agent's frequency. Determines how often the opencog server should
-     *  schedule this agent. A value of 1 (the default) means that the agent
-     *  will be executed every server cycle; a value of 2 means that the agent
-     *  will be executed every 2 cycles; and so on. */
+    /**
+     * The agent's frequency. Determines how often the opencog server should
+     * schedule this agent. A value of 1 (the default) means that the agent
+     * will be executed every server cycle; a value of 2 means that the agent
+     * will be executed every 2 cycles; and so on.
+     */
     int _frequency;
 
-    /** Sets the list of parameters for this agent and their default values.
+    /**
+     * Sets the list of parameters for this agent and their default values.
      * If any parameter values are unspecified in the Config singleton, sets
      * them to the default values.
      * Note: it is assumed to be called only during initialization, so it is not
-     * thread safe and shouldn't be called from multiple threads */
+     * thread safe and shouldn't be called from multiple threads
+     */
     void setParameters(const std::vector<std::string>&);
     std::vector<std::string> _parameters;
 
-    /** The atoms utilized by the Agent in a single cycle, to be used by the
-     *  System Activity Table to assign credit to this agent. */
+    /**
+     * The atoms utilized by the Agent in a single cycle, to be used by the
+     * System Activity Table to assign credit to this agent.
+     */
     std::vector<UnorderedHandleSet> _utilizedHandleSets;
     mutable std::mutex _handleSetMutex;
 
@@ -179,7 +188,8 @@ protected:
 
 public:
 
-    /** Return the agent's logger object
+    /**
+     * Return the agent's logger object
      *
      * @return A logger object.
      */
@@ -191,12 +201,13 @@ public:
     /** Agent's destructor */
     virtual ~Agent();
 
-    /** Abstract run method. Should be overridden by a derived agent with the
-     *  actual agent's behavior. */
+    /**
+     * Abstract run method. Should be overridden by a derived agent with the
+     * actual agent's behavior.
+     */
     virtual void run() = 0;
 
-    /** Agent stop() method, called when the agent is stopped
-     */
+    /** Agent stop() method, called when the agent is stopped */
     virtual void stop() {}
 
     /** Returns the agent's frequency. */
@@ -208,12 +219,16 @@ public:
     /** Returns the agent's class info. */
     virtual const ClassInfo& classinfo() const = 0;
 
-    /** Dumps the agent's name and all its configuration parameters
-     * to a string. */
+    /**
+     * Dumps the agent's name and all its configuration parameters
+     * to a string.
+     */
     std::string to_string() const;
 
-    /** Returns the sequence of handle sets for this cycle that the agent
-     *  would like to claim credit for in the System Activity Table. */
+    /**
+     * Returns the sequence of handle sets for this cycle that the agent
+     * would like to claim credit for in the System Activity Table.
+     */
     virtual std::vector<UnorderedHandleSet> getUtilizedHandleSets() const
     {
         std::lock_guard<std::mutex> lock(_handleSetMutex);
@@ -286,6 +301,7 @@ public:
         return _attentionValue;
 #endif
     }
+
     void setAV(AttentionValuePtr new_av)
     {
 #ifdef SHARED_PTR_ATOMIC_OPS

--- a/opencog/cogserver/server/Agent.h
+++ b/opencog/cogserver/server/Agent.h
@@ -159,23 +159,23 @@ protected:
     mutable std::mutex _handleSetMutex;
 
     /** Total stimulus given out to atoms */
-    stim_t totalStimulus;
+    stim_t _totalStimulus;
 
     /** Hash table of atoms given stimulus since reset */
-    AtomStimHashMap stimulatedAtoms;
-    mutable std::mutex stimulatedAtomsMutex;
+    AtomStimHashMap _stimulatedAtoms;
+    mutable std::mutex _stimulatedAtomsMutex;
 
     /** called by AtomTable via a boost::signals2::signal when an atom is removed. */
     void atomRemoved(AtomPtr);
 
-    AttentionValue::sti_t STIAtomWage;
-    AttentionValue::lti_t LTIAtomWage;
+    AttentionValue::sti_t _STIAtomWage;
+    AttentionValue::lti_t _LTIAtomWage;
 
-    AttentionValue::sti_t targetSTI;
-    AttentionValue::lti_t targetLTI;
+    AttentionValue::sti_t _targetSTI;
+    AttentionValue::lti_t _targetLTI;
 
-    AttentionValue::sti_t stiFundsBuffer;
-    AttentionValue::lti_t ltiFundsBuffer;
+    AttentionValue::sti_t _stiFundsBuffer;
+    AttentionValue::lti_t _ltiFundsBuffer;
 
 public:
 

--- a/opencog/cogserver/server/Agent.h
+++ b/opencog/cogserver/server/Agent.h
@@ -159,7 +159,7 @@ protected:
     mutable std::mutex _handleSetMutex;
 
     /** Total stimulus given out to atoms */
-    std::atomic<stim_t> totalStimulus;
+    stim_t totalStimulus;
 
     /** Hash table of atoms given stimulus since reset */
     AtomStimHashMap stimulatedAtoms;

--- a/opencog/cogserver/server/Agent.h
+++ b/opencog/cogserver/server/Agent.h
@@ -230,7 +230,7 @@ public:
      * @param amount of stimulus to give.
      * @return total stimulus given since last reset.
      */
-    stim_t stimulateAtom(Handle h, stim_t amount);
+    stim_t stimulateAtom(const Handle&, stim_t amount);
 
     /**
      * Stimulate all atoms in HandleSeq evenly with a given amount of stimulus.
@@ -239,14 +239,14 @@ public:
      * @param amount amount of stimulus to share.
      * @return remainder stimulus after equal spread between atoms.
      */
-    stim_t stimulateAtom(HandleSeq hs, stim_t amount);
+    stim_t stimulateAtom(const HandleSeq&, stim_t amount);
 
     /**
      * Remove stimulus from a Handle's atom.
      *
      * @param atom handle
      */
-    void removeAtomStimulus(Handle h);
+    void removeAtomStimulus(const Handle&);
 
     /**
      * Reset stimulus.
@@ -269,15 +269,15 @@ public:
      * @param h handle of atom to get stimulus for.
      * @return total stimulus since last reset.
      */
-    stim_t getAtomStimulus(Handle h) const;
+    stim_t getAtomStimulus(const Handle&) const;
 
-    void experimentalStimulateAtom(Handle h,float stimulus);
+    void experimentalStimulateAtom(const Handle&, double stimulus);
 
     AttentionValue::sti_t calculate_STI_Wage();
 
     AttentionValue::lti_t calculate_LTI_Wage();
 
-    AttentionValuePtr getAV()
+    AttentionValuePtr getAV(void)
     {
 #ifdef SHARED_PTR_ATOMIC_OPS
         return std::atomic_load(&_attentionValue);

--- a/tests/server/AgentUTest.cxxtest
+++ b/tests/server/AgentUTest.cxxtest
@@ -110,15 +110,13 @@ public:
     MyAgentWithDefaults(CogServer& cs) : Agent(cs) {
         _count = 0;
      
-        static const std::string defaultConfig[] = {
-        
+        setParameters({
             "MYAGENT_USE_BAYES", "true",
             "MYAGENT_ENERGY", "12345",
             "MYAGENT_ENTHUSIASM", "1000",
             "MYAGENT_MOOD", "happy",
             "",""
-        };
-        setParameters(defaultConfig);
+        });
      }
     ~MyAgentWithDefaults() {}
     void setFrequency(int f) { _frequency = f; }


### PR DESCRIPTION
General cleanup of the Agent code:

-- fixes several obvious bugs, including overflow of the total stimulous (which was being stored as a short!!)
-- replaces floats by doubles
-- fixes pointer to invalid memory being mistaken as a valid message logger

Net result is a passel of failing unit tests get fixed.