### PR TITLE
Partial fix to ChatLangUTest library path issue

### DIFF
--- a/tests/nlp/chatlang/ChatlangUTest.cxxtest
+++ b/tests/nlp/chatlang/ChatlangUTest.cxxtest
@@ -54,8 +54,19 @@ public:
         scm = new SchemeEval(as);
         scm->eval("(add-to-load-path \"/usr/local/share/opencog/scm\")");
         scm->eval("(add-to-load-path \"" PROJECT_BINARY_DIR "\")");
-        scm->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "/tests/nlp/chatlang\")");
+        scm->eval("(add-to-load-path \"" PROJECT_BINARY_DIR "/opencog/\")");
+        scm->eval("(add-to-load-path \"" PROJECT_BINARY_DIR "/opencog/scm/\")");
+        scm->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "/tests/nlp/chatlang/\")");
 
+        scm->eval("(setenv \"LTDL_LIBRARY_PATH\" "
+                  "\"/usr/local/lib/opencog:/usr/local/lib/opencog/modules:"
+                  PROJECT_BINARY_DIR "/opencog/spacetime:"
+                  PROJECT_BINARY_DIR "/opencog/attention:"
+                  PROJECT_BINARY_DIR "/opencog/embodiment:"
+                  PROJECT_BINARY_DIR "/opencog/nlp/types"
+         "\")");
+
+        
         // This is really really strange... we should not need to actually load
         // any of the codes like this as they are part of the chatlang module?
         // But for some reason two of the chatlang tests were failing on my


### PR DESCRIPTION
It still fails if run before `sudo make install`, because the `(opencog eva-behavior)` module isn't found, but now 9 of 12 tests pass, so some minor progress. There really should be a way around manipulating `LTDL_LIBRARY_PATH` in test files, though...