### PR TITLE
Put the Rest API back into working order.

### DIFF
--- a/opencog/python/web/api/apiatomcollection.py
+++ b/opencog/python/web/api/apiatomcollection.py
@@ -743,7 +743,7 @@ Returns a JSON representation of the result, indicating success or failure.
         """
 
         atom = self.atom_map.get_atom(id)
-        if not atom == None:
+        if atom == None:
             abort(404, 'Atom not found')
 
         status = self.atomspace.remove(atom)

--- a/opencog/python/web/api/apiatomcollection.py
+++ b/opencog/python/web/api/apiatomcollection.py
@@ -529,7 +529,6 @@ the atom. Example:
         # Outgoing set
         if 'outgoing' in data:
             print data
-            print "duuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuude data", data
             if len(data['outgoing']) > 0:
                 outgoing = [self.atom_map.get_atom(uid)
                                 for uid in data['outgoing']]
@@ -702,7 +701,9 @@ containing the atom.
             (sti, lti, vlti) = ParseAttentionValue.parse(data)
             the_atom.av = {'sti': sti, 'lti': lti, 'vlti': vlti}
 
-        return {'atoms': marshal(the_atom, atom_fields)}
+        dicty = marshal(the_atom, atom_fields)
+        dicty['handle'] = self.atom_map.get_uid(the_atom)
+        return {'atoms': dicty}
 
     @swagger.operation(
 	notes='''

--- a/opencog/python/web/api/apiatomcollection.py
+++ b/opencog/python/web/api/apiatomcollection.py
@@ -29,6 +29,7 @@ class AtomCollectionAPI(Resource):
         return cls
 
     def __init__(self):
+        self.atom_map = AtomMap()
         self.reqparse = reqparse.RequestParser()
         self.reqparse.add_argument(
             'type', type=str, location='args', choices=types.__dict__.keys())
@@ -299,7 +300,7 @@ class AtomCollectionAPI(Resource):
 
         if id != "":
             try:
-                atom = self.atomspace.get_atom_with_uuid(id)
+                atom = self.atom_map.atom_from_uid(id)
                 atoms = [atom]
             except IndexError:
                 atoms = []
@@ -695,7 +696,7 @@ containing the atom.
             (sti, lti, vlti) = ParseAttentionValue.parse(data)
             Atom(id, self.atomspace).av = {'sti': sti, 'lti': lti, 'vlti': vlti}
 
-        atom = self.atomspace.get_atom_with_uuid(id)
+        atom = self.atom_map.atom_from_uid(id)
         return {'atoms': marshal(atom, atom_fields)}
 
     @swagger.operation(
@@ -735,11 +736,11 @@ Returns a JSON representation of the result, indicating success or failure.
         Removes an atom from the AtomSpace
         """
 
-        if not Atom(id, self.atomspace):
+        atom = self.atom_map.atom_from_uid(id)
+        if not atom == None
             abort(404, 'Atom not found')
-        else:
-            atom = self.atomspace.get_atom_with_uuid(id)
 
         status = self.atomspace.remove(atom)
+        self.atom_map.remove(atom, id)
         response = DeleteAtomResponse(id, status)
         return {'result': response.format()}

--- a/opencog/python/web/api/apiatomcollection.py
+++ b/opencog/python/web/api/apiatomcollection.py
@@ -531,8 +531,8 @@ the atom. Example:
             print data
             print "duuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuude data", data
             if len(data['outgoing']) > 0:
-                outgoing = [Atom(uuid, self.atomspace)
-                                for uuid in data['outgoing']]
+                outgoing = [self.atom_map.get_atom(uid)
+                                for uid in data['outgoing']]
         else:
             outgoing = None
 

--- a/opencog/python/web/api/apiatomcollection.py
+++ b/opencog/python/web/api/apiatomcollection.py
@@ -29,7 +29,7 @@ class AtomCollectionAPI(Resource):
         return cls
 
     def __init__(self):
-        self.atom_map = AtomMap()
+        self.atom_map = global_atom_map
         self.reqparse = reqparse.RequestParser()
         self.reqparse.add_argument(
             'type', type=str, location='args', choices=types.__dict__.keys())
@@ -300,7 +300,7 @@ class AtomCollectionAPI(Resource):
 
         if id != "":
             try:
-                atom = self.atom_map.get_atom(id)
+                atom = self.atom_map.get_atom(int(id))
                 atoms = [atom]
             except IndexError:
                 atoms = []

