### PR TITLE
Handle more terms in chatlang

### DIFF
--- a/opencog/nlp/chatlang/terms.scm
+++ b/opencog/nlp/chatlang/terms.scm
@@ -42,3 +42,22 @@
                   (PartOfSpeech (Variable var) (DefinedLinguisticConcept p))
                   (WordInstanceLink (Variable var) (Variable "$P")))))
     (cons v c)))
+
+(define (proper-names . w)
+  "Terms represent multi-word proper names. It must have at least two words."
+  (define w1-atoms (word (car w)))
+  (define vars (car w1-atoms))
+  (define conds (cdr w1-atoms))
+  (define var-head (gar (caar w1-atoms)))
+  (define (template w)
+    (let* ((w-atoms (word w))
+           (v (car w-atoms))
+           (c (cdr w-atoms))
+           (el (EvaluationLink (LinkGrammarRelationship "G")
+                               (ListLink var-head
+                                         (gar (car v))))))
+      (append! vars v)
+      (append! conds c (list el))
+      (set! var-head (gar (car v)))))
+  (for-each template (cdr w))
+  (cons vars conds))

--- a/opencog/nlp/chatlang/terms.scm
+++ b/opencog/nlp/chatlang/terms.scm
@@ -18,6 +18,7 @@
    for word mentions in the rule pattern."
   (let* ((name (choose-var-name))
          (v (list (TypedVariable (Variable name) (Type "WordInstanceNode"))))
+         ; TODO -- need to actually get the lemma of "w" here
          (c (list (LemmaLink (Variable name) (WordNode w))
                   (WordInstanceLink (Variable name) (Variable "$P")))))
     (cons v c)))
@@ -80,7 +81,30 @@
       (cons v (append c cond-mv))
       (cons v c))))
 
+; This is NOT meant for external use
+; To generate the common atomese representation for main subject and object
+(define (main-so-template w r)
+  "The template for generating the main subject and object atomese."
+  (let* ((main-verb-atomese (main-verb-template))
+         (lemma-atomese (lemma w))
+         (var-so (gar (caar lemma-atomese))))
+    (cons (append (car main-verb-atomese)
+                  (car lemma-atomese))
+          (append (cdr main-verb-atomese)
+                  (cdr lemma-atomese)
+                  (list (Evaluation (DefinedLinguisticRelationship r)
+                                    (List (Variable "$main_verb")
+                                          var-so)))))))
+
 (define (main-verb w)
   "Term is the main verb of the sentence."
   (main-verb-template (list (Lemma (Variable "$main_verb") (Word w))
                             (WordInstance (Variable "$main_verb") (Variable "$P")))))
+
+(define (main-subj w)
+  "Term is the main subject of the sentence."
+  (main-so-template w "_subj"))
+
+(define (main-obj w)
+  "Term is the main object of the sentence."
+  (main-so-template w "_obj"))

--- a/opencog/nlp/chatlang/terms.scm
+++ b/opencog/nlp/chatlang/terms.scm
@@ -61,3 +61,26 @@
       (set! var-head (gar (car v)))))
   (for-each template (cdr w))
   (cons vars conds))
+
+; This is NOT meant for external use
+; The name of the variables ("$left_wall" and "$main_verb") are fixed
+; here as they are shared with all the main subj, obj, and verb, and
+; having fixed names seems to make it clearer and easier
+(define* (main-verb-template #:optional cond-mv)
+  "The template for generating the main verb atomese, since this is needed
+   for defining main subject, verb, and object."
+  (let* ((v (list (TypedVariable (Variable "$left_wall") (Type "WordInstanceNode"))
+                  (TypedVariable (Variable "$main_verb") (Type "WordInstanceNode"))))
+         (c (list (WordInstanceLink (Variable "$left_wall") (Variable "$P"))
+                  (WordInstanceLink (Variable "$main_verb") (Variable "$P"))
+                  (EvaluationLink (LinkGrammarRelationship "WV")
+                                  (ListLink (Variable "$left_wall")
+                                            (Variable "$main_verb"))))))
+    (if cond-mv
+      (cons v (append c cond-mv))
+      (cons v c))))
+
+(define (main-verb w)
+  "Term is the main verb of the sentence."
+  (main-verb-template (list (Lemma (Variable "$main_verb") (Word w))
+                            (WordInstance (Variable "$main_verb") (Variable "$P")))))

--- a/opencog/nlp/chatlang/terms.scm
+++ b/opencog/nlp/chatlang/terms.scm
@@ -110,3 +110,11 @@
 (define (main-obj w)
   "Term is the main object of the sentence."
   (main-so-template w "_obj"))
+
+(define (or-choices . w)
+  "The choices available, need to match either one of them in the list."
+  (let ((var (choose-var-name)))
+    (cons (list (TypedVariable (Variable var) (Type "WordInstanceNode")))
+          (list (WordInstanceLink (Variable var) (Variable "$P"))
+                ; TODO -- need to actually get the lemma of "x" here
+                (ChoiceLink (map (lambda (x) (LemmaLink (Variable var) (Word x))) w))))))

--- a/opencog/nlp/chatlang/terms.scm
+++ b/opencog/nlp/chatlang/terms.scm
@@ -18,7 +18,7 @@
    for word mentions in the rule pattern."
   (let* ((name (choose-var-name))
          (v (list (TypedVariable (Variable name) (Type "WordInstanceNode"))))
-         ; TODO -- need to actually get the lemma of "w" here
+         ; Note: This assumes "w" is already a lemma
          (c (list (LemmaLink (Variable name) (WordNode w))
                   (WordInstanceLink (Variable name) (Variable "$P")))))
     (cons v c)))
