### PR TITLE
Change the default accum weight to zero in aiml chatbot

### DIFF
--- a/opencog/nlp/aiml/aiml.scm
+++ b/opencog/nlp/aiml/aiml.scm
@@ -316,7 +316,7 @@
 
 	;; Return #t for the first rule in the RULE-LIST for which the
 	;; accumulated weight is above THRESH.
-	(define accum 0.000000001)
+	(define accum 0.0)
 	(define (pick-first ATOM THRESH)
 		(set! accum (+ accum (get-weight ATOM)))
 		(< THRESH accum))


### PR DESCRIPTION
this is causing it to pick the first rule in the list almost all the time

@linas would it be ok to simply set the default value to zero, or change it to something smaller?