### PR TITLE
Revert "Remove unused StringManipulator and StringTokenizer includes"

### DIFF
--- a/opencog/learning/PatternMiner/PatternMinerBF.cc
+++ b/opencog/learning/PatternMiner/PatternMinerBF.cc
@@ -40,6 +40,7 @@
 #include <opencog/embodiment/atom_types.h>
 #include <opencog/query/BindLinkAPI.h>
 #include <opencog/util/Config.h>
+#include <opencog/util/StringManipulator.h>
 
 #include "HTree.h"
 #include "PatternMiner.h"

--- a/opencog/spacetime/SpaceServer.cc
+++ b/opencog/spacetime/SpaceServer.cc
@@ -27,6 +27,8 @@
 #include <boost/bind.hpp>
 
 #include <opencog/util/Logger.h>
+#include <opencog/util/StringTokenizer.h>
+#include <opencog/util/StringManipulator.h>
 #include <opencog/util/oc_assert.h>
 
 #include <opencog/atomspace/AtomSpace.h>

--- a/opencog/spatial/3DSpaceMap/BlockEntity.cc
+++ b/opencog/spatial/3DSpaceMap/BlockEntity.cc
@@ -22,7 +22,9 @@
  */
 
 #include "BlockEntity.h"
+#include <opencog/util/StringManipulator.h>
 #include <opencog/util/Logger.h>
+
 
 using namespace opencog;
 using namespace opencog::spatial;

--- a/opencog/spatial/AStarTest.cc
+++ b/opencog/spatial/AStarTest.cc
@@ -23,6 +23,7 @@
 
 
 #include <opencog/util/mt19937ar.h>
+#include <opencog/util/StringManipulator.h>
 
 #include <opencog/spatial/AStarController.h>
 #include <opencog/spatial/LocalSpaceMap2DUtil.h>

--- a/opencog/spatial/LocalSpaceMap2DUtil.cc
+++ b/opencog/spatial/LocalSpaceMap2DUtil.cc
@@ -25,6 +25,7 @@
 #include <opencog/util/functional.h>
 #include <opencog/util/Logger.h>
 #include <opencog/util/random.h>
+#include <opencog/util/StringManipulator.h>
 
 #include <opencog/spatial/LocalSpaceMap2DUtil.h>
 #include <opencog/spatial/LocalSpaceMap2D.h>


### PR DESCRIPTION
Reverts opencog/opencog#2643