### PR TITLE
Execute the defined schema "AIML-tag get" for "that" tag

### DIFF
--- a/opencog/nlp/aiml/import/aiml2psi.pl
+++ b/opencog/nlp/aiml/import/aiml2psi.pl
@@ -700,8 +700,10 @@ sub process_that
 
 	$tout .= &split_string($indent, $1);
 	$tout .= $indent . "(ExecutionOutput\n";
-	$tout .= $indent . "   (DefinedSchema \"AIML-tag that\")\n";
-	$tout .= $indent . "   (ListLink))\n";
+	$tout .= $indent . "   (DefinedSchema \"AIML-tag get\")\n";
+	$tout .= $indent . "   (ListLink\n";
+	$tout .= $indent . "      (Concept \"that\")\n";
+	$tout .= $indent . "   ))\n";
 	if ($2 ne "")
 	{
 		$tout .= &process_aiml_tags($indent, $2);


### PR DESCRIPTION
Currently it fails as there is no `(DefinedSchema "AIML-tag that")` defined. I believe it's ok to just call `(ExecutionOutput (DefinedSchema "AIML-tag get") (List (Concept "that")))` directly from the rule instead of defining `(DefinedSchema "AIML-tag that")` to do the same