### PR TITLE
Store additional kinds of counts obtained on input text

### DIFF
--- a/opencog/nlp/learn/link-pipeline.scm
+++ b/opencog/nlp/learn/link-pipeline.scm
@@ -149,7 +149,7 @@
 	(define (get-no seq-lnk)
 		(string->number (cog-name (gdr seq-lnk))))
 
-	(sort (map-word-instances make-ordered-word PARSE)
+	(sort (map make-ordered-word (parse-get-words PARSE))
 		(lambda (wa wb)
 			(< (get-no wa) (get-no wb))))
 )
@@ -177,9 +177,7 @@
 	(map-parses
 		(lambda (parse)
 			(count-one-atom any-parse)
-			(map-word-instances
-				try-count-one-word
-				parse))
+			(map try-count-one-word (parse-get-words parse)))
 		(list single-sent))
 )
 
@@ -363,9 +361,8 @@
 
 	(map-parses
 		(lambda (parse)
-			(map-word-instances
-				(lambda (wi) (try-count-one-cset (word-inst-get-cset wi)))
-				parse))
+			(map (lambda (wi) (try-count-one-cset (word-inst-get-cset wi)))
+				(parse-get-words parse)))
 		(list single-sent))
 )
 

--- a/opencog/nlp/learn/link-pipeline.scm
+++ b/opencog/nlp/learn/link-pipeline.scm
@@ -43,7 +43,7 @@
 ; sentence. This count is stored in the CountTV for the EvaluationLink
 ; on (PredicateNode "*-Sentence Word Pair-*").  A second count is
 ; maintained for this same pair, but including the distance between the
-; two words. This is on (PredicateNode "*-Pair Distance-*").  Since
+; two words. This is on (SchemaNode "*-Pair Distance-*").  Since
 ; sentences always start with LEFT-WALL, this can be used to reconstruct
 ; the typical word-order in a sentence.
 ;
@@ -144,7 +144,14 @@
 			(word-inst-get-word word-inst)
 			(NumberNode (- (get-number word-inst) wall-no))))
 
-	(map-word-instances make-ordered-word PARSE)
+	; Ahhh .. later code will be easier, if we return the list in
+	; sequential order. So, define a compare function and sort it.
+	(define (get-no seq-lnk)
+		(string->number (cog-name (gdr seq-lnk))))
+
+	(sort (map-word-instances make-ordered-word PARSE)
+		(lambda (wa wb)
+			(< (get-no wa) (get-no wb))))
 )
 
 ; ---------------------------------------------------------------------

--- a/opencog/nlp/learn/link-pipeline.scm
+++ b/opencog/nlp/learn/link-pipeline.scm
@@ -210,13 +210,13 @@
 	(define pair-dist (SchemaNode "*-Pair Distance-*"))
 
 	; Get the scheme-number of the word-sequence number
-	(define (get-number word-inst)
-		(string->number (cog-name (word-inst-get-number word-inst))))
+	(define (get-no seq-lnk)
+		(string->number (cog-name (gdr seq-lnk))))
 
 	; Create and count a word-pair, and the distance.
-	(define (count-one-pair left-word right-word)
-		(define pare (ListLink left-word right-word))
-		(define dist (- (get-number right-word) (get-number left-word)))
+	(define (count-one-pair left-seq right-seq)
+		(define pare (ListLink (gar left-seq) (gar right-seq)))
+		(define dist (- (get-no right-seq) (get-no left-seq)))
 
 		(count-one-atom (EvaluationLink pair-pred pare))
 		(count-one-atom (ExecutionLink pair-dist pare (NumberNode dist))))

--- a/opencog/nlp/learn/link-pipeline.scm
+++ b/opencog/nlp/learn/link-pipeline.scm
@@ -174,11 +174,11 @@
 			(lambda (key . args) #f)))
 
 	(count-one-atom any-sent)
-	(map-parses
+	(for-each
 		(lambda (parse)
 			(count-one-atom any-parse)
-			(map try-count-one-word (parse-get-words parse)))
-		(list single-sent))
+			(for-each try-count-one-word (parse-get-words parse)))
+		(sentence-get-parses single-sent))
 )
 
 ; ---------------------------------------------------------------------
@@ -352,18 +352,18 @@
 ;
 ; Just like the above, but for the disjuncts.
 
