### PR TITLE
Handle ctrl-C interrupts in the shell

### DIFF
--- a/opencog/cogserver/shell/GenericShell.cc
+++ b/opencog/cogserver/shell/GenericShell.cc
@@ -312,13 +312,13 @@ void GenericShell::line_discipline(const std::string &expr)
 			c = expr[i+1];
 			if ((IP == c) || (AO == c))
 			{
-				_eval_done = true;
-// xxx should call eval_finished()?
-				// Must write the abort prompt, first, because telnet will
-				// silently ignore any bytes that come before it.
+				// Must write the abort prompt, first, because
+				// telnet will silently ignore any bytes that
+				// come before it.
 				put_output(abort_prompt);
 				_evaluator->interrupt();
 				_evaluator->clear_pending();
+				finish_eval();
 				return;
 			}
 
@@ -380,14 +380,14 @@ void GenericShell::line_discipline(const std::string &expr)
 
 void GenericShell::start_eval()
 {
-	// OC_ASSERT(_eval_done, "Bad evaluator flag state!");
+	OC_ASSERT(_eval_done, "Bad evaluator flag state!");
 	std::unique_lock<std::mutex> lck(_mtx);
 	_eval_done = false;
 }
 
 void GenericShell::finish_eval()
 {
-	// OC_ASSERT(not _eval_done, "Bad evaluator flag state!");
+	OC_ASSERT(not _eval_done, "Bad evaluator flag state!");
 	std::unique_lock<std::mutex> lck(_mtx);
 	_eval_done = true;
 	_cv.notify_all();
@@ -428,6 +428,7 @@ void GenericShell::eval_loop(void)
 	{
 		try
 		{
+			while_not_done();
 			evalque.pop(in);
 			start_eval();
 			_evaluator->begin_eval();

--- a/opencog/cogserver/shell/GenericShell.cc
+++ b/opencog/cogserver/shell/GenericShell.cc
@@ -69,6 +69,9 @@ GenericShell::GenericShell(void)
 
 GenericShell::~GenericShell()
 {
+	self_destruct = true;
+	evalque.cancel();
+
 	if (evalthr)
 	{
 		logger().debug("[GenericShell] dtor, wait for eval thread 0x%x.",

--- a/opencog/cogserver/shell/GenericShell.cc
+++ b/opencog/cogserver/shell/GenericShell.cc
@@ -166,22 +166,17 @@ static GenericShell* _redirector = nullptr;
 //
 void GenericShell::eval(const std::string &expr)
 {
-	// The first time through, there might not be an evaluator yet.
-	// Create one now. We cannot do this in the constructor, for a
-	// rather subtle reason: multiple calls to the constructor may
-	// run in the same thread, resulting in multiple shells sharing
-	// the same evaluator, which leads to a badness. We really want
-	// each unique instance of the shell to have it's own evaluator,
-	// and so we defer allocation until this point.
-	//
-	// The ctor runs in the main cogserver request-processor thread.
-	// Calling get_evaluator() there would always return the same
-	// single instance of the evaluator (because there can be at most
-	// just one evaluator per thread).
+	// First time through, initialize the evaluator.  We can't do this
+	// in the ctor, since we can't get the evaluator until after the
+	// derived-class ctor has run, and thus informed us as to whether
+	// the evaluator will be guile (scheme) or python.
 	if (nullptr == _evaluator)
 	{
-		_evaluator = get_evaluator();
-		_evaluator->clear_pending();
+		_init_done = false;
+		// Run the evaluation loop in a distinct thread.
+		auto eval_wrapper = [&](void) { eval_loop(); };
+		evalthr = new std::thread(eval_wrapper);
+		while (not _init_done) { sched_yield(); }
 	}
 
 	// Work-around some printing madness. See issue
@@ -222,43 +217,8 @@ void GenericShell::eval(const std::string &expr)
 	}
 #endif // PERFORM_STDOUT_DUPLICATION
 
-	// Run the evaluator (in a different thread)
-	poll_needed = false;
+	// Queue up the expr, where it will be evaluated in another thread.
 	line_discipline(expr);
-
-	// Avoid polling, if an evaluation thread was not created. This is
-	// used to handle interrupts (control-c's).
-	if (not poll_needed)
-	{
-		std::string retstr = poll_output();
-		socket->Send(retstr);
-	}
-	else
-	{
-		// Poll for output from the evaluator, and send back results.
-		auto poll_wrapper = [&](void)
-		{
-			std::string retstr = poll_output();
-			while (0 < retstr.size())
-			{
-				socket->Send(retstr);
-				retstr = poll_output();
-			}
-		};
-
-		// Always wait for the previous poll of results to complete, before
-		// starting the next one.  The goal here is to keep results
-		// serialized on the socket, so that chronologically-earlier
-		// results are written to the socket in order, before the newer
-		// results.
-		if (pollthr)
-		{
-			pollthr->join();
-			delete pollthr;
-		}
-		sched_yield();
-		pollthr = new std::thread(poll_wrapper);
-	}
 
 #ifdef PERFORM_STDOUT_DUPLICATION
 	if (show_output and show_prompt)
@@ -329,7 +289,7 @@ void GenericShell::line_discipline(const std::string &expr)
 
 	if (0 == len)
 	{
-		do_eval("\n");
+		evalque.push("\n");
 		return;
 	}
 
@@ -399,10 +359,8 @@ void GenericShell::line_discipline(const std::string &expr)
 	 * The newline is always cut. Re-insert it; otherwise, comments
 	 * within procedures will have the effect of commenting out the
 	 * rest of the procedure, leading to garbage.
-	 * (This is a pointless string copy, it should be eliminated.)
 	 */
-	std::string input = expr + "\n";
-	do_eval(input);
+	evalque.push(expr + "\n");
 }
 
 /* ============================================================== */
@@ -436,47 +394,51 @@ void GenericShell::while_not_done()
 }
 
 /* ============================================================== */
-/**
- * Evaluate the expression. Assumes line discipline was already done.
- */
-void GenericShell::do_eval(const std::string &input)
+
+/// eval_loop. Dequeue and run each queued evaluation request.
+/// Assumes line discipline has already been done (as it must be:
+/// it is impossible to queue OOB interrupts.)
+void GenericShell::eval_loop(void)
 {
-	// Always wait for the previous evaluation to complete, before
-	// starting the next one.  That is, evaluations are always
-	// explicitly serialized.
-	//
-	// ... and even if they were not, we cannot use the same evaluator
-	// in two different threads at the same time; a single evaluator is
-	// not thread-safe against itself. So always wait for the previous
-	// evaluation thread to finish, before we go at it again.
-	if (evalthr)
-	{
-		evalthr->join();
-		delete evalthr;
-		evalthr = nullptr;
-	}
+	OC_ASSERT(nullptr == _evaluator, "Bad evaluator state!");
 
-	// Wait for the polling thread to finish also, as otherwise a new
-	// evaluation might be started before polling for the last one has
-	// finished.  The new evaluation might clobber previous results.
-	if (pollthr)
-	{
-		pollthr->join();
-		delete pollthr;
-		pollthr = nullptr;
-	}
+	// Per-shell evaluator.  We do this here, not in the ctor, because
+	// we want a unique, private evaluator for this thread. By contrast,
+	// the ctor might be called many times within one thread, and thus,
+	// each invocation would end up with the same evaluator.
+	_evaluator = get_evaluator();
+	_evaluator->clear_pending();
 
-	start_eval();
-	poll_needed = true;
+	// Poll for output from the evaluator, and send back results.
+	auto poll_wrapper = [&](void) { poll_loop(); };
+	pollthr = new std::thread(poll_wrapper);
 
-	auto eval_wrapper = [&](const std::string& in)
+	// Derived-class initializer. (The scheme shell uses this to set the
+	// atomspace).
+	thread_init();
+
+	std::string in;
+	while (true)
 	{
-		thread_init();
+		evalque.pop(in);
+		start_eval();
 		_evaluator->begin_eval();
 		_evaluator->eval_expr(in);
-	};
+	}
+}
 
-	evalthr = new std::thread(eval_wrapper, input);
+void GenericShell::poll_loop(void)
+{
+	_init_done = true;
+
+	// Poll for output from the evaluator, and send back results.
+	while (true)
+	{
+		std::string retstr = poll_output();
+		if (0 < retstr.size())
+			socket->Send(retstr);
+usleep(10000);
+	}
 }
 
 void GenericShell::thread_init(void)
@@ -501,8 +463,9 @@ std::string GenericShell::poll_output()
 		return result;
 	}
 
-	// If we are here, there's no pending output. Does the
-	// evaluator have anything for us?
+	// If we are here, there's no pending output. Does the evaluator
+	// have anything for us?  Note that the ->poll_result() method
+	// will block, if the evaluator is not done.
 	std::string result = _evaluator->poll_result();
 	if (0 < result.size())
 		return result;

--- a/opencog/cogserver/shell/GenericShell.h
+++ b/opencog/cogserver/shell/GenericShell.h
@@ -28,6 +28,8 @@
 #include <string>
 #include <thread>
 
+#include <opencog/util/concurrent_queue.h>
+
 /**
  * The GenericShell class implements an "escape" from the default cogserver
  * command processor. It is useful when a module has a large number of
@@ -58,6 +60,8 @@ class GenericShell
 		ConsoleSocket* socket;
 		std::thread* evalthr;
 		std::thread* pollthr;
+		concurrent_queue<std::string> evalque;
+		volatile bool _init_done;
 
 	protected:
 		std::string abort_prompt;
@@ -70,9 +74,10 @@ class GenericShell
 		virtual GenericEval* get_evaluator(void) = 0;
 		virtual void thread_init(void);
 		virtual void line_discipline(const std::string &expr);
-		virtual void do_eval(const std::string &expr);
 
 		// Concurrency handling
+		void eval_loop();
+		void poll_loop();
 		bool _eval_done;
 		std::condition_variable _cv;
 		std::mutex _mtx;
@@ -82,7 +87,6 @@ class GenericShell
 		void while_not_done();
 
 		// Output handling.
-		bool poll_needed;
 		virtual void put_output(const std::string&);
 		virtual std::string poll_output();
 

--- a/opencog/cogserver/shell/GenericShell.h
+++ b/opencog/cogserver/shell/GenericShell.h
@@ -69,7 +69,7 @@ class GenericShell
 		std::string pending_prompt;
 		bool show_output;
 		bool show_prompt;
-		bool self_destruct;
+		volatile bool self_destruct;
 
 		virtual GenericEval* get_evaluator(void) = 0;
 		virtual void thread_init(void);

--- a/opencog/cogserver/shell/GenericShell.h
+++ b/opencog/cogserver/shell/GenericShell.h
@@ -55,7 +55,8 @@ class GenericEval;
 class GenericShell
 {
 	private:
-		std::string pending_output;
+		std::mutex _pending_mtx;
+		std::string _pending_output;
 
 		ConsoleSocket* socket;
 		std::thread* evalthr;
@@ -88,6 +89,7 @@ class GenericShell
 
 		// Output handling.
 		virtual void put_output(const std::string&);
+		virtual std::string get_output();
 		virtual std::string poll_output();
 
 	public:

--- a/opencog/cogserver/shell/PythonShell.cc
+++ b/opencog/cogserver/shell/PythonShell.cc
@@ -51,7 +51,7 @@ PythonShell::~PythonShell()
     // to flush pending input in the python shell, as otherwise,
     // there is no way to know that no more python input will
     // arrive!
-    GenericShell::do_eval("");
+    GenericShell::eval("");
 
     // Don't delete, its currently set to a singleton instance.
     //	if (evaluator) delete evaluator;
@@ -78,7 +78,7 @@ void PythonShell::eval(const std::string &expr)
         // to flush pending input in the python shell, as otherwise,
         // there is no way to know that no more python input will
         // arrive!
-        GenericShell::do_eval("");
+        GenericShell::eval("");
     }
 }
 

--- a/tests/server/ShellUTest.cxxtest
+++ b/tests/server/ShellUTest.cxxtest
@@ -20,7 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <assert.h>
 #include <thread>
 #include <unistd.h>
 
@@ -39,7 +38,7 @@ void gargleblast(int tid, int reps)
 		if (rc != 0)
 			printf("Error: Create rep %d of %d in thread %d failed\n",
 				i, reps, tid);
-		assert(rc==0);
+		TS_ASSERT_EQUALS(rc, 0);
 		usleep(50000);
 
 		if (20 <= i)
@@ -49,7 +48,7 @@ void gargleblast(int tid, int reps)
 			if (rc != 0)
 				printf("Error: Delete rep %d of %d in thread %d failed\n",
 					i, reps, tid);
-			assert(rc==0);
+			TS_ASSERT_EQUALS(rc, 0);
 		}
 		usleep(50000);
 	}

--- a/tests/server/ShellUTest.cxxtest
+++ b/tests/server/ShellUTest.cxxtest
@@ -20,11 +20,11 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <assert.h>
 #include <thread>
 #include <unistd.h>
 
 #include <opencog/util/Config.h>
-#include <opencog/util/oc_assert.h>
 #include <opencog/cogserver/server/CogServer.h>
 
 using namespace opencog;
@@ -36,15 +36,20 @@ void gargleblast(int tid, int reps)
 		char buf[1000];
 		sprintf(buf, "echo '(Evaluation (Predicate \"visible face\") (List (Number %d)))\n' | nc -q 1 localhost 17333", i);
 		int rc = system(buf);
-		OC_ASSERT(rc==0, "system call failure");
+		if (rc != 0)
+			printf("Error: Create rep %d of %d in thread %d failed\n",
+				i, reps, tid);
+		assert(rc==0);
 		usleep(50000);
 
 		if (20 <= i)
 		{
 			sprintf(buf, "echo '(cog-delete (Evaluation (Predicate \"visible face\") (List (Number %d))))\n' | nc -q 1 localhost 17333", i-20);
 			rc = system(buf);
-			OC_ASSERT(rc==0, "system call failure");
-
+			if (rc != 0)
+				printf("Error: Delete rep %d of %d in thread %d failed\n",
+					i, reps, tid);
+			assert(rc==0);
 		}
 		usleep(50000);
 	}


### PR DESCRIPTION
The previous incarnation of the shell did not handle keyboard interrupts some of the time. This one fixes it so they always work.