### PR TITLE
add chatscript.scm to CMakeLists

### DIFF
--- a/opencog/nlp/chatbot-psi/CMakeLists.txt
+++ b/opencog/nlp/chatbot-psi/CMakeLists.txt
@@ -8,6 +8,7 @@ ADD_GUILE_MODULE (chatbot-psi.scm
 	utils.scm
 	random-sentence-generator.scm
 	pln-actions.scm
+	chatscript.scm
 	pln-contexts.scm
 	pln-psi-rules.scm
 	pln-reasoner.scm


### PR DESCRIPTION
@leungmanhin, does chatscript.scm need to be added to CMakeLists here?

Without it, I get an error in the cogserver scheme shell:
opencog> scm
Entering scheme shell; use ^D or a single . on a line by itself to exit.
guile> (use-modules (opencog nlp chatbot-psi))
. . .
ERROR: In procedure primitive-load-path: Unable to find file "opencog/nlp/chatbot-psi/chatscript.scm" in load path
ABORT: misc-error
                           