--- a/opencog/python/web/api/apiatomcollection.py
+++ b/opencog/python/web/api/apiatomcollection.py
@@ -558,8 +558,7 @@ the atom. Example:
                        'parameters.')
 
         dictoid = marshal(atom, atom_fields)
-        # dictoid['handle'] = uid
-#### XXX xxxxxxxxxxxxx above almost works but crashes
+        dictoid['handle'] = uid
         return {'atoms': dictoid}
 
     @swagger.operation(

--- a/opencog/python/web/api/mappers.py
+++ b/opencog/python/web/api/mappers.py
@@ -94,7 +94,8 @@ av_fields = {
 # Atom helpers
 class FormatHandleList(fields.Raw):
     def format(self, values):
-        return [elem.value() for elem in values]
+        print "duuuuuuuuuuude horma tht hands", values
+        return [global_atom_map.get_uid(elem) for elem in values]
 
 
 class AtomListResponse(object):
@@ -135,7 +136,6 @@ class AtomMap:
         self.uid_from_atom = dict()
 
     def get_uid(self, atom):
-        print "duuuuude the getter", atom
         if (atom in self.uid_from_atom):
             uid = self.uid_from_atom[atom]
             return uid
@@ -147,7 +147,6 @@ class AtomMap:
         return uid
 
     def get_atom(self, uid):
-        # print "duuuuude ask for the uid", uid
         if (uid in self.atom_from_uid):
             return self.atom_from_uid[uid]
         return None

--- a/opencog/python/web/api/mappers.py
+++ b/opencog/python/web/api/mappers.py
@@ -127,6 +127,34 @@ class DeleteAtomResponse(object):
             'success': self.status
         }
 
+# Map associating integer uid to actual atom.
+class AtomMap:
+    def __init__(self):
+        self.next_unused_uid = 1;
+        self.atom_from_uid = dict()
+        self.uid_from_atom = dict()
+
+    def get_uid(self, atom):
+        if (atom in self.uid_from_atom):
+            uid = self.uid_from_atom[atom]
+            return uid
+
+        uid = self.next_unused_uid
+        self.next_unused_uid = self.next_unused_uid + 1
+        self.atom_from_uid[uid] = atom
+        self.uid_from_atom[atom] = uid
+        return uid
+
+    def get_atom(self, uid):
+        if (uid in self.atom_from_uid):
+            return self.atom_from_uid[uid]
+        return None
+
+    def remove(self, atom, uid):
+        del self.atom_from_uid[uid]
+        del self.uid_from_atom[atom]
+
+
 atom_fields = {
     'handle': FormatHandleValue(attribute='uuid'),
     'type': fields.String(attribute='type_name'),

--- a/opencog/python/web/api/mappers.py
+++ b/opencog/python/web/api/mappers.py
@@ -102,14 +102,17 @@ class AtomListResponse(object):
         self.atoms = atoms
 
     def format(self):
-        dictoid = marshal(self.atoms, atom_fields)
-        # xxxxxxxxxxxx need to add handles here!
+        alist = []
+        for atom in self.atoms:
+            matom = marshal(atom, atom_fields)
+            matom['handle'] = global_atom_map.get_uid(atom)
+            alist.append(matom)
         return {
             # @todo: Add pagination (http://flask.pocoo.org/snippets/44/)
             'complete': True,
             'skipped': 0,
             'total': len(self.atoms),
-            'atoms': dictoid
+            'atoms': alist
         }
 
 

--- a/opencog/python/web/api/mappers.py
+++ b/opencog/python/web/api/mappers.py
@@ -94,7 +94,6 @@ av_fields = {
 # Atom helpers
 class FormatHandleList(fields.Raw):
     def format(self, values):
-        print "duuuuuuuuuuude horma tht hands", values
         return [global_atom_map.get_uid(elem) for elem in values]
 
 

--- a/opencog/python/web/api/mappers.py
+++ b/opencog/python/web/api/mappers.py
@@ -94,7 +94,7 @@ av_fields = {
 # Atom helpers
 class FormatHandleValue(fields.Raw):
     def format(self, value):
-        return value
+        return 0
 
 
 class FormatHandleList(fields.Raw):
@@ -135,6 +135,7 @@ class AtomMap:
         self.uid_from_atom = dict()
 
     def get_uid(self, atom):
+        print "duuuuude the gtter", atom
         if (atom in self.uid_from_atom):
             uid = self.uid_from_atom[atom]
             return uid
@@ -156,7 +157,7 @@ class AtomMap:
 
 
 atom_fields = {
-    'handle': FormatHandleValue(attribute='uuid'),
+    # 'handle': FormatHandleValue(attribute='uuid'),
     'type': fields.String(attribute='type_name'),
     'name': fields.String,
     'outgoing': FormatHandleList(attribute='out'),

--- a/opencog/python/web/api/mappers.py
+++ b/opencog/python/web/api/mappers.py
@@ -34,7 +34,7 @@ class ParseTruthValue(object):
         # (see: opencog\cython\opencog\atomspace_details.pyx,
         #       opencog\cython\opencog\atomspace.pxd)
         if tv_type != 'simple':
-            if tv_type in ['composite', 'count', 'indefinite']:
+            if tv_type in ['count', 'indefinite']:
                 # @todo: check error type
                 abort(400, 'Invalid request: truthvalue type \'' +
                            tv_type + '\' is not supported')
@@ -92,11 +92,6 @@ av_fields = {
 
 
 # Atom helpers
-class FormatHandleValue(fields.Raw):
-    def format(self, value):
-        return 0
-
-
 class FormatHandleList(fields.Raw):
     def format(self, values):
         return [elem.value() for elem in values]
@@ -107,12 +102,14 @@ class AtomListResponse(object):
         self.atoms = atoms
 
     def format(self):
+        dictoid = marshal(self.atoms, atom_fields)
+        # xxxxxxxxxxxx need to add handles here!
         return {
             # @todo: Add pagination (http://flask.pocoo.org/snippets/44/)
             'complete': True,
             'skipped': 0,
             'total': len(self.atoms),
-            'atoms': marshal(self.atoms, atom_fields)
+            'atoms': dictoid
         }
 
 
@@ -135,7 +132,7 @@ class AtomMap:
         self.uid_from_atom = dict()
 
     def get_uid(self, atom):
-        print "duuuuude the gtter", atom
+        print "duuuuude the getter", atom
         if (atom in self.uid_from_atom):
             uid = self.uid_from_atom[atom]
             return uid
@@ -147,6 +144,7 @@ class AtomMap:
         return uid
 
     def get_atom(self, uid):
+        # print "duuuuude ask for the uid", uid
         if (uid in self.atom_from_uid):
             return self.atom_from_uid[uid]
         return None
@@ -155,9 +153,9 @@ class AtomMap:
         del self.atom_from_uid[uid]
         del self.uid_from_atom[atom]
 
+global_atom_map = AtomMap()
 
 atom_fields = {
-    # 'handle': FormatHandleValue(attribute='uuid'),
     'type': fields.String(attribute='type_name'),
     'name': fields.String,
     'outgoing': FormatHandleList(attribute='out'),

--- a/opencog/python/web/api/utilities.py
+++ b/opencog/python/web/api/utilities.py
@@ -6,6 +6,10 @@ def count_to_confidence(count):
     default_k = 800.0 # See TruthValue::DEFAULT_K
     return count / (count + default_k)
 
+def confidence_to_count(conf):
+    default_k = 800.0 # See TruthValue::DEFAULT_K
+    return default_k * conf / (1.0 - conf)
+
 # This is a temporary hack due to the changes made by
 # https://github.com/opencog/opencog/pull/2012 and,
 # https://github.com/opencog/atomspace/pull/611

--- a/tests/python/restapi/test_restapi.py
+++ b/tests/python/restapi/test_restapi.py
@@ -77,13 +77,15 @@ class TestRESTApi():
 
         # Compare to the values created in the AtomSpace
         frog = self.atomspace.add_node(
-            types.ConceptNode, 'giant_frog', TruthValue(.08, 0.2))
+            types.ConceptNode, 'giant_frog',
+            TruthValue(.08, count_to_confidence(0.2)))
         atomspace_result = frog
         assert post_result['name'] == atomspace_result.name
         assert types.__dict__.get(post_result['type']) == atomspace_result.type
         assert TruthValue(
             float(post_result['truthvalue']['details']['strength']),
-            float(post_result['truthvalue']['details']['count'])) \
+            count_to_confidence(
+                float(post_result['truthvalue']['details']['count']))) \
             == atomspace_result.tv
 
         # Get by handle and compare

--- a/tests/python/restapi/test_restapi.py
+++ b/tests/python/restapi/test_restapi.py
@@ -63,7 +63,6 @@ class TestRESTApi():
                                          data=json.dumps(atom),
                                          headers=self.headers)
         post_result = json.loads(post_response.data)['atoms']
-        print "duuuuuude reso=", post_result
 
         # Verify values returned by the POST request
         assert post_result['type'] == atom['type']
@@ -77,15 +76,14 @@ class TestRESTApi():
             truthvalue['details']['count'], places=5)
 
         # Compare to the values created in the AtomSpace
-        atomspace_result = Atom(post_result['handle'], self.atomspace)
-        assert Atom(post_result['handle'], self.atomspace).value() == \
-            atomspace_result.value()
+        frog = self.atomspace.add_node(
+            types.ConceptNode, 'giant_frog', TruthValue(.08, 0.2))
+        atomspace_result = frog
         assert post_result['name'] == atomspace_result.name
         assert types.__dict__.get(post_result['type']) == atomspace_result.type
         assert TruthValue(
             float(post_result['truthvalue']['details']['strength']),
-            count_to_confidence(
-                float(post_result['truthvalue']['details']['count']))) \
+            float(post_result['truthvalue']['details']['count'])) \
             == atomspace_result.tv
 
         # Get by handle and compare
@@ -94,6 +92,10 @@ class TestRESTApi():
             self.client.get(self.uri + 'atoms/' + str(handle))
         get_result_handle = \
             json.loads(get_response_handle.data)['result']['atoms'][0]
+        print "duuuuudeski nday", handle
+        print "duuuuudeski respo", get_response_handle
+        print "duuuuudeski poster=", post_result
+        print "duuuuudeski repost=", get_result_handle
         assert post_result == get_result_handle
 
         # Get by name and compare

--- a/tests/python/restapi/test_restapi.py
+++ b/tests/python/restapi/test_restapi.py
@@ -59,6 +59,13 @@ class TestRESTApi():
         post_result = json.loads(post_response.data)['atoms']
         return post_result
 
+    def get_atom(self, handle):
+        get_response_handle = \
+            self.client.get(self.uri + 'atoms/' + str(handle))
+        get_result_handle = \
+            json.loads(get_response_handle.data)['result']['atoms'][0]
+        return get_result_handle
+
     def test_a_post_and_get_node(self):
         # Create a test node
         truthvalue = {'type': 'simple',
@@ -151,12 +158,13 @@ class TestRESTApi():
             truthvalue['details']['count'], places=5)
         assert self.jswan['handle'] in post_result['outgoing']
         assert self.janimal['handle'] in post_result['outgoing']
-        print "duuuuuuuuu"
 
         # Compare to the values created in the AtomSpace
-        atomspace_result = Atom(post_result['handle'], self.atomspace)
-        assert Atom(post_result['handle'], self.atomspace).value() == \
-            atomspace_result.value()
+        self.swan_animal = self.atomspace.add_link(
+            types.InheritanceLink, [self.swan, self.animal],
+            TruthValue(0.5, count_to_confidence(0.4)))
+
+        atomspace_result = self.swan_animal
         assert types.__dict__.get(post_result['type']) == atomspace_result.type
         assert TruthValue(
             float(post_result['truthvalue']['details']['strength']),
@@ -173,9 +181,11 @@ class TestRESTApi():
         assert post_result == get_result_handle
 
         # Check if the link is in the incoming set of each of the nodes
+        self.jswan = self.get_atom(self.jswan['handle'])
+        self.janimal = self.get_atom(self.janimal['handle'])
         for h in post_result['outgoing']:
-            assert post_result['handle'] \
-                in [atom.value() for atom in Atom(h, self.atomspace).incoming]
+            assert post_result['handle'] in self.jswan['incoming']
+            assert post_result['handle'] in self.janimal['incoming']
 
     def test_c_put_and_get_tv_av_node(self):
         atom = self.swan

--- a/tests/python/restapi/test_restapi.py
+++ b/tests/python/restapi/test_restapi.py
@@ -310,7 +310,7 @@ class TestRESTApi():
                == existing_atom.tv
 
     # @raises(IndexError)
-    def test_g_delete_node(self):
+    def xtest_g_delete_node(self):
         atom = self.swan
         handle = atom.value()
         get_response = self.client.get(self.uri + 'atoms/' + str(handle))
@@ -327,7 +327,7 @@ class TestRESTApi():
         assert self.atomspace.get_atom_with_uuid(handle) == None
 
     # @raises(IndexError)
-    def test_h_delete_link(self):
+    def xtest_h_delete_link(self):
         atom = self.bird_animal
         handle = atom.value()
         get_response = self.client.get(self.uri + 'atoms/' + str(handle))

--- a/tests/python/restapi/test_restapi.py
+++ b/tests/python/restapi/test_restapi.py
@@ -94,10 +94,6 @@ class TestRESTApi():
             self.client.get(self.uri + 'atoms/' + str(handle))
         get_result_handle = \
             json.loads(get_response_handle.data)['result']['atoms'][0]
-        print "duuuuudeski nday", handle
-        print "duuuuudeski respo", get_response_handle
-        print "duuuuudeski poster=", post_result
-        print "duuuuudeski repost=", get_result_handle
         assert post_result == get_result_handle
 
         # Get by name and compare

--- a/tests/python/restapi/test_restapi.py
+++ b/tests/python/restapi/test_restapi.py
@@ -355,20 +355,26 @@ class TestRESTApi():
 
     # @raises(IndexError)
     def test_g_delete_node(self):
-        atom = self.swan
-        handle = atom.value()
+        jswan = self.mkswan()
+        handle = jswan['handle']
         get_response = self.client.get(self.uri + 'atoms/' + str(handle))
         get_result = json.loads(get_response.data)['result']['atoms'][0]
 
+        old_size = self.atomspace.size()
         delete_response = \
-            self.client.delete(self.uri + 'atoms/' + str(atom.value()))
+            self.client.delete(self.uri + 'atoms/' + str(handle))
         delete_result = json.loads(delete_response.data)['result']
 
         assert delete_result['success']
         assert delete_result['handle'] == get_result['handle']
 
         # Confirm the atom isn't contained in the AtomSpace anymore
-        assert self.atomspace.get_atom_with_uuid(handle) == None
+        # Actually, the python bindings don't provide a way to ask
+        # this question. So we check the size, instead.  Should shrink
+        # by 2, since both the swan, and the inhertance link get
+        # deleted.
+        new_size = self.atomspace.size()
+        assert new_size + 2 == old_size
 
     # @raises(IndexError)
     def test_h_delete_link(self):

--- a/tests/python/restapi/test_restapi.py
+++ b/tests/python/restapi/test_restapi.py
@@ -378,20 +378,25 @@ class TestRESTApi():
 
     # @raises(IndexError)
     def test_h_delete_link(self):
-        atom = self.bird_animal
-        handle = atom.value()
+        jatom = self.mkbird_animal()
+        handle = jatom['handle']
         get_response = self.client.get(self.uri + 'atoms/' + str(handle))
         get_result = json.loads(get_response.data)['result']['atoms'][0]
 
+        old_size = self.atomspace.size()
         delete_response = \
-            self.client.delete(self.uri + 'atoms/' + str(atom.value()))
+            self.client.delete(self.uri + 'atoms/' + str(handle))
         delete_result = json.loads(delete_response.data)['result']
 
         assert delete_result['success']
         assert delete_result['handle'] == get_result['handle']
 
         # Confirm the atom isn't contained in the AtomSpace anymore
-        assert self.atomspace.get_atom_with_uuid(handle) == None
+        # Actually, the python bindings don't provide a way to ask
+        # this question. So we check the size, instead.  Should shrink
+        # by 1, since only the inhertance link gets deleted.
+        new_size = self.atomspace.size()
+        assert new_size + 1 == old_size
 
     def test_i_get_atoms_by_av(self):
         # Assign some STI values

--- a/tests/python/restapi/test_restapi.py
+++ b/tests/python/restapi/test_restapi.py
@@ -188,20 +188,24 @@ class TestRESTApi():
             assert post_result['handle'] in self.janimal['incoming']
 
     def test_c_put_and_get_tv_av_node(self):
-        atom = self.swan
+        jswan = self.mkatom(
+                {'type': 'ConceptNode', 'name': 'swan',
+                'truthvalue': {'type': 'simple',
+                'details': {'strength': 0.001, 'count': 0.9}}})
+
         truthvalue = \
             {'type': 'simple', 'details': {'strength': 0.005, 'count': 0.8}}
         attentionvalue = {'sti': 9, 'lti': 2, 'vlti': True}
         atom_update = \
             {'truthvalue': truthvalue, 'attentionvalue': attentionvalue}
         put_response = self.client.put(
-            self.uri + 'atoms/' + str(atom.value()),
+            self.uri + 'atoms/' + str(jswan['handle']),
             data=json.dumps(atom_update),
             headers=self.headers)
         put_result = json.loads(put_response.data)['atoms']
 
         # Verify values returned by the PUT request
-        assert put_result['handle'] == atom.value()
+        assert put_result['handle'] == jswan['handle']
         assert_almost_equals(
             float(put_result['truthvalue']['details']['strength']),
             truthvalue['details']['strength'], places=5)
@@ -212,10 +216,10 @@ class TestRESTApi():
         assert put_result['attentionvalue']['lti'] == attentionvalue['lti']
         assert put_result['attentionvalue']['vlti'] == attentionvalue['vlti']
 
+        print "duuuude cccc"
         # Compare to the values updated in the AtomSpace
         atomspace_result = Atom(put_result['handle'], self.atomspace)
-        assert Atom(put_result['handle'], self.atomspace).value() == \
-            atomspace_result.value()
+        atomspace_result = self.swan
         assert types.__dict__.get(put_result['type']) == atomspace_result.type
         assert TruthValue(
             float(put_result['truthvalue']['details']['strength']),
@@ -224,9 +228,10 @@ class TestRESTApi():
             == atomspace_result.tv
         assert put_result['attentionvalue'] == atomspace_result.av
 
+        print "duuuude cccc"
         # Get by handle and compare
         get_response = \
-            self.client.get(self.uri + 'atoms/' + str(atom.value()))
+            self.client.get(self.uri + 'atoms/' + str(jswan['handle']))
         get_result = json.loads(get_response.data)['result']['atoms'][0]
         assert put_result == get_result
 

--- a/tests/python/restapi/test_restapi.py
+++ b/tests/python/restapi/test_restapi.py
@@ -51,7 +51,7 @@ class TestRESTApi():
         del self.api
         del self.client
 
-    def test_post_and_get_node(self):
+    def test_a_post_and_get_node(self):
         # Create a test node
         truthvalue = {'type': 'simple',
                       'details': {'strength': 0.08, 'count': 0.2}}
@@ -110,7 +110,7 @@ class TestRESTApi():
             json.loads(get_response_name_type.data)['result']['atoms'][0]
         assert post_result == get_result_name_type
 
-    def test_post_and_get_link(self):
+    def test_b_post_and_get_link(self):
         # Create a test link between swan and animal
         truthvalue = \
             {'type': 'simple', 'details': {'strength': 0.5, 'count': 0.4}}
@@ -157,7 +157,7 @@ class TestRESTApi():
             assert post_result['handle'] \
                 in [atom.value() for atom in Atom(h, self.atomspace).incoming]
 
-    def test_put_and_get_tv_av_node(self):
+    def test_c_put_and_get_tv_av_node(self):
         atom = self.swan
         truthvalue = \
             {'type': 'simple', 'details': {'strength': 0.005, 'count': 0.8}}
@@ -200,7 +200,7 @@ class TestRESTApi():
         get_result = json.loads(get_response.data)['result']['atoms'][0]
         assert put_result == get_result
 
-    def test_put_and_get_tv_av_link(self):
+    def test_d_put_and_get_tv_av_link(self):
         atom = self.bird_animal
         truthvalue = \
             {'type': 'simple', 'details': {'strength': 0.9, 'count': 0.95}}
@@ -244,7 +244,7 @@ class TestRESTApi():
         get_result = json.loads(get_response.data)['result']['atoms'][0]
         assert put_result == get_result
 
-    def test_post_revise_existing_node(self):
+    def test_e_post_revise_existing_node(self):
         # Attempt to create a node, where a node already exists with that name
         # and type. Should revise existing node.
         existing_atom = self.bird
@@ -275,7 +275,7 @@ class TestRESTApi():
                 float(post_result['truthvalue']['details']['count']))) \
                == existing_atom.tv
 
-    def test_post_revise_existing_link(self):
+    def test_f_post_revise_existing_link(self):
         # Attempt to create a link, where a link already exists with that name
         # and outgoing set.
         # Should revise existing link.
@@ -309,7 +309,7 @@ class TestRESTApi():
                == existing_atom.tv
 
     # @raises(IndexError)
-    def test_delete_node(self):
+    def test_g_delete_node(self):
         atom = self.swan
         handle = atom.value()
         get_response = self.client.get(self.uri + 'atoms/' + str(handle))
@@ -326,7 +326,7 @@ class TestRESTApi():
         assert self.atomspace.get_atom_with_uuid(handle) == None
 
     # @raises(IndexError)
-    def test_delete_link(self):
+    def test_h_delete_link(self):
         atom = self.bird_animal
         handle = atom.value()
         get_response = self.client.get(self.uri + 'atoms/' + str(handle))
@@ -342,7 +342,7 @@ class TestRESTApi():
         # Confirm the atom isn't contained in the AtomSpace anymore
         assert self.atomspace.get_atom_with_uuid(handle) == None
 
-    def test_get_atoms_by_av(self):
+    def test_i_get_atoms_by_av(self):
         # Assign some STI values
         self.bird.sti = 9
         self.swan.sti = 20
@@ -372,14 +372,14 @@ class TestRESTApi():
         assert set([atom['handle'] for atom in get_result]) \
             == {self.bird_animal.value()}
 
-    def test_get_types(self):
+    def test_j_get_types(self):
         # Verify that a list of valid atom types was returned
         get_response = self.client.get(self.uri + 'types')
         get_result = json.loads(get_response.data)['types']
         assert len(get_result) > 0
         assert get_result.__contains__('ConceptNode')
 
-    def test_tv_filter(self):
+    def test_k_tv_filter(self):
         # Should return animal, swan_bird, bird_animal (3 atoms)
         get_response = self.client.get(self.uri + 'atoms?tvStrengthMin=0.1')
         get_result = json.loads(get_response.data)['result']['atoms']
@@ -395,7 +395,7 @@ class TestRESTApi():
         get_result = json.loads(get_response.data)['result']['atoms']
         assert len(get_result) == 1
 
-    def test_include_incoming_outgoing(self):
+    def test_l_include_incoming_outgoing(self):
         # Should return bird and swan (2 atoms)
         get_response = self.client.get(
             self.uri +
@@ -417,7 +417,7 @@ class TestRESTApi():
         get_result = json.loads(get_response.data)['result']['atoms']
         assert len(get_result) == 5
 
-    def test_scheme_command(self):
+    def test_m_scheme_command(self):
         # Test an arbitrary Scheme command to ensure the binding is working
         # properly
 
@@ -446,7 +446,7 @@ class TestRESTApi():
         # Verify that it matches the previous response
         assert post_result == "5\n"
 
-    def test_dot_export(self):
+    def test_n_dot_export(self):
         # Export the atomspace to DOT format and ensure that there is a
         # properly defined DOT header created and the correct atoms are
         # included in the description

--- a/tests/python/restapi/test_restapi.py
+++ b/tests/python/restapi/test_restapi.py
@@ -82,7 +82,7 @@ class TestRESTApi():
         janimal = self.mkanimal()
         return self.mkatom(
             {'type': 'InheritanceLink', 'truthvalue':
-            {'type': 'simple', 'details': {'strength': 0.5, 'count': 0.4}},
+            {'type': 'simple', 'details': {'strength': 1.0, 'count': 0.9}},
              'outgoing': [jswan['handle'], janimal['handle']]})
 
     def get_atom(self, handle):
@@ -277,12 +277,13 @@ class TestRESTApi():
         # Compare to the values updated in the AtomSpace
         atomspace_result = self.bird_animal
         assert types.__dict__.get(put_result['type']) == atomspace_result.type
+        batv = TruthValue(0.9, count_to_confidence(0.95))
         assert TruthValue(
             float(put_result['truthvalue']['details']['strength']),
             count_to_confidence(
                 float(put_result['truthvalue']['details']['count']))) \
-            == atomspace_result.tv
-        assert put_result['attentionvalue'] == atomspace_result.av
+            == batv
+        assert put_result['attentionvalue'] == attentionvalue
 
         # Get by handle and compare
         get_response = \
@@ -314,7 +315,6 @@ class TestRESTApi():
             truthvalue['details']['count'], places=5)
 
         # Compare to the values updated in the AtomSpace
-        assert post_result['handle'] == existing_atom.value()
         assert TruthValue(
             float(post_result['truthvalue']['details']['strength']),
             count_to_confidence(

--- a/tests/python/restapi/test_restapi.py
+++ b/tests/python/restapi/test_restapi.py
@@ -78,12 +78,12 @@ class TestRESTApi():
                 'details': {'strength': 0.1, 'count': 0.95}}})
 
     def mkbird_animal(self):
-        jswan = self.mkswan()
+        jbird = self.mkbird()
         janimal = self.mkanimal()
         return self.mkatom(
             {'type': 'InheritanceLink', 'truthvalue':
             {'type': 'simple', 'details': {'strength': 1.0, 'count': 0.9}},
-             'outgoing': [jswan['handle'], janimal['handle']]})
+             'outgoing': [jbird['handle'], janimal['handle']]})
 
     def get_atom(self, handle):
         get_response_handle = \
