### PR TITLE
Minor updates to chatbot-psi

### DIFF
--- a/opencog/nlp/chatbot-psi/contexts.scm
+++ b/opencog/nlp/chatbot-psi/contexts.scm
@@ -112,13 +112,18 @@
         (let ((rand-idx (list-ref idx (random (length idx)))))
             (if (equal? (length input-wl) 1)
                 (set! rsg-input (cog-name (car input-wl)))
-                (if (equal? rand-idx 0)
-                    (set! rsg-input (string-append
-                        (cog-name (list-ref input-wl rand-idx))
-                            " " (cog-name (list-ref input-wl (+ rand-idx 1)))))
-                    (set! rsg-input (string-append
-                        (cog-name (list-ref input-wl (- rand-idx 1)))
-                            " " (cog-name (list-ref input-wl rand-idx))))
+                ; Feed the keyword directly to the generator, or with the
+                ; word either before or after that keyword
+                (if (> .7 (random 1.0))
+                    (set! rsg-input (cog-name (list-ref input-wl rand-idx)))
+                    (if (equal? rand-idx 0)
+                        (set! rsg-input (string-append
+                            (cog-name (list-ref input-wl rand-idx))
+                                " " (cog-name (list-ref input-wl (+ rand-idx 1)))))
+                        (set! rsg-input (string-append
+                            (cog-name (list-ref input-wl (- rand-idx 1)))
+                                " " (cog-name (list-ref input-wl rand-idx))))
+                    )
                 )
             )
             (stv 1 1)

--- a/opencog/nlp/chatbot-psi/pln-reasoner.scm
+++ b/opencog/nlp/chatbot-psi/pln-reasoner.scm
@@ -122,6 +122,9 @@
    (Predicate "happy")
    (Concept "Peter"))
 
+;; This is required for SuReal to generate the answer
+(nlp-parse "small cats are cute")
+
 ;;;;;;;;;;;;;;;
 ;; L2S rules ;;
 ;;;;;;;;;;;;;;;


### PR DESCRIPTION
to make sure when we run the pln demo, the required sentence form for sureal to generate the "happy people" answer always exists, and also let it send just the keyword to the random sentence generator sometimes to increase the varieties