### PR TITLE
Remove bot-name when calling chatscript

### DIFF
--- a/opencog/nlp/chatbot-psi/chatscript.scm
+++ b/opencog/nlp/chatbot-psi/chatscript.scm
@@ -4,7 +4,7 @@
 (define cs-server "127.0.0.1")
 (define cs-port 1024)
 (define cs-username "opencog")
-(define cs-bot-name "rose")
+(define cs-bot-name "")
 
 ; Send a message to the ChatScript server
 (define (send-to-chatscript msg)


### PR DESCRIPTION
It's no longer needed