### PR TITLE
Ecandev

### DIFF
--- a/opencog/attention/AFImportanceDiffusionAgent.cc
+++ b/opencog/attention/AFImportanceDiffusionAgent.cc
@@ -54,9 +54,6 @@ void AFImportanceDiffusionAgent::run()
                                   AttentionParamQuery::dif_spread_hebonly));
 
     spreadImportance();
-
-    //some sleep code
-    std::this_thread::sleep_for(std::chrono::milliseconds(get_sleep_time()));
 }
 
 /*

--- a/opencog/attention/AFRentCollectionAgent.cc
+++ b/opencog/attention/AFRentCollectionAgent.cc
@@ -54,13 +54,6 @@ void AFRentCollectionAgent::selectTargets(HandleSeq &targetSetOut)
 {
     std::back_insert_iterator< std::vector<Handle> > out_hi(targetSetOut);
     attentionbank(_as).get_handle_set_in_attentional_focus(out_hi);
-    /* Without adding this sleep code right below the above method call,
-     * nlp-parse evaluation thread waits for minutes before it gets a chance to
-     * run.  XXX FIXME .. maybe sched_yield() would be a better choice?
-     */
-    // sched_yield();
-    std::this_thread::sleep_for(std::chrono::nanoseconds(1));
-    //std::this_thread::sleep_for(std::chrono::seconds(1));
 }
 
 void AFRentCollectionAgent::collectRent(HandleSeq& targetSet)

--- a/opencog/attention/ImportanceDiffusionBase.cc
+++ b/opencog/attention/ImportanceDiffusionBase.cc
@@ -68,28 +68,8 @@ ImportanceDiffusionBase::ImportanceDiffusionBase(CogServer& cs) : Agent(cs)
  */
 void ImportanceDiffusionBase::updateMaxSpreadPercentage()
 {
-    Handle h = _as->get_handle(CONCEPT_NODE, "CONFIG-DiffusionPercent");
-
-    if (h)
-    {
-        HandleSeq resultSet;
-        // Given the PredicateNode, walk to the NumberNode
-        h->getIncomingSet(back_inserter(resultSet));
-        h = resultSet.front();
-        if (h->isLink()) {
-            resultSet = h->getOutgoingSet();
-            h = resultSet.back();
-            resultSet = h->getOutgoingSet();
-            h = resultSet.front();
-        }
-        double value = std::atof(h->getName().c_str());
-        _atq.set_param(AttentionParamQuery::dif_spread_percentage, value);
-
-#ifdef DEBUG
-        std::cout << "Diffusion percentage set to: " <<
-                     maxSpreadPercentage << std::endl;
-#endif
-    }
+    maxSpreadPercentage = std::stod(_atq.get_param_value(
+                AttentionParamQuery::dif_spread_percentage));
 }
 
 ImportanceDiffusionBase::~ImportanceDiffusionBase()

--- a/opencog/attention/WAImportanceDiffusionAgent.cc
+++ b/opencog/attention/WAImportanceDiffusionAgent.cc
@@ -51,8 +51,6 @@ void WAImportanceDiffusionAgent::run()
     hebbianMaxAllocationPercentage =std::stod(_atq.get_param_value(
                                      AttentionParamQuery::dif_tournament_size));
     spreadImportance();
-    //some sleep code
-    std::this_thread::sleep_for(std::chrono::milliseconds(get_sleep_time()));
 }
 
 /*

--- a/opencog/attention/WAImportanceDiffusionAgent.cc
+++ b/opencog/attention/WAImportanceDiffusionAgent.cc
@@ -103,7 +103,7 @@ HandleSeq WAImportanceDiffusionAgent::diffusionSourceVector(void)
 AttentionValue::sti_t WAImportanceDiffusionAgent::calculateDiffusionAmount(Handle h)
 {
     static ecan::StochasticDiffusionAmountCalculator sdac(_as);
-    float amount = sdac.diffusion_amount(h, _decayPercentage);
-   
-    return amount;
+    float current_estimate = sdac.diffused_value(h, maxSpreadPercentage);
+
+    return _bank->get_sti(h) - current_estimate;
 }

--- a/opencog/attention/WAImportanceDiffusionAgent.h
+++ b/opencog/attention/WAImportanceDiffusionAgent.h
@@ -59,7 +59,6 @@ class AtomSpace;
 class WAImportanceDiffusionAgent : public ImportanceDiffusionBase
 {
 private:
-    float  _decayPercentage;
     void spreadImportance();
     AttentionValue::sti_t calculateDiffusionAmount(Handle);
 

--- a/opencog/attention/WAImportanceDiffusionAgent.h
+++ b/opencog/attention/WAImportanceDiffusionAgent.h
@@ -59,12 +59,8 @@ class AtomSpace;
 class WAImportanceDiffusionAgent : public ImportanceDiffusionBase
 {
 private:
-    unsigned int SAMPLE_SIZE = 1;
-    unsigned int _tournamentSize;
     float  _decayPercentage;
-
     void spreadImportance();
-    Handle tournamentSelect(HandleSeq population);
     AttentionValue::sti_t calculateDiffusionAmount(Handle);
 
 public:

--- a/opencog/attention/WARentCollectionAgent.h
+++ b/opencog/attention/WARentCollectionAgent.h
@@ -29,6 +29,7 @@
 
 #include <opencog/util/RandGen.h>
 #include <opencog/cogserver/server/Agent.h>
+#include <opencog/attentionbank/StochasticImportanceDiffusion.h>
 
 #include "RentCollectionBaseAgent.h"
 
@@ -49,9 +50,7 @@ namespace opencog {
     class WARentCollectionAgent : public RentCollectionBaseAgent
     {
     private:
-        unsigned int SAMPLE_SIZE = 5;
-        unsigned int _tournamentSize;
-        Handle tournamentSelect(HandleSeq population);
+        ecan::StochasticDiffusionAmountCalculator _sdac;
 
     public:
         const ClassInfo& classinfo() const { return info(); }


### PR DESCRIPTION
 - Changed the way rent and diffusion in Whole AtomSpace was calculated. Now, Atoms directly and randomly selected from ImportanceBin and their last update average time is calculated using methods defined StochasticImortanceDiffusion class found in atomspace/attentionbank dir. 

- Removed deprecated code.