### PR TITLE
Fixes for python test failures

### DIFF
--- a/opencog/spatial/CMakeLists.txt
+++ b/opencog/spatial/CMakeLists.txt
@@ -136,6 +136,11 @@ TARGET_LINK_LIBRARIES(astartest
  #	)
  #ENDIF(HAVE_SPATIAL_TOOLS)
  #
+
+INSTALL (TARGETS SpaceMap
+	DESTINATION "lib${LIB_DIR_SUFFIX}/opencog"
+)
+
 INSTALL (FILES
 	Agent.h
 	AStarController.h
@@ -161,6 +166,7 @@ INSTALL (FILES
 	VisibilityMap.h
 	DESTINATION "include/${PROJECT_NAME}/spatial"
 )
+
 INSTALL (FILES
 	math/BoundingBox.h
 	math/Dimension2.h

--- a/tests/cython/CMakeLists.txt
+++ b/tests/cython/CMakeLists.txt
@@ -27,8 +27,6 @@ ENDIF (HAVE_SERVER)
 # cannot be tested unless the cogserver is actually being built!
 IF (HAVE_SERVER)
 	ADD_CXXTEST(PyEvalUTest)
-	CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/cython/pyeval.conf
-		${PROJECT_BINARY_DIR}/tests/cython/pyeval.conf)
 
 	TARGET_LINK_LIBRARIES(PyEvalUTest
 		py-shell

--- a/tests/cython/PyEvalUTest.cxxtest
+++ b/tests/cython/PyEvalUTest.cxxtest
@@ -63,20 +63,6 @@ public:
         logger().set_level(Logger::DEBUG);
         logger().set_print_to_stdout_flag(true);
 
-        // Load special config file for the test
-        string configFile = PROJECT_BINARY_DIR"/tests/cython/pyeval.conf";
-        try {
-            config().load(configFile.c_str(), false);
-        } catch (RuntimeException &e) {
-            std::cerr << e.get_message() << std::endl;
-            exit(1);
-        }
-        // Setup global logger
-        logger().set_filename(config()["LOG_FILE"]);
-        logger().set_level(Logger::get_level_from_string(config()["LOG_LEVEL"]));
-        logger().set_backtrace_level(Logger::get_level_from_string(config()["BACK_TRACE_LOG_LEVEL"]));
-        logger().set_print_to_stdout_flag(config().get_bool("LOG_TO_STDOUT"));
-
         // Set cycle duration to a smaller value so that this test does not take too long.
         config().set("SERVER_CYCLE_DURATION", "10");  // in milliseconds
         TestCogServer& cogserver = static_cast<TestCogServer&>(server(TestCogServer::createInstance)); 
@@ -117,5 +103,4 @@ public:
         // Make sure we get a "Hello" back.
         TS_ASSERT_DIFFERS(pythonEvalRequestResult->result.find("Hello"), std::string::npos)
     }
-
 };

--- a/tests/cython/PyEvalUTest.cxxtest
+++ b/tests/cython/PyEvalUTest.cxxtest
@@ -59,7 +59,8 @@ private:
 
 public:
 
-    PyEvalUTest() {
+    PyEvalUTest()
+    {
         logger().set_level(Logger::DEBUG);
         logger().set_print_to_stdout_flag(true);
 
@@ -67,16 +68,16 @@ public:
         config().set("SERVER_CYCLE_DURATION", "10");  // in milliseconds
         TestCogServer& cogserver = static_cast<TestCogServer&>(server(TestCogServer::createInstance)); 
 
+        // This path is relative to the build diretory, not the install dir...
         config().set("MODULES", "opencog/cogserver/shell/libpy-shell.so");
         cogserver.loadModules();
     }
 
-    ~PyEvalUTest() {
-        TestCogServer& cogserver = static_cast<TestCogServer&>(server(TestCogServer::createInstance)); 
+    ~PyEvalUTest()
+    {
 	    // erase the log file if no assertions failed
 	    if (!CxxTest::TestTracker::tracker().suiteFailed())
             std::remove(logger().get_filename().c_str());
-        cogserver.unloadModule("opencog::py-shell");
     }
 
     void setUp() {
@@ -85,7 +86,8 @@ public:
     void tearDown() {
     }
 
-    void testPyEvalScript() {
+    void testPyEvalScript()
+    {
         TestCogServer& cogserver = static_cast<TestCogServer&>(server(TestCogServer::createInstance));
 
         //  Create the py-eval request.

--- a/tests/cython/PythonModuleUTest.cxxtest
+++ b/tests/cython/PythonModuleUTest.cxxtest
@@ -58,7 +58,8 @@ private:
 
 public:
 
-    PythonModuleUTest() {
+    PythonModuleUTest()
+   {
         logger().set_level(Logger::DEBUG);
         logger().set_print_to_stdout_flag(true);
 
@@ -70,12 +71,11 @@ public:
         cogserver.loadModules();
     }
 
-    ~PythonModuleUTest() {
-        TestCogServer& cogserver = static_cast<TestCogServer&>(server(TestCogServer::createInstance));
+    ~PythonModuleUTest()
+    {
 	    // erase the log file if no assertions failed
 	    if (!CxxTest::TestTracker::tracker().suiteFailed())
             std::remove(logger().get_filename().c_str());
-        cogserver.unloadModule("opencog::PythonModule");
     }
 
     void setUp() {
@@ -84,7 +84,8 @@ public:
     void tearDown() {
     }
 
-    void testLoadExceptionAgent() {
+    void testLoadExceptionAgent()
+    {
         TestCogServer& cogserver = static_cast<TestCogServer&>(server(TestCogServer::createInstance));
         // test loading a module
         Request* loadpyRequest = cogserver.createRequest("loadpy");
@@ -96,10 +97,12 @@ public:
         // process request
         cogserver.runLoopStep();
         // ensure that the exception is reported
+        printf("Got >>>%s<<<\n", srr->result.c_str());
         TS_ASSERT_DIFFERS(srr->result.find("TypeError"), std::string::npos);
     }
 
-    void testAgentWithRunException() {
+    void testAgentWithRunException()
+    {
         TestCogServer& cogserver = static_cast<TestCogServer&>(server(TestCogServer::createInstance));
 
         // test loading a module
@@ -121,7 +124,8 @@ public:
         TS_ASSERT_THROWS_ANYTHING(pythonTestAgent->run());
     }
 
-    void testPreloadAgent () {
+    void testPreloadAgent ()
+    {
         TestCogServer& cogserver = static_cast<TestCogServer&>(server(TestCogServer::createInstance));
         // agent is actually loaded from python module in test constructor
         // just check it actually can be created though
@@ -135,7 +139,8 @@ public:
         TS_ASSERT(pythonTestAgent != NULL);
     }
 
-    void testProcessAgents() {
+    void testProcessAgents()
+    {
         TestCogServer& cogserver = static_cast<TestCogServer&>(server(TestCogServer::createInstance));
 
         // test loading a module
@@ -146,7 +151,7 @@ public:
         cogserver.runLoopStep();
 
         // create agent
-        AgentPtr pythonTestAgent = cogserver.createAgent("test_agent.TestAgent",true);
+        AgentPtr pythonTestAgent = cogserver.createAgent("test_agent.TestAgent", true);
         TS_ASSERT(pythonTestAgent != NULL);
 
         cogserver.runLoopStep();
@@ -177,7 +182,6 @@ public:
                 // and one handle in the set
                 TS_ASSERT(act->utilizedHandleSets[0]->getSize() == 1);
             }
-            */
+        */
     }
-
 };

--- a/tests/cython/pyeval.conf
+++ b/tests/cython/pyeval.conf
@@ -1,2 +1,0 @@
-# Run these python modules on start up
-PYTHON_PRELOAD = pyshell


### PR DESCRIPTION
Remove stale code in python unit tests.

Install the missing 3DSpaceMap library