-(define (update-disjunct-counts single-sent)
+(define (update-disjunct-counts SENT)
 
 	(define (try-count-one-cset CSET)
 		(catch 'wrong-type-arg
 			(lambda () (count-one-atom (make-word-cset CSET)))
 			(lambda (key . args) #f)))
 
-	(map-parses
+	(for-each
 		(lambda (parse)
 			(map (lambda (wi) (try-count-one-cset (word-inst-get-cset wi)))
 				(parse-get-words parse)))
-		(list single-sent))
+		(sentence-get-parses SENT))
 )
 
 ; ---------------------------------------------------------------------

--- a/opencog/nlp/learn/link-pipeline.scm
+++ b/opencog/nlp/learn/link-pipeline.scm
@@ -248,7 +248,7 @@
 )
 
 ; ---------------------------------------------------------------------
-; map-lg-links -- loop over all link-grammar links in a list of sentences.
+; for-each-lg-link -- loop over all link-grammar links in a sentence.
 ;
 ; Each link-grammar link is of the general form:
 ;
@@ -260,11 +260,11 @@
 ;
 ; The PROC is a function to be invoked on each of these.
 ;
-(define (map-lg-links PROC sent-list)
-	(map-parses
+(define (for-each-lg-link PROC SENT)
+	(for-each
 		(lambda (parse)
-			(map PROC (parse-get-links parse)))
-		sent-list)
+			(for-each PROC (parse-get-links parse)))
+		(sentence-get-parses SENT))
 )
 
 ; ---------------------------------------------------------------------
@@ -344,7 +344,7 @@
 			(lambda () (count-one-atom (make-word-link link)))
 			(lambda (key . args) #f)))
 
-	(map-lg-links try-count-one-link (list single-sent))
+	(for-each-lg-link try-count-one-link (list single-sent))
 )
 
 ; ---------------------------------------------------------------------
@@ -426,15 +426,15 @@
 ; (relex-parse "this is")
 ; (get-new-parsed-sentences)
 ;
-; (map-lg-links prt (get-new-parsed-sentences))
+; (for-each-lg-link prt (get-new-parsed-sentences))
 ;
-; (map-lg-links (lambda (x) (prt (make-word-link x)))
+; (for-each-lg-link (lambda (x) (prt (make-word-link x)))
 ;    (get-new-parsed-sentences))
 ;
-; (map-lg-links (lambda (x) (prt (gddr (make-word-link x))))
+; (for-each-lg-link (lambda (x) (prt (gddr (make-word-link x))))
 ;    (get-new-parsed-sentences))
 ;
-; (map-lg-links (lambda (x) (cog-inc-count! (make-word-link x) 1))
+; (for-each-lg-link (lambda (x) (cog-inc-count! (make-word-link x) 1))
 ;    (get-new-parsed-sentences))
 ;
 ; (observe-text "abcccccccccc  defffffffffffffffff")

--- a/opencog/nlp/learn/link-pipeline.scm
+++ b/opencog/nlp/learn/link-pipeline.scm
@@ -2,7 +2,8 @@
 ; link-pipeline.scm
 ;
 ; Link-grammar word and link-counting pipeline.  Currently counts
-; words, word-pairs (links), disjuncts, parses and sentences.
+; words, several kinds of word-pairs (links, and order-relations),
+; and also disjuncts, parses and sentences.
 ;
 ; Copyright (c) 2013, 2017 Linas Vepstas <linasvepstas@gmail.com>
 ;
@@ -25,7 +26,10 @@
 ; *) how many sentences have been observed.
 ; *) how many parses were observed.
 ; *) how many words have been observed (counting once-per-word)
-; *) how many relationship triples have been observed.
+; *) how many word-order pairs have been observed.
+; *) the distance between words in the above pairs.
+; *) how many times a word appears first in a sentence.
+; *) how many link-relationship triples have been observed.
 ; *) how many disjuncts have been observed.
 ;
 ; Sentences are counted by updating the count on `(SentenceNode "ANY")`.
@@ -33,8 +37,37 @@
 ; Words are counted by updating the count on the `WordNode` for that
 ; word. It is counted with multiplicity: once for each time it occurs
 ; in a parse.  That is, if a word appears twice in a parse, it is counted
