### PR TITLE
Fix keyword matching in random sentence generator

### DIFF
--- a/opencog/nlp/chatbot-psi/contexts.scm
+++ b/opencog/nlp/chatbot-psi/contexts.scm
@@ -94,41 +94,36 @@
 
 (define rsg-input "")
 (define (check-theme target-words)
-    (define idx '())
-    (define cnt 0)
-    (define input-wl (cog-outgoing-set (get-input-word-list)))
+    (define input-text (cog-name (get-input-text-node)))
+    (define matched-keywords '())
 
-    ; target-words is a list of strings
-    (filter
+    (for-each
         (lambda (w)
-            (if (list? (member (cog-name w) target-words))
-                (set! idx (append idx (list cnt))))
-            (set! cnt (+ cnt 1)))
-        input-wl
+            (if (not (equal? #f (regexp-exec
+                    (make-regexp (string-append "\\b" w "\\b") regexp/icase) input-text)))
+                (set! matched-keywords (append matched-keywords (list w)))
+            )
+        )
+        target-words
     )
 
-    (if (null? idx)
+    (if (> (length matched-keywords) 0)
+        (begin
+            (set! rsg-input (list-ref matched-keywords (random (length matched-keywords))))
+            (stv 1 1))
         (stv 0 1)
-        (let ((rand-idx (list-ref idx (random (length idx)))))
-            (if (equal? (length input-wl) 1)
-                (set! rsg-input (cog-name (car input-wl)))
-                ; Feed the keyword directly to the generator, or with the
-                ; word either before or after that keyword
-                (if (> .7 (random 1.0))
-                    (set! rsg-input (cog-name (list-ref input-wl rand-idx)))
-                    (if (equal? rand-idx 0)
-                        (set! rsg-input (string-append
-                            (cog-name (list-ref input-wl rand-idx))
-                                " " (cog-name (list-ref input-wl (+ rand-idx 1)))))
-                        (set! rsg-input (string-append
-                            (cog-name (list-ref input-wl (- rand-idx 1)))
-                                " " (cog-name (list-ref input-wl rand-idx))))
-                    )
-                )
-            )
-            (stv 1 1)
-        )
     )
+
+(display "matched-keywords = ")
+(display (length matched-keywords))
+(newline)
+(display matched-keywords)
+(newline)
+(display "rsg-input\n")
+(display rsg-input)
+(newline)
+
+(stv 0 1)
 )
 
 (define (check-pkd-words)

--- a/opencog/nlp/chatbot-psi/contexts.scm
+++ b/opencog/nlp/chatbot-psi/contexts.scm
@@ -99,9 +99,18 @@
 
     (for-each
         (lambda (w)
-            (if (not (equal? #f (regexp-exec
-                    (make-regexp (string-append "\\b" w "\\b") regexp/icase) input-text)))
-                (set! matched-keywords (append matched-keywords (list w)))
+            (let ((r1 (regexp-exec (make-regexp
+                          (string-append "\\b" w "\\b") regexp/icase) input-text))
+                  (r2 (regexp-exec (make-regexp
+                          (string-append "\\w+\\s+\\b" w "\\b") regexp/icase) input-text))
+                  (r3 (regexp-exec (make-regexp
+                          (string-append "\\b" w "\\b\\s+\\w+") regexp/icase) input-text)))
+                (if (not (equal? #f r1))
+                    (set! matched-keywords (append matched-keywords (list w))))
+                (if (not (equal? #f r2))
+                    (set! matched-keywords (append matched-keywords (list (match:substring r2)))))
+                (if (not (equal? #f r3))
+                    (set! matched-keywords (append matched-keywords (list (match:substring r3)))))
             )
         )
         target-words
@@ -113,17 +122,6 @@
             (stv 1 1))
         (stv 0 1)
     )
-
-(display "matched-keywords = ")
-(display (length matched-keywords))
-(newline)
-(display matched-keywords)
-(newline)
-(display "rsg-input\n")
-(display rsg-input)
-(newline)
-
-(stv 0 1)
 )
 
 (define (check-pkd-words)


### PR DESCRIPTION
Fix the problem that it wasn't able to recognize multi-word keywords