### PR TITLE
Fix process_set

### DIFF
--- a/opencog/nlp/aiml/import/aiml2psi.pl
+++ b/opencog/nlp/aiml/import/aiml2psi.pl
@@ -569,7 +569,7 @@ sub process_set
 	my $text = $_[1];
 	my $tout = "";
 
-	$text =~ /(.*?)<set name='(.*?)'>(.*)<\/set>(.*?)/;
+	$text =~ /(.*?)<set name='(.*?)'>(.*)<\/set>(.*)/;
 
 	$tout .= &split_string($indent, $1);
 	$tout .= $indent . "(ExecutionOutput\n";


### PR DESCRIPTION
I notice that when it converts a rule with a set tag arranges in a way like this:
```
<template>
FIRST<set name="topic">SECOND</set>THIRD
</template>
```
The text after `</set>` is discarded, this would fix the problem