### PR TITLE
Fix a bug in GenericShell that keeps a thread alive forever

### DIFF
--- a/opencog/cogserver/shell/GenericShell.cc
+++ b/opencog/cogserver/shell/GenericShell.cc
@@ -523,6 +523,10 @@ void GenericShell::poll_loop(void)
 		if (_eval_done) usleep(10000);
 	}
 
+	// It's also possible that it reaches the dtor (turning self_destruct == true)
+	// shortly after an evaluation has just finished. It may then exit the loop
+	// above without polling the output, eventually causing the evalthr to stay
+	// in while_not_done() forever. So let's do it one more time here
 	std::string retstr(poll_output());
 	if (0 < retstr.size())
 		socket->Send(retstr);

--- a/opencog/cogserver/shell/GenericShell.cc
+++ b/opencog/cogserver/shell/GenericShell.cc
@@ -522,6 +522,16 @@ void GenericShell::poll_loop(void)
 		// slower than this...)
 		if (_eval_done) usleep(10000);
 	}
+
+	std::string retstr(poll_output());
+	if (0 < retstr.size())
+		socket->Send(retstr);
+
+	while (not _eval_done)
+	{
+		poll_output();
+		usleep(10000);
+	}
 }
 
 void GenericShell::thread_init(void)


### PR DESCRIPTION
There is a case that's causing the problem. It happens a lot more often when two messages are being sent simultaneously to the same socket, for example:
```python
#saliency location
#Degree of the salient point
def saliency(self,x,y,z,deg):
	sal = '(StateLink (AnchorNode "locations")' + \
		'(List (NumberNode '+ str(x)+ ')' + \
		'(NumberNode '+ str(y)+ ')' + \
		'(NumberNode '+ str(z) + ')))\n' + \
		'(StateLink (AnchorNode "Degree value")' + \
		'(NumberNode '+ str(deg)+'))\n'
	netcat(self.hostname,self.port,sal)
```
(in https://github.com/opencog/ros-behavior-scripting/blob/master/ros_bridge/atomic_msgs.py#L143-L152)

It always fails when the destructor of GenericShell is called by the ServerSocket shortly (and only) after the evaluation of the two messages has just finished. In this case the `pollthr` may exit the `poll_loop()` without calling `poll_output()` (and hence it doesn't have the chance to call `finish_eval()` to unlock the mutex), the `evalthr` will then be stuck in `while_not_done()` and never get killed. As a result, it keep occupying the console socket forever. Eventually when the number of concurrently open sockets reaches 60 (the max allowed), the whole stack stops responding. This PR should fix this problem.