### PR TITLE
Limit number of open sockets to the cogserver.

### DIFF
--- a/opencog/cogserver/server/ConsoleSocket.h
+++ b/opencog/cogserver/server/ConsoleSocket.h
@@ -73,9 +73,17 @@ private:
     // zero already; these use a different method of holding off the dtor.
     // Basically, the shell dtor has to run first, before the
     // ServerSocket::handle_connection() invokes this dtor.
-    unsigned int _use_count;
-    std::mutex _mtx;
-    std::condition_variable _cv;
+    volatile unsigned int _use_count;
+    std::mutex _in_use_mtx;
+    std::condition_variable _in_use_cv;
+
+    // A count of the number of concurrent open sockets. This is used
+    // to limit the number of connections to the cogserver, so that it
+    // doesn't crash with a `accept: Too many open files` error.
+    static unsigned int _max_open_sockets;
+    static volatile unsigned int _num_open_sockets;
+    static std::mutex _max_mtx;
+    static std::condition_variable _max_cv;
 
 protected:
 
@@ -109,8 +117,8 @@ public:
     ConsoleSocket(void);
     ~ConsoleSocket();
 
-    void get() { std::unique_lock<std::mutex> lck(_mtx); _use_count++; }
-    void put() { std::unique_lock<std::mutex> lck(_mtx); _use_count--; _cv.notify_all(); }
+    void get() { std::unique_lock<std::mutex> lck(_in_use_mtx); _use_count++; }
+    void put() { std::unique_lock<std::mutex> lck(_in_use_mtx); _use_count--; _in_use_cv.notify_all(); }
 
     /**
      * OnRequestComplete: called when a request has finished. It

--- a/opencog/cogserver/server/NetworkServer.cc
+++ b/opencog/cogserver/server/NetworkServer.cc
@@ -85,6 +85,9 @@ void NetworkServer::listen()
         boost::asio::ip::tcp::socket* sock = new boost::asio::ip::tcp::socket(_io_service);
         _acceptor.accept(*sock);
 
+        // The total number of concurrently open sockets is managed by
+        // keeping a count in ConsoleSocket, and blocking when there are
+        // too many.
         ConsoleSocket* ss = new ConsoleSocket();
         ss->set_connection(sock);
         std::thread(&ConsoleSocket::handle_connection, ss).detach();

--- a/opencog/cogserver/server/ServerSocket.cc
+++ b/opencog/cogserver/server/ServerSocket.cc
@@ -54,12 +54,14 @@ void ServerSocket::Send(const std::string& cmd)
 
     // The most likely cause of an error is that the remote side has
     // closed the socket, even though we still had stuff to send.
-    // I beleive this is a ENOTCON errno, maybe its another one as well.
+    // I beleive this is a ENOTCON errno, maybe others as well.
+    // (for example, ECONNRESET `Connection reset by peer`)
     // Don't log these harmless errors.
     if (error.value() != boost::system::errc::success and
         error.value() != boost::asio::error::not_connected and
         error.value() != boost::asio::error::broken_pipe and
-        error.value() != boost::asio::error::bad_descriptor)
+        error.value() != boost::asio::error::bad_descriptor and
+        error.value() != boost::asio::error::connection_reset)
         logger().warn("ServerSocket::Send(): %s on thread 0x%x",
              error.message().c_str(), pthread_self());
 }


### PR DESCRIPTION
This is a minor enhancement, inspired by bug #2550 