### PR TITLE
Not to destroy the shell too early

### DIFF
--- a/opencog/cogserver/shell/GenericShell.cc
+++ b/opencog/cogserver/shell/GenericShell.cc
@@ -69,12 +69,6 @@ GenericShell::GenericShell(void)
 
 GenericShell::~GenericShell()
 {
-	self_destruct = true;
-
-	// It can happen that we are already canelling.
-	try { evalque.cancel(); }
-	catch (const std::exception& ex) {}
-
 	if (evalthr)
 	{
 		logger().debug("[GenericShell] dtor, wait for eval thread 0x%x.",
@@ -85,6 +79,13 @@ GenericShell::~GenericShell()
 		delete evalthr;
 		evalthr = nullptr;
 	}
+
+	self_destruct = true;
+
+	// It can happen that we are already canelling.
+	try { evalque.cancel(); }
+	catch (const std::exception& ex) {}
+
 	logger().debug("[GenericShell] dtor finished.");
 }
 


### PR DESCRIPTION
When a message arrives and has been pushed to the `evalque`, the shell may be destroyed immediately even before the expr in the `evalque` has the chance to be evaluated. This causes the robot to "ignore" a lot of the messages it receives

This should fix this particular problem, as described in https://github.com/opencog/opencog/issues/2592 as well