### PR TITLE
Try to get a pickup response if aiml chatbot doesn't generate a reply on the first attempt

### DIFF
--- a/opencog/nlp/aiml/aiml.scm
+++ b/opencog/nlp/aiml/aiml.scm
@@ -506,8 +506,9 @@
 		; that contains unsupported tags (e.g. condition), or a rule
 		; that is broken in some way. Maybe it's better to trigger the
 		; "pickup search" manually for now, than giving no responses
-		(if (equal? response (List))
-			(set! response (word-list-flatten (do-while-same (List) 5))))
+		(if (equal? response (List)) (begin
+			(display "no response has been generated, looking for a pickup\n")
+			(set! response (word-list-flatten (do-while-same (List) 5)))))
 
 		; The robots response is the current "that".
 		; Store up to two previous inputs and outputs

--- a/opencog/nlp/aiml/aiml.scm
+++ b/opencog/nlp/aiml/aiml.scm
@@ -501,6 +501,14 @@
 
 	(let ((response (word-list-flatten (do-while-same SENT 5))))
 
+		; Try to look for any pickup responses if "response" is empty.
+		; This may happen occasionally if it get stuck at a rule
+		; that contains unsupported tags (e.g. condition), or a rule
+		; that is broken in some way. Maybe it's better to trigger the
+		; "pickup search" manually for now, than giving no responses
+		(if (equal? response (List))
+			(set! response (word-list-flatten (do-while-same (List) 5))))
+
 		; The robots response is the current "that".
 		; Store up to two previous inputs and outputs
 		; XXX TODO: Would be better to log and retrieve the chat


### PR DESCRIPTION
It happens occasionally that aiml chatbot is not giving any response, and most of the time it's because a rule that contains unsupported features (e.g. the condition tag) has been selected. I guess it's better to find a pickup response than giving no reply in this situation