### PR TITLE
Fix bug when calling random sentence generator

### DIFF
--- a/opencog/nlp/chatbot-psi/contexts.scm
+++ b/opencog/nlp/chatbot-psi/contexts.scm
@@ -110,13 +110,16 @@
     (if (null? idx)
         (stv 0 1)
         (let ((rand-idx (list-ref idx (random (length idx)))))
-            (if (equal? rand-idx 0)
-                (set! rsg-input (string-append
-                    (cog-name (list-ref input-wl rand-idx))
-                        " " (cog-name (list-ref input-wl (+ rand-idx 1)))))
-                (set! rsg-input (string-append
-                    (cog-name (list-ref input-wl (- rand-idx 1)))
-                        " " (cog-name (list-ref input-wl rand-idx))))
+            (if (equal? (length input-wl) 1)
+                (set! rsg-input (cog-name (car input-wl)))
+                (if (equal? rand-idx 0)
+                    (set! rsg-input (string-append
+                        (cog-name (list-ref input-wl rand-idx))
+                            " " (cog-name (list-ref input-wl (+ rand-idx 1)))))
+                    (set! rsg-input (string-append
+                        (cog-name (list-ref input-wl (- rand-idx 1)))
+                            " " (cog-name (list-ref input-wl rand-idx))))
+                )
             )
             (stv 1 1)
         )


### PR DESCRIPTION
It didn't handle single word input that is also one of the "relevant words" that the random sentence generator is looking for