-; twice.  Counts for relations are stored in the TV for the EvaluationLink.
-; Disjuncts are counted by incrementing the LgWordCset for a given word.
+; twice.
+;
+; Word-pairs show up, and are counted in four different ways. First,
+; a count is made if two words appear, left-right ordered, in the same
+; sentence. This count is stored in the CountTV for the EvaluationLink
+; on (PredicateNode "*-Sentence Word Pair-*").  A second count is
+; maintained for this same pair, but including the distance between the
+; two words. This is on (PredicateNode "*-Pair Distance-*").  In
+; conjuction with these counts, it becomes interesting to see which
+; words occur at the starts of sentences.
+;
+; Word-pairs are also designated by means of Link Grammar parses of a
+; sentence. A Link Grammar parse creates a list of typed links between
+; pairs of words in the sentence. Each such link is counted once, for
+; each time that it occurs.  These counts are maintained in the CountTV
+; on the EvaluationLink for the LinkGrammarRelationshipNode for that
+; word-pair.  In addition, a count is maintained of the length of that
+; link.
+;
+; For the initial stages of the langauge-learning project, the parses
+; are produced by the "any" langauge parser, which produces random planar
+; trees.  This creates a sampling of word-pairs that is different than
+; merely having them show up in the same sentence.  That is, a covering
+; of a sentence by random trees does not produce the same edge statistics
+; as a clique of edges drawn between all words. This is explored further
+; in the diary, in a section devoted to this topic.
+;
+; The Link Grammar parse also produces and reports the disjuncts that were
+; used for each word. These are useful in and of themselves; they indicate
+; the hubbiness (link-multiplicity) of each word. The disjunct counts are
+; maintained on the LgWordCset for a given word.
 
 (use-modules (opencog) (opencog nlp) (opencog persist))
 

--- a/opencog/nlp/learn/notes
+++ b/opencog/nlp/learn/notes
@@ -3697,3 +3697,11 @@ scm_init_guile ()
 Done creating 120 threads
 
 
+argh  this is broken:
+cog-map-chase-links-chk
+cog-par-chase-links-chk
+
+thus all users of map-parses might be broken
+map-parses
+parallel-map-parses
+map-word-instances

--- a/opencog/nlp/learn/notes
+++ b/opencog/nlp/learn/notes
@@ -3705,3 +3705,9 @@ thus all users of map-parses might be broken
 map-parses
 parallel-map-parses
 map-word-instances
+
+ (use-modules (opencog) (opencog persist) (opencog persist-sql))
+ (use-modules (opencog nlp) (opencog nlp learn))
+ (sql-open "postgres:///en_pairs?user=linas")
+ (use-relex-server "127.0.0.1" 4445)
+