@@ -99,7 +99,7 @@
 (define (main-verb w)
   "Term is the main verb of the sentence."
   (main-verb-template
-    ; TODO -- need to actually get the lemma of "w" here
+    ; Note: This assumes "w" is already a lemma
     (list (LemmaLink (Variable "$main_verb") (Word w))
           (WordInstanceLink (Variable "$main_verb") (Variable "$P")))))
 
@@ -116,5 +116,5 @@
   (let ((var (choose-var-name)))
     (cons (list (TypedVariable (Variable var) (Type "WordInstanceNode")))
           (list (WordInstanceLink (Variable var) (Variable "$P"))
-                ; TODO -- need to actually get the lemma of "x" here
+                ; Note: This assumes "x" is already a lemma
                 (ChoiceLink (map (lambda (x) (LemmaLink (Variable var) (Word x))) w))))))

--- a/opencog/nlp/chatlang/terms.scm
+++ b/opencog/nlp/chatlang/terms.scm
@@ -37,12 +37,12 @@
 
 (define (pos w p)
   "Term with a specific POS tag (note: canonical form of word, not literal)"
-  (let* ((var (choose-var-name))
-         (v (list (TypedVariable (Variable var) (Type "WordInstanceNode"))))
-         (c (list (Lemma (Variable var) (Word w))
-                  (PartOfSpeech (Variable var) (DefinedLinguisticConcept p))
-                  (WordInstanceLink (Variable var) (Variable "$P")))))
-    (cons v c)))
+  (let* ((lemma-atomese (lemma w))
+         (var-node (gar (caar lemma-atomese))))
+    (cons (car lemma-atomese)
+          (append (cdr lemma-atomese)
+                  (list (PartOfSpeechLink var-node
+                                          (DefinedLinguisticConcept p)))))))
 
 (define (proper-names . w)
   "Terms represent multi-word proper names. It must have at least two words."
@@ -92,14 +92,16 @@
                   (car lemma-atomese))
           (append (cdr main-verb-atomese)
                   (cdr lemma-atomese)
-                  (list (Evaluation (DefinedLinguisticRelationship r)
-                                    (List (Variable "$main_verb")
-                                          var-so)))))))
+                  (list (EvaluationLink (DefinedLinguisticRelationship r)
+                                        (ListLink (Variable "$main_verb")
+                                                  var-so)))))))
 
 (define (main-verb w)
   "Term is the main verb of the sentence."
-  (main-verb-template (list (Lemma (Variable "$main_verb") (Word w))
-                            (WordInstance (Variable "$main_verb") (Variable "$P")))))
+  (main-verb-template
+    ; TODO -- need to actually get the lemma of "w" here
+    (list (LemmaLink (Variable "$main_verb") (Word w))
+          (WordInstanceLink (Variable "$main_verb") (Variable "$P")))))
 
 (define (main-subj w)
   "Term is the main subject of the sentence."

--- a/opencog/nlp/chatlang/translator.scm
+++ b/opencog/nlp/chatlang/translator.scm
@@ -90,10 +90,14 @@
          (proc-terms (fold process-pattern-term
                            template
                            pattern))
+         ; There may be duplicates if the pattern contains any two or more
+         ; of the main-* terms, e.g. main-verb, main-subj, and main-obj
+         (var-list (delete-duplicates (car proc-terms)))
+         (cond-list (delete-duplicates (cdr proc-terms)))
          (seq-check (term-sequence-check pattern)))
     (psi-rule
-      (list (Satisfaction (VariableList (car proc-terms))
-                          (And (append (cdr proc-terms) (list seq-check)))))
+      (list (Satisfaction (VariableList var-list)
+                          (And (append cond-list (list seq-check)))))
       (primitive-eval action)
       (True)
       (stv .9 .9)


### PR DESCRIPTION
It should now be able to handle 'proper names'. 'main verb', 'main subj', 'main obj' and 'or choices'.