@@ -277,12 +277,11 @@ class TestRESTApi():
         # Compare to the values updated in the AtomSpace
         atomspace_result = self.bird_animal
         assert types.__dict__.get(put_result['type']) == atomspace_result.type
-        batv = TruthValue(0.9, count_to_confidence(0.95))
         assert TruthValue(
             float(put_result['truthvalue']['details']['strength']),
             count_to_confidence(
                 float(put_result['truthvalue']['details']['count']))) \
-            == batv
+            == atomspace_result.tv
         assert put_result['attentionvalue'] == attentionvalue
 
         # Get by handle and compare
@@ -326,9 +325,10 @@ class TestRESTApi():
         # and outgoing set.
         # Should revise existing link.
         existing_atom = self.bird_animal
+        jbird_animal = self.mkbird_animal()
         truthvalue = \
             {'type': 'simple', 'details': {'strength': 0.1, 'count': 0.95}}
-        outgoing = [a.value() for a in existing_atom.out]
+        outgoing = jbird_animal['outgoing']
         atom = {'type': 'InheritanceLink',
                 'truthvalue': truthvalue,
                 'outgoing': outgoing}
@@ -347,7 +347,6 @@ class TestRESTApi():
             truthvalue['details']['count'], places=5)
 
         # Compare to the values updated in the AtomSpace
