### PR TITLE
Change it back to use 'map' when iterating through the demands in psi-step

### DIFF
--- a/opencog/openpsi/main.scm
+++ b/opencog/openpsi/main.scm
@@ -123,7 +123,7 @@
     (psi-controller-update-weights)
 
     ; Do action-selection.
-    (par-map
+    (map
         (lambda (d)
             (let ((updater (psi-get-updater d)))
                 ; Run the updater for the demand.


### PR DESCRIPTION
Basically reverting the change I made in https://github.com/opencog/opencog/pull/2613, as this `par-map` seems to cause more pain than gain...