--- a/opencog/nlp/learn/notes
+++ b/opencog/nlp/learn/notes
@@ -3440,3 +3440,260 @@ args:\n((EvaluationLink\n   (LinkGrammarRelationshipNode \"ANY\")\n
 SQLAtomStorage::doGetLink
 IOException
  fixed in commit 327fc6c0a3c8b4b62ac80a61e2fdfc6971190c30
+
+arghhh, last checkpoint: 24304265 24M distinct words
+select sum(floatvalue[3]) from valuations where type=7;
+
+gives 1914173302 == 1.9G observations
+
+single-quote -- leading
+semicolon -- leading
+foobar
+sql-stats should print name of the DB and the login user.<F4>
+/home/ubuntu/run/hs_err_pid31730.log
+but only when sock is dropped...
+bug https://github.com/opencog/atomspace/issues/1054
+
+
+Using bdwgc as of 
+0f4244e130541a591d638c98f820b6b49e915ac0
+Author: Ivan Maidanski <ivmai@mail.ru>
+Date:   Thu Jan 12 00:58:41 2017 +0300
+
+
+stack below seen twice 3 4
+#0  0x00007ffff762c350 in pthread_kill ()
+   from /lib/x86_64-linux-gnu/libpthread.so.0
+#1  0x00007ffff785f490 in GC_suspend_all () at pthread_stop_world.c:640
+#2  0x00007ffff785f564 in GC_stop_world () at pthread_stop_world.c:748
+#3  0x00007ffff784b19e in GC_stopped_mark (
+    stop_func=stop_func@entry=0x7ffff784aca0 <GC_never_stop_func>)
+    at alloc.c:650
+#4  0x00007ffff784bd19 in GC_try_to_collect_inner (
+    stop_func=0x7ffff784aca0 <GC_never_stop_func>) at alloc.c:488
+#5  0x00007ffff784bf9a in GC_try_to_collect_general (
+    stop_func=stop_func@entry=0x0, force_unmap=force_unmap@entry=0)
+    at alloc.c:1064
+#6  0x00007ffff784c06d in GC_gcollect () at alloc.c:1088
+#7  0x00007ffff7b06529 in scm_i_gc (what=<synthetic pointer>)
+    at ../../libguile/gc.c:266
+#8  scm_gc () at ../../libguile/gc.c:255
+#9  0x00005555555551f2 in Eval::~Eval() ()
+
+
+stack below seen twice.3 
+#0  0x00007ffff762c350 in pthread_kill ()
+   from /lib/x86_64-linux-gnu/libpthread.so.0
+#1  0x00007ffff785f6fb in GC_start_world () at pthread_stop_world.c:990
+#2  0x00007ffff784b2d6 in GC_stopped_mark (
+    stop_func=stop_func@entry=0x7ffff784aca0 <GC_never_stop_func>)
+    at alloc.c:728
+#3  0x00007ffff784bd19 in GC_try_to_collect_inner (
+    stop_func=0x7ffff784aca0 <GC_never_stop_func>) at alloc.c:488
+#4  0x00007ffff784bf9a in GC_try_to_collect_general (
+    stop_func=stop_func@entry=0x0, force_unmap=force_unmap@entry=0)
+    at alloc.c:1064
+#5  0x00007ffff784c06d in GC_gcollect () at alloc.c:1088
+#6  0x00007ffff7b06529 in scm_i_gc (what=<synthetic pointer>)
+    at ../../libguile/gc.c:266
+#7  scm_gc () at ../../libguile/gc.c:255
+#8  0x00005555555551f2 in Eval::~Eval() ()
+
+==============================================
+latest bdwgc does this:
+#0  GC_push_all_eager (bottom=<optimized out>, 
+    top=top@entry=0x7ffff43f7000 <error: Cannot access memory at address
+0x7ffff43f7000>) at mark.c:1599
+#1  0x00007ffff7855625 in GC_push_all_stack (bottom=<optimized out>, 
+    top=top@entry=0x7ffff43f7000 <error: Cannot access memory at address
+0x7ffff43f7000>) at mark.c:1609
+#2  0x00007ffff78568aa in GC_push_all_stack_sections (lo=<optimized
+out>, 
+    lo@entry=0x7ffff43f56c0 <error: Cannot access memory at address
+0x7ffff43f56c0>, 
+    hi=hi@entry=0x7ffff43f7000 <error: Cannot access memory at address
+0x7ffff43f7000>, traced_stack_sect=<optimized out>) at mark_rts.c:565
+#3  0x00007ffff785f2fd in GC_push_all_stacks () at
+pthread_stop_world.c:557
+#4  0x00007ffff7855bcf in GC_mark_some (
+    cold_gc_frame=0x7fffe43d5d00 "\274ǧ\367\377\177") at mark.c:343
+#5  0x00007ffff784b20d in GC_stopped_mark (
+    stop_func=stop_func@entry=0x7ffff784aca0 <GC_never_stop_func>)
+    at alloc.c:702
+#6  0x00007ffff784bd19 in GC_try_to_collect_inner (
+    stop_func=0x7ffff784aca0 <GC_never_stop_func>) at alloc.c:488
+#7  0x00007ffff784bf9a in GC_try_to_collect_general (
+    stop_func=stop_func@entry=0x0, force_unmap=force_unmap@entry=0)
+    at alloc.c:1064
+#8  0x00007ffff784c06d in GC_gcollect () at alloc.c:1088
+#9  0x00007ffff7b06529 in scm_i_gc (what=<synthetic pointer>)
+    at ../../libguile/gc.c:266
+#10 scm_gc () at ../../libguile/gc.c:255
+#11 0x00005555555551f2 in Eval::~Eval() ()
+
+
+apt-cache show libgc-dev
+libgc-dev_7.4.2-8_amd64.deb
+git tag
+gc7_4_2
+gc7_4_4
+gc7_6_0 <---  try this one -- notpe still bad.
+
+
+    txt="Error: get_uuid(): cannot find (ListLink\n  (WordNode \"Hume\"
+(ctv 1.000000 0.000000 16.000000)) ; [1287745831931189139][1]\n
+(WordNode \",\" (ctv 1.000000 0.000000 64.000000)) ;
+[7731950238383222497][1]\n"...)
+
+            result = RAISE_SIGNAL(p, GC_sig_thr_restart);
+
+
+Guess  some of the threads are exiting when gc runs...
+
+for (p = GC_threads[i]; p != 0; p = p -> next) {
+p 
+
+#define RAISE_SIGNAL(t, sig) pthread_kill(THREAD_SYSTEM_ID(t), sig)
+#define THREAD_SYSTEM_ID(t) (t)->id
+
+ohhh 7.6 sometimes deadlocks...
+
+------------------ done iteration 14
+Done creating 120 threads
+
+Thread 1917 "a.out" received signal SIGSEGV, Segmentation fault.
+[Switching to Thread 0x7fffc639b700 (LWP 27872)]
+0x00007ffff762d350 in pthread_kill ()
+   from /lib/x86_64-linux-gnu/libpthread.so.0
+(gdb) bt
+#0  0x00007ffff762d350 in pthread_kill ()
+   from /lib/x86_64-linux-gnu/libpthread.so.0
+#1  0x00007ffff785fe70 in GC_suspend_all () at pthread_stop_world.c:640
+#2  0x00007ffff785ff44 in GC_stop_world () at pthread_stop_world.c:748
+
+(igdb) up
+#1  0x00007ffff785fe70 in GC_suspend_all () at pthread_stop_world.c:640
+640	              result = RAISE_SIGNAL(p, GC_sig_suspend);
+(gdb) print p
+$1 = (GC_thread) 0x7ffff7a7d380 <first_thread>
+(gdb) print i
+$2 = 0
+(gdb) print p->id
+$3 = 140737198868224
+(gdb) print /x p->id
+$4 = 0x7fffeebec700
+
+Sooo.. p->id  is not self.
+
+(gdb) print /x p->next
+$5 = 0x0
+
+(gdb) print GC_threads[1]
+$6 = (volatile GC_thread) 0x0
+
+(gdb) print /x self
+$10 = 0x7fffc639b700   -- yes this agreees with gdb message on top.
+
+(gdb) info thr --  lists all the threads. ...  0x7fffeebec700 is not listed,
+its not a valid thread.
+
+sure looks like bdwgc is failing to keep GC_threads[0] accurate.!!
+
+(gdb) print p->flags
+$11 = 6 '\006'
+
+include/private/pthread_support.h
+#       define FINISHED 1       /* Thread has exited.
+#       define DETACHED 2       /* Thread is treated as detached.
+                                /* Thread may really be detached, or
+                                /* it may have been explicitly
+                                /* registered, in which case we can
+                                /* deallocate its GC_Thread_Rep once
+                                /* it unregisters itself, since it
+                                /* may not return a GC pointer.
+#       define MAIN_THREAD 4    /* True for the original thread only.
+
+but its not teh main thread::: .. p is neoither of the below:
+(gdb) info thr
+  Id   Target Id         Frame 
+  1    Thread 0x7ffff7fc7300 (LWP 24666) "a.out" 0x00007ffff762767d in pthread_join () from /lib/x86_64-linux-gnu/libpthread.so.0
+* 1917 Thread 0x7fffc639b700 (LWP 27872) "a.out" 0x00007ffff762d350 in pthread_kill () from /lib/x86_64-linux-gnu/libpthread.so.0
+
+(gdb) print *p
+$12 = {next = 0x0, id = 140737198868224, stop_info = {last_stop_count = 1545, 
+    stack_ptr = 0x7fffeebeb6c0 <error: Cannot access memory at address 0x7fffeebeb6c0>}, flags = 6 '\006', thread_blocked = 0 '\000', finalizer_skipped = 0, 
+  finalizer_nested = 0 '\000', stack_end = 0x0, altstack = 0x0, 
+  altstack_size = 0, stack = 0x0, stack_size = 0, traced_stack_sect = 0x0, 
+  status = 0x0, tlfs = {_freelists = {{0x1, 0xbd, 0x555555818520, 
+        0x55555591f5d0, 0x5555557ff500, 0x3d, 0x1, 0x1, 0x1, 0x65, 
+        0x1 <repeats 14 times>, 0x1a}, {0x1, 0x5555559242d0, 0x55555587d820, 
+        0x555555908540, 0x10, 0x3d, 0x5555558ff2a0, 0xb9, 0x1c, 0xb, 0x0, 0x1, 
+        0x1, 0x1, 0x1, 0x1, 0x555555927d00, 0x1, 0x14, 0x1, 0x1, 0x1, 0x1, 
+        0x1, 0x1}, {0x1 <repeats 25 times>}}, gcj_freelists = {
+      0xffffffffffffffff, 0x1 <repeats 24 times>}}}
+
+
+new thread handled at line 538
+threa delete on 572
+GC_delete_thread  line 550
+but also ... GC_delete_gc_thread line 592
+
+GC_delete_thread called from only one place:
+GC_unregister_my_thread_inner
+called from two places:
+   GC_unregister_my_thread
+   GC_thread_exit_proc  -- not called by guile
+
+pthread_start.c:    pthread_cleanup_push(GC_thread_exit_proc, me);
+
+
+scm_gc is NOT being called in guile mode.!!  Example 1
+but fixing this does not cure the bug.
+
+threads.c:    GC_unregister_my_thread ();
+
+libguile/gc.c
+
+static void on_thread_exit (void *v)
+calls GC_unregister_my_thread() but only if t->needs_unregister) is set
+called by init_thread_key 
+by scm_i_init_thread_for_guile
+by scm_init_guile()
+
+Hmm   scm_i_with_guile no longer calls scm_init_guile()
+but with_guile() does call scm_i_init_thread_for_guile
+which does call init....
+
+maybe the exit handler is still running.... when the gc is called.
+
+except the thread should remain valid until all of the exit handlers
+have returned.  So maybe a thread handler did not run? ??
+
+
+Program terminated with signal SIGSEGV, Segmentation fault.
+#0  0x00007f19e496f350 in pthread_kill ()
+   from /lib/x86_64-linux-gnu/libpthread.so.0
+[Current thread is 1 (Thread 0x7f19aa6a7700 (LWP 7486))]
+
+sconew not being called !  
+GC_register_my_thread
+print notin
+print nxt
+
+x /150xg &board
+
+[Current thread is 1 (Thread 0x7f7aa3a6d700 (LWP 25905))]
+
+ print p
+$3 = (GC_thread) 0x7f7abb142380 <first_thread>
+
+(gdb) print /x p->id
+$5 = 0x7f7ab7a95700  this is the first thread....
+
+Needs_unreg was not set!!
+scm_init_guile ()
+
+------------------ done iteration 540
+Done creating 120 threads
+
+

--- a/opencog/nlp/relex2logic/tv-utilities.scm
+++ b/opencog/nlp/relex2logic/tv-utilities.scm
@@ -139,6 +139,11 @@
 "
   r2l-count SENT -- maintain counts of R2L atoms for SENT-LIST.
 
+  XXX FIXME ... this does NOT maintain counts in the same way as
+  all the other code ... i.e. it does NOT use CountTV.
+
+  This is some experimental? code and it might be obsolete?
+
   sent-list:
   - A list of SentenceNodes
 "
@@ -149,16 +154,17 @@
             (cog-set-tv! atom (stv 1 1))
         ))
 
-    (parallel-map-parses
-        (lambda (p)
-            (let* ((r2l-outputs (parse-get-r2l-outputs p))
-                (all-nodes (delete-duplicates
-                    (append-map cog-get-all-nodes r2l-outputs))))
+    (define (count-one-parse p)
+        (let* ((r2l-outputs (parse-get-r2l-outputs p))
+            (all-nodes (delete-duplicates
+                (append-map cog-get-all-nodes r2l-outputs))))
 
-                (map update-tv all-nodes)
-                (map update-tv r2l-outputs)
-            )
+            (map update-tv all-nodes)
+            (map update-tv r2l-outputs)
         )
-        sent-list
     )
+    (for-each
+        (lambda (sent)
+            (for-each count-one-parse (sentence-get-parses sent)))
+        sent-list)
 )

--- a/opencog/nlp/scm/nlp-utils.scm
+++ b/opencog/nlp/scm/nlp-utils.scm
@@ -160,6 +160,8 @@
 (define-public (sent-get-interp sent-node)
 "
   sent-get-interp - Given a SentenceNode returns a list of InterpretationNodes
+
+  XXX fix-me -- might this not be parse-dependent???
 "
     (parse-get-interp (car (sentence-get-parses sent-node)))
 )
@@ -248,7 +250,7 @@
   Specifically, if the word in a sentence is a parenthesis, then the
   ReferenceLink between the specific paren, and the general paren does
   not get created.  Viz, there is no `(ReferenceLink (WordInstanceNode
-  "(@4bf5e341-c6b") (WordNode "("))`. Some paren-counter somewhere is
+  '(@4bf5e341-c6b') (WordNode '('))`. Some paren-counter somewhere is
   broken and gets confused. Beats me where. It should be fixed. In the
   meanhile, a 'wrong-type-arg exception is thrown, when the `car` below
   dereferences the empty list. Callers of this function may want to

--- a/opencog/nlp/scm/nlp-utils.scm
+++ b/opencog/nlp/scm/nlp-utils.scm
@@ -10,7 +10,6 @@
 ; -- deleting all atoms pertaining to a sentence
 ;
 ; The function names that can be found here are:
-; -- map-parses   Call proceedure on every parse of the sentence.
 ; -- document-get-sentences Get senteces in document.
 ; -- sentence-get-parses    Get parses of a sentence.
 ; -- sentence-get-utterance-type  Get the speech act of a sentence.
@@ -49,52 +48,17 @@
 (use-modules (srfi srfi-1))
 
 ; ---------------------------------------------------------------------
-(define-public (map-parses proc sent-or-list)
+(define-public (document-get-sentences DOCO)
 "
-  map-parses   Call proceedure on every parse of the sentence.
+  document-get-sentences DOCO -- Get senteces in document DOCO
 
-  map-parses proc sent
-  Call proceedure 'proc' on every parse of the sentence 'sent'
-
-  Expected input is a SentenceNode, or possibly a list of SentenceNodes.
-  Each SentenceNode serves as an anchor to all of the parses of a sentence.
-  It is connected via ParseLink's to each of the individual parses of the
-  sentence. This routine backtracks over the ParseNode to find these.
-
-  The recursion will stop if proc returns something other than #f. This
-  routine returns the last value that stopped the recursion. (In other
-  words, this is not really a map, but something kind-of weird -- XXX
-  this should probably be fixed -- TODO)
+  Given a document DOCO, return a list of sentences in that document.
+  Throws an error if DOCO is not a DocumentNode
 "
-	(cog-map-chase-links-chk 'ParseLink 'ParseNode
-		proc sent-or-list 'SentenceNode)
-)
-
-; Same as above, but multi-threaded -- each parse dispatched to its own
-; thread, on a distinct CPU.
-(define-public (parallel-map-parses proc sent-or-list)
-"
-  parallel-map-parses   Call proceedure on every parse of the sentence.
-  Each parse is handled in a unique thread.
-"
-	(cog-par-chase-links-chk 'ParseLink 'ParseNode
-		proc sent-or-list 'SentenceNode)
-)
-
-; ---------------------------------------------------------------------
-(define-public (document-get-sentences doco)
-"
-  document-get-sentences Get senteces in document.
-
-  document-get-sentences doco
-
-  Given a document, return a list of sentences in that document
-  Throws an error if doco is not a DocumentNode
-"
-	(if (eq? (cog-type doco) 'DocumentNode)
-		(cog-get-reference doco)
+	(if (eq? (cog-type DOCO) 'DocumentNode)
+		(cog-get-reference DOCO)
 		(throw 'wrong-atom-type 'document-get-sentences
-			"Error: expecting DocumentNode:" doco)
+			"Error: expecting DocumentNode:" DOCO)
 	)
 )
 

--- a/opencog/nlp/scm/nlp-utils.scm
+++ b/opencog/nlp/scm/nlp-utils.scm
@@ -298,7 +298,17 @@
   `(WordInstance 'olah@12345')`, return `(WordNode 'olah')`
 
   There can only ever be one WordNode per WordInstance, so this returns
-  a single atom.
+  a single atom.  However ...
+
+  However, due to a RelEx bug, this function might throw an exception.
+  Specifically, if the word in a sentence is a parenthesis, then the
+  ReferenceLink between the specific paren, and the general paren does
+  not get created.  Viz, there is no `(ReferenceLink (WordInstanceNode
+  "(@4bf5e341-c6b") (WordNode "("))`. Some paren-counter somewhere is
+  broken and gets confused. Beats me where. It should be fixed. In the
+  meanhile, a 'wrong-type-arg exception is thrown, when the `car` below
+  dereferences the empty list. Callers of this function may want to
+  catch this exception.
 "
 	(car (cog-chase-link 'ReferenceLink 'WordNode word-inst))
 )

--- a/opencog/nlp/scm/nlp-utils.scm
+++ b/opencog/nlp/scm/nlp-utils.scm
@@ -4,16 +4,13 @@
 ;;; Commentary:
 ;
 ; Assorted NLP utilities.  Operations include:
-; -- looping over all sentences in a document
-; -- looping over all parses of a sentence (map-parses)
-; -- looping over all words in a sentence (map-word-instances)
-; -- get word of word instance. (word-inst-get-word)
-; -- get word senses
+; -- getting the various parses of a sentence
+; -- getting the words in a parse
+; -- getting assorted word properties
 ; -- deleting all atoms pertaining to a sentence
 ;
 ; The function names that can be found here are:
 ; -- map-parses   Call proceedure on every parse of the sentence.
-; -- map-word-instances     Call proc on each word-instance of parse.
 ; -- document-get-sentences Get senteces in document.
 ; -- sentence-get-parses    Get parses of a sentence.
 ; -- sentence-get-utterance-type  Get the speech act of a sentence.
@@ -82,23 +79,6 @@
 "
 	(cog-par-chase-links-chk 'ParseLink 'ParseNode
 		proc sent-or-list 'SentenceNode)
-)
-
-; ---------------------------------------------------------------------
-(define-public (map-word-instances proc parse-or-list)
-"
-  map-word-instances PROC PARSE -- Call PROC on each word-instance of PARSE.
-
-  Return a list of items, produced by calling PROC on each word-instance
-  in the parse.
-
-  Expected input is a ParseNode or a list of ParseNodes. These serve
-  as anchors to all of the word instances in a parse. The word instances
-  can be found by back-tracking through the WordInstanceLink to the
-  individual words, which is what this method does.
-"
-	(cog-map-chase-links-chk 'WordInstanceLink 'WordInstanceNode
-		proc parse-or-list 'ParseNode)
 )
 
 ; ---------------------------------------------------------------------
@@ -223,10 +203,10 @@
 ; ---------------------------------------------------------------------
 (define-public (parse-get-words parse-node)
 "
-  parse-get-words - Given a parse, return a list of all words in the parse
+  parse-get-words - Return a list of all word-instances in the parse.
 
   Given a parse, return all word instances in arbitary order
-  This version is faster than the in order version.
+  This version is faster than the ordered version.
 "
 	(cog-chase-link 'WordInstanceLink 'WordInstanceNode parse-node)
 )

--- a/opencog/nlp/scm/nlp-utils.scm
+++ b/opencog/nlp/scm/nlp-utils.scm
@@ -87,10 +87,10 @@
 ; ---------------------------------------------------------------------
 (define-public (map-word-instances proc parse-or-list)
 "
-  map-word-instances   Call proc on each word-instance of parse.
+  map-word-instances PROC PARSE -- Call PROC on each word-instance of PARSE.
 
-  map-word-instances proc parse
-  Call proceedure 'proc' on each word-instance of 'parse'
+  Return a list of items, produced by calling PROC on each word-instance
+  in the parse.
 
   Expected input is a ParseNode or a list of ParseNodes. These serve
   as anchors to all of the word instances in a parse. The word instances
@@ -236,6 +236,9 @@
   parse-get-words-in-order - Given a parse, return a list of all words in the parse in order
 
   Given a parse, return all word instances in order
+
+  XXX FIXME this is a very complicated, very inefficient implementation
+  there is a much easier way to get this.
 "
 	(define word-inst-list (cog-chase-link 'WordInstanceLink 'WordInstanceNode parse-node))
 	(define number-list (map word-inst-get-number word-inst-list))

--- a/opencog/nlp/scm/nlp-utils.scm
+++ b/opencog/nlp/scm/nlp-utils.scm
@@ -178,7 +178,8 @@
 ; ---------------------------------------------------------------------
 (define-public (sent-get-words-in-order sent-node)
 "
-  sent-get-words-in-order - Given a sentence, return a list of all words in order
+  sent-get-words-in-order - Given a sentence, return a list of all
+  of the word-instances in each parse, in order.
 
   Given a sentence, return all word instances in order
 "
@@ -231,22 +232,19 @@
 )
 
 ; ---------------------------------------------------------------------
-(define-public (parse-get-words-in-order parse-node)
+(define-public (parse-get-words-in-order PARSE)
 "
-  parse-get-words-in-order - Given a parse, return a list of all words in the parse in order
-
-  Given a parse, return all word instances in order
-
-  XXX FIXME this is a very complicated, very inefficient implementation
-  there is a much easier way to get this.
+  parse-get-words-in-order - Given PARSE, return a list of all word
+  instances in the parse, in sequential order.
 "
-	(define word-inst-list (cog-chase-link 'WordInstanceLink 'WordInstanceNode parse-node))
-	(define number-list (map word-inst-get-number word-inst-list))
+	; Get the scheme-number of the word-sequence numbe
+	(define (get-number word-inst)
+		(string->number (cog-name (word-inst-get-number word-inst))))
+
 	(define (less-than word-inst-1 word-inst-2)
-		(define index-1 (list-index (lambda (a-node) (equal? word-inst-1 a-node)) word-inst-list))
-		(define index-2 (list-index (lambda (a-node) (equal? word-inst-2 a-node)) word-inst-list))
-		(< (string->number (cog-name (list-ref number-list index-1))) (string->number (cog-name (list-ref number-list index-2)))))
-	(sort word-inst-list less-than)
+		(< (get-number word-inst-1) (get-number word-inst-2)))
+
+	(sort (parse-get-words PARSE) less-than)
 )
 
 ; --------------------------------------------------------------------

--- a/opencog/nlp/scm/parse-rank.scm
+++ b/opencog/nlp/scm/parse-rank.scm
@@ -297,7 +297,7 @@
 	; (display mi-edge-list) (newline)
 
 	; Score each of the parses in the sentence
-	(map-parses score-one-parse sent-node)
+	(for-each score-one-parse (sentence-get-parses sent-node))
 	#f
 )
 


### PR DESCRIPTION
There's a variety of interesting statistics that can be gathered, for observed text input. Gather these.  The file `opencog/nlp/learn/link-pipeline.scm` describes what all of these are.  They are further elaborated on, in the diary, although that is not yet merged.

This also removes two badly-designed API routines.