### PR TITLE
Try again with other implications if sureal returns nothing for the chosen one

### DIFF
--- a/opencog/nlp/chatbot-psi/pln-actions.scm
+++ b/opencog/nlp/chatbot-psi/pln-actions.scm
@@ -55,7 +55,14 @@
     (define sureal-result (sureal logic))
 
     (if (null? sureal-result)
-        ; Try again until the semantics-list is empty
+        ; SuReal may give nothing because sometimes R2L generates the same pattern
+        ; (that PLN is looking for) for words that have very different disjuncts.
+        ; This introduces 'noise' and confuses SuReal so it generates nothing if
+        ; the 'noisy' one got chosen. So try again with other implications in the
+        ; semantics-list until the list is empty.
+        ; This is kind of like a workaround, would be better to fix in R2L, but
+        ; that requires too much work and R2L may be replaced by something better
+        ; shortly in the future...
         (if (eq? 1 (length semantics-list))
             '()
             (get-sureal-result (delete semantics semantics-list))

--- a/opencog/nlp/chatbot-psi/pln-actions.scm
+++ b/opencog/nlp/chatbot-psi/pln-actions.scm
@@ -59,11 +59,13 @@
            (assoc-inferred-names (get-assoc-inferred-names))
            (iu-names (get-input-utterance-names))
            (iu-inter (lambda (x) (lset-intersection equal? x iu-names)))
-           (not-null-iu-inter? (lambda (x) (not (null? (iu-inter (second x))))))
+           (not-null-iu-inter?
+                (lambda (x) (not (null? (iu-inter (list (first (second x))))))))
            (filtered-in (filter not-null-iu-inter? assoc-inferred-names))
            (semantics-list (shuffle (map first filtered-in)))
            (semantics (select-highest-tv-semantics semantics-list))
-           (semantics-type (cog-type semantics))
+           (semantics-type
+                (if (null? semantics) semantics (cog-type semantics)))
            (logic (if (equal? 'ImplicationLink semantics-type)
                       (implication-to-evaluation-s2l (gar semantics)
                                                      (gdr semantics))

--- a/opencog/nlp/chatbot-psi/pln-reasoner.scm
+++ b/opencog/nlp/chatbot-psi/pln-reasoner.scm
@@ -518,13 +518,6 @@
     ;; Apply Implication direct evaluation (and put the result in
     ;; pln-inferred-atoms state)
     (let* ((direct-eval-results (cog-fc (SetLink) rb3 (SetLink))))
-        ;; Filter only inferred result containing "happy". This is a
-        ;; temporary hack to make it up for the lack of attentional
-        ;; allocation
-        ;(must-contain (list (Predicate "happy") (Predicate "smart") (Predicate "funny")))
-        ;(ff (lambda (x) (lset<= equal? (cog-get-all-nodes x) must-contain)))
-        ;(filtered-results (filter ff (cog-outgoing-set direct-eval-results))))
-
         (add-to-pln-inferred-atoms direct-eval-results)
     )
 

--- a/opencog/nlp/chatbot-psi/pln-reasoner.scm
+++ b/opencog/nlp/chatbot-psi/pln-reasoner.scm
@@ -517,15 +517,15 @@
 
     ;; Apply Implication direct evaluation (and put the result in
     ;; pln-inferred-atoms state)
-    (let* ((direct-eval-results (cog-fc (SetLink) rb3 (SetLink)))
+    (let* ((direct-eval-results (cog-fc (SetLink) rb3 (SetLink))))
         ;; Filter only inferred result containing "happy". This is a
         ;; temporary hack to make it up for the lack of attentional
         ;; allocation
-        (must-contain (list (Predicate "happy")))
-        (ff (lambda (x) (lset<= equal? must-contain (cog-get-all-nodes x))))
-        (filtered-results (filter ff (cog-outgoing-set direct-eval-results))))
+        ;(must-contain (list (Predicate "happy") (Predicate "smart") (Predicate "funny")))
+        ;(ff (lambda (x) (lset<= equal? (cog-get-all-nodes x) must-contain)))
+        ;(filtered-results (filter ff (cog-outgoing-set direct-eval-results))))
 
-        (add-to-pln-inferred-atoms (Set filtered-results))
+        (add-to-pln-inferred-atoms direct-eval-results)
     )
 
     (cog-logger-debug "[PLN-Reasoner] pln-inferred-atoms = ~a"

--- a/opencog/nlp/chatbot-psi/pln-utils.scm
+++ b/opencog/nlp/chatbot-psi/pln-utils.scm
@@ -58,5 +58,6 @@
 
 (define (shuffle l)
   (map cdr
-    (sort (map (lambda (x) (cons (random 1.0) x)) l)
-          (lambda (x y) (< (car x) (car y))))))
+    (sort
+        (map (lambda (x) (cons (random 1.0 (random-state-from-platform)) x)) l)
+         (lambda (x y) (< (car x) (car y))))))


### PR DESCRIPTION
In `(do-pln-QA)`, it sometimes gives nothing even if the required information exists in the atomspace. This should fix the problem