### PR TITLE
Update SuReal to skip looking for an LG dictionary entry as a criteria of determining if a node is a word

### DIFF
--- a/opencog/nlp/sureal/SuRealSCM.cc
+++ b/opencog/nlp/sureal/SuRealSCM.cc
@@ -193,16 +193,27 @@ HandleSeqSeq SuRealSCM::do_sureal_match(Handle h, bool use_cache)
             n->getType() == DEFINED_LINGUISTIC_PREDICATE_NODE)
            continue;
 
-        std::string sName = NodeCast(n)->getName();
+        std::string sName = n->getName();
+
+        // if it is an instance, check if it has the LG relationships
+        if (sName.find("@") != std::string::npos)
+        {
+            Handle hWordInstNode = pAS->get_handle(WORD_INSTANCE_NODE, sName);
+
+            // no corresponding WordInstanceNode found
+            if (hWordInstNode == Handle::UNDEFINED)
+                continue;
+
+            // if no LG link generated for the instance
+            if (get_target_neighbors(hWordInstNode, LG_WORD_CSET).empty())
+                continue;
+        }
+
         std::string sWord = sName.substr(0, sName.find_first_of('@'));
         Handle hWordNode = pAS->get_handle(WORD_NODE, sWord);
 
         // no WordNode found
         if (hWordNode == Handle::UNDEFINED)
-            continue;
-
-        // if no LG dictionary entry
-        if (get_target_neighbors(hWordNode, LG_DISJUNCT).empty())
             continue;
 
         sVars.insert(n);


### PR DESCRIPTION
Sometimes if an unusual / new word that does not yet exist in the LG dictionary being sent to SuReal, SuReal does not treat it as a word (variable) and as a result returning nothing sometimes, even if that word exists in some previously parsed sentences. This PR removes that checking but add additional ones to identify words