### PR TITLE
Restructure header-file inclusions

### DIFF
--- a/opencog/cogserver/server/BuiltinRequestsModule.cc
+++ b/opencog/cogserver/server/BuiltinRequestsModule.cc
@@ -24,8 +24,9 @@
 
 #include <iomanip>
 
-#include <opencog/cogserver/server/CogServer.h>
 #include <opencog/util/ansi.h>
+#include <opencog/cogserver/server/CogServer.h>
+#include <opencog/cogserver/server/ConsoleSocket.h>
 
 #include "BuiltinRequestsModule.h"
 

--- a/opencog/cogserver/server/NetworkServer.cc
+++ b/opencog/cogserver/server/NetworkServer.cc
@@ -24,9 +24,10 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "NetworkServer.h"
-
 #include <opencog/util/Logger.h>
+#include <opencog/cogserver/server/ConsoleSocket.h>
+
+#include "NetworkServer.h"
 
 using namespace opencog;
 

--- a/opencog/cogserver/server/NetworkServer.h
+++ b/opencog/cogserver/server/NetworkServer.h
@@ -31,14 +31,11 @@
 
 #include <boost/asio.hpp>
 
-#include <opencog/cogserver/server/ConsoleSocket.h>
-
 namespace opencog
 {
 /** \addtogroup grp_server
  *  @{
  */
-
 
 /**
  * This class implements the entity responsible for managing the

--- a/opencog/cogserver/server/Request.cc
+++ b/opencog/cogserver/server/Request.cc
@@ -26,6 +26,8 @@
 #include <opencog/util/Logger.h>
 #include <opencog/util/oc_assert.h>
 
+#include <opencog/cogserver/server/ConsoleSocket.h>
+
 #include "Request.h"
 
 using namespace opencog;

--- a/opencog/cogserver/server/Request.h
+++ b/opencog/cogserver/server/Request.h
@@ -30,7 +30,6 @@
 #include <list>
 #include <string>
 
-#include <opencog/cogserver/server/ConsoleSocket.h>
 #include <opencog/cogserver/server/Factory.h>
 
 namespace opencog
@@ -40,6 +39,7 @@ namespace opencog
  */
 
 class CogServer;
+class ConsoleSocket;
 
 /**
  * The DECLARE_CMD_REQUEST macro provides a simple, easy-to-use interface

--- a/opencog/cogserver/server/ShutdownRequest.cc
+++ b/opencog/cogserver/server/ShutdownRequest.cc
@@ -22,11 +22,12 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "ShutdownRequest.h"
-
 #include <sstream>
 
 #include <opencog/cogserver/server/CogServer.h>
+#include <opencog/cogserver/server/ConsoleSocket.h>
+
+#include "ShutdownRequest.h"
 
 using namespace opencog;
 


### PR DESCRIPTION
This lessens un-needed dependencies between files. This will result in a smaller set of rebuilds, if certain header files are touched.