-        assert post_result['handle'] == existing_atom.value()
         assert TruthValue(
             float(post_result['truthvalue']['details']['strength']),
             count_to_confidence(
@@ -355,7 +354,7 @@ class TestRESTApi():
                == existing_atom.tv
 
     # @raises(IndexError)
-    def xtest_g_delete_node(self):
+    def test_g_delete_node(self):
         atom = self.swan
         handle = atom.value()
         get_response = self.client.get(self.uri + 'atoms/' + str(handle))
@@ -372,7 +371,7 @@ class TestRESTApi():
         assert self.atomspace.get_atom_with_uuid(handle) == None
 
     # @raises(IndexError)
-    def xtest_h_delete_link(self):
+    def test_h_delete_link(self):
         atom = self.bird_animal
         handle = atom.value()
         get_response = self.client.get(self.uri + 'atoms/' + str(handle))

--- a/tests/python/restapi/test_restapi.py
+++ b/tests/python/restapi/test_restapi.py
@@ -63,6 +63,7 @@ class TestRESTApi():
                                          data=json.dumps(atom),
                                          headers=self.headers)
         post_result = json.loads(post_response.data)['atoms']
+        print "duuuuuude reso=", post_result
 
         # Verify values returned by the POST request
         assert post_result['type'] == atom['type']

--- a/tests/python/restapi/test_restapi.py
+++ b/tests/python/restapi/test_restapi.py
@@ -405,28 +405,31 @@ class TestRESTApi():
         self.bird_animal.sti = 15
         self.animal.sti = 0
 
+        jswan = self.mkswan()
+        jbird = self.mkbird()
+        jbird_animal = self.mkbird_animal()
         get_response = \
             self.client.get(self.uri + 'atoms?filterby=attentionalfocus')
         get_result = json.loads(get_response.data)['result']['atoms']
         assert len(get_result) == 3
         assert set([atom['handle'] for atom in get_result]) \
-            == {self.bird.value(),
-                self.swan.value(),
-                self.bird_animal.value()}
+            == {jbird['handle'],
+                jswan['handle'],
+                jbird_animal['handle']}
 
         get_response = \
             self.client.get(self.uri + 'atoms?filterby=stirange&stimin=15')
         get_result = json.loads(get_response.data)['result']['atoms']
         assert len(get_result) == 2
         assert set([atom['handle'] for atom in get_result]) \
-            == {self.swan.value(), self.bird_animal.value()}
+            == {jswan['handle'], jbird_animal['handle']}
 
         get_response = self.client.get(
             self.uri + 'atoms?filterby=stirange&stimin=15&stimax=18')
         get_result = json.loads(get_response.data)['result']['atoms']
         assert len(get_result) == 1
         assert set([atom['handle'] for atom in get_result]) \
-            == {self.bird_animal.value()}
+            == {jbird_animal['handle']}
 
     def test_j_get_types(self):
         # Verify that a list of valid atom types was returned


### PR DESCRIPTION
Previous cython UUID changes broke the REST API. Set it back into working order.

(Its now impossible to get the UUID from the atomspace)