### PR TITLE
Fix process_tag in aiml2psi

### DIFF
--- a/opencog/nlp/aiml/import/aiml2psi.pl
+++ b/opencog/nlp/aiml/import/aiml2psi.pl
@@ -531,6 +531,10 @@ sub process_star
 	$tout;
 }
 
+my @pt1 = ();
+my @pt2 = ();
+my @pt3 = ();
+
 # process_tag -- process a generic, un-named tag
 #
 # First argument: the tag name
@@ -545,17 +549,24 @@ sub process_tag
 
 	$text =~ /(.*?)<$tag>(.*?)<\/$tag>(.*)/;
 
-	$tout .= &process_aiml_tags($indent, $1);
+	push(@pt1, $1);
+	push(@pt2, $2);
+	push(@pt3, $3);
+
+	$tout .= &process_aiml_tags($indent, pop(@pt1));
 	$tout .= $indent . "(ExecutionOutput\n";
 	$tout .= $indent . "   (DefinedSchema \"AIML-tag $tag\")\n";
 	$tout .= $indent . "   (ListLink\n";
 	$tout .= $indent . "      (ListLink\n";
-	$tout .= &process_aiml_tags($indent . "         ", $2);
+	$tout .= &process_aiml_tags($indent . "         ", pop(@pt2));
 	$tout .= $indent . "   )))\n";
-	if ($3 ne "")
+
+	my $t3 = pop(@pt3);
+	if ($t3 ne "")
 	{
-		$tout .= &process_aiml_tags($indent, $3);
+		$tout .= &process_aiml_tags($indent, $t3);
 	}
+
 	$tout;
 }
 


### PR DESCRIPTION
There is a problem when converting a rule that will call `process_tag`more than one time, e.g.
```
<template>
  <think>
    <set name="topic">
      <person><star/></person>
    </set>
  </think>
  <random>
    <li>I like <bot name="forfun"/>.</li>
    <li>I like <bot name="friend"/>.</li>
  </random>
</template>
```
`<think>` will be handled in `process_tag`, the text within `<random>` is assigned to `$3` and is supposed to be sent back to `process_aiml_tags` for further processing. However `<person>` is also handled in `process_tag` and handling `<person>` happens before sending `$3` to `process_aiml_tags`, and calling `process_tag` again seems to reset the value in `$3`, and as a result the text within `<random>` will be lost. This PR should fix this problem