### PR TITLE
Expand "action-rule-ao" to accept ConceptNode as well

### DIFF
--- a/opencog/nlp/chatbot-eva/imperative.scm
+++ b/opencog/nlp/chatbot-eva/imperative.scm
@@ -60,7 +60,8 @@
 					(EvaluationLink
 						(Type "DefinedPredicateNode")
 						(TypeChoice
-						   (Type "ListLink") (Type "SetLink")))))
+						   (Type "ListLink") (Type "SetLink")
+						   (Type "ConceptNode")))))
 		)
 		(AndLink
 			(ListLink current-action (Variable "$action"))


### PR DESCRIPTION
For commands like "Look at this", it creates:
```
(EvaluationLink
    (DefinedPredicateNode "Look-at-thing cmd")
    (ConceptNode "salient-point")
)
```
So `action-rule-ao` should also look for `ConceptNode`

Should work together with https://github.com/opencog/ros-behavior-scripting/pull/161