### PR TITLE
Language learning: Major format bugfix.

### DIFF
--- a/opencog/nlp/learn/README
+++ b/opencog/nlp/learn/README
@@ -206,6 +206,20 @@ So, set up the text-ingestion pipeline:
    pair-wise linkages for the above sentences. If the above are empty,
    something is wrong. Go to step zero.
 
+10b) Optionally reduce the amount of data that is collected. Currently,
+  the `observe-text` function in 'link-pipeline.scm` collects counts
+  on four different kinds of structures:
+
+  * Word counts -- how often a word is seen.
+  * Clique pairs, and pair-lengths -- This generates a HUGE amount of
+                  data! For every word pair, there might be 20 or 30
+                  different lengths at which it is observed, so the
+                  database will be 20x or 30x larger!  Watch out!
+  * Lg "ANY" word pairs -- how often a word-pair is observed.
+  * Disjunct counts -- how often the random ANY disjuncts are used.
+                You almost surely do not need this.  This is for my
+                own personal curiosity.
+
 11) Get ready to feed it text. It would be best to get text that
   consists of narrative literature, adventure and young-adult novels,
   newspaper stories. These contain a good mix of common nouns and verbs,

--- a/opencog/nlp/learn/README
+++ b/opencog/nlp/learn/README
@@ -211,10 +211,15 @@ So, set up the text-ingestion pipeline:
   on four different kinds of structures:
 
   * Word counts -- how often a word is seen.
-  * Clique pairs, and pair-lengths -- This generates a HUGE amount of
-                  data! For every word pair, there might be 20 or 30
-                  different lengths at which it is observed, so the
-                  database will be 20x or 30x larger!  Watch out!
+  * Clique pairs, and pair-lengths -- This counts pairs using the "clique
+                  pair" counting method.  The max length between words
+                  can be specified. Optionally, the lengths of the pairs
+                  can be recorded. Caution: enabling length recording
+                  will result in 6x or 20x more data to be collected,
+                  if you've set the length to 6 or 20.  That's because
+                  any given word pair will be observed at almost any
+                  length apart, each of these is an atom with a count.
+                  Watch out!
   * Lg "ANY" word pairs -- how often a word-pair is observed.
   * Disjunct counts -- how often the random ANY disjuncts are used.
                 You almost surely do not need this.  This is for my

--- a/opencog/nlp/learn/README
+++ b/opencog/nlp/learn/README
@@ -220,6 +220,13 @@ So, set up the text-ingestion pipeline:
                 You almost surely do not need this.  This is for my
                 own personal curiosity.
 
+10c) Optionally tune the forced garbage collection paramters. Currently
+  garbage collection is forced every 20 sentences; this helps keep RAM
+  usage down on small-RAM achines.  However, it does cost CPU time.
+  Adjust the `how-often` parameter in `observe-text` in
+  `link-pipeline.scm` to suit your whims in RAM usage and time spent
+  in GC.
+
 11) Get ready to feed it text. It would be best to get text that
   consists of narrative literature, adventure and young-adult novels,
   newspaper stories. These contain a good mix of common nouns and verbs,

--- a/opencog/nlp/learn/notes
+++ b/opencog/nlp/learn/notes
@@ -5882,6 +5882,7 @@ select count(*) from atoms;  <<< 10317409 = 10M atoms total
 WordNodes: 139790 -- 140K
 EvaluationLink : 4886362 -- 4.9M
 ListLink: exactly the same.
+LgWordCset: 404882 = 405K   Hmm Curious.
 
 select count(*) from valuations; <<< 5431036 = 5.4M values
 
@@ -5914,9 +5915,10 @@ Disjuncts from MST-parsed books from "tranche-1" of mostly project
 gutenberg books. Based off of the en_pairs_tone. Contains MI for tone,
 but not the cosine angles.
 
-STATUS: good
+STATUS: bad
 DATE: 27 May 2017
-REASON: I think it's good.
+REASON: Uses LgWordCset for for connectors and pseudo-connectors.
+   Which screws up statistics.
 
 en_pairs_tone_mst=> \dt+
                         List of relations
@@ -5940,6 +5942,8 @@ valuations.type=7 AND typecodes.typename='EvaluationLink';
 EaluationLink:  559225036 = 559M almost 4X more than baseline.
 WordNode: 125696239 = 126M = identical to baseline;
 LgWordCset: 133363005 = 134M  Hm. 9M more ob.
+XXX Wait. Since 134M were ANY links, that means only 9M are MST links.
+Oh wow. We need to fix this.
 
 Key 10317416  *-FrequencyKey-*
 Key 10872983  *-Mutual Info Key-*
@@ -5998,8 +6002,71 @@ ParseNode << 12468055 = 12.5M parses more than double.
 0b1908dfc232de4ea4e20d616cbbe290  en_pairs_ttwo.sql.bz2
 
 ==================================================================
+en_pairs_ttwo_mst
+-----------------
+Random parses from tranche-1 and tranche-2, together with MST parses from
+both tranches.
+
+STATUS: good
+DATE: 8 Jun 2017
+REASON: I think it's good.
+
+3993988657 Bytes = 3.99 GB uncompressed
+
+32d2396c4751311dd0a8cd8698465f3d  en_pairs_ttwo_mst.sql
+
+==================================================================
+en_pairs_tthree
+---------------
+Random parses from tranche-1, tranche-2 and tranche_3.
+
+STATUS: good
+DATE: 8 Jun 2017
+REASON: I think it's good.
+
+                        List of relations
+ Schema |    Name    | Type  | Owner  |    Size    | Description 
+--------+------------+-------+--------+------------+-------------
+ public | atoms      | table | ubuntu | 2831 MB    | 
+ public | spaces     | table | ubuntu | 40 kB      | 
+ public | typecodes  | table | ubuntu | 56 kB      | 
+ public | valuations | table | ubuntu | 2099 MB    | 
+ public | values     | table | ubuntu | 8192 bytes | 
+(5 rows)
+
+select count(*) from atoms;  <<< 32125825 = 32M atoms (15M more than before)
+select count(*) from valuations; <<< 16901543 = 16.9M (8.1M more)
+
+SELECT count(atoms.uuid) FROM atoms,typecodes WHERE
+atoms.type=typecodes.type AND typecodes.typename='foobar';
+
+WordNode: 431609 = 432K (245K more) !!! that's a lot. More than double.
+EvaluationLink: 15224271 = 15.2 M (7.2M more, almost double) 
+
+SELECT sum(floatvalue[3]) FROM valuations WHERE type=7;
+1588822019 << 1.59 G observations (832M more, more than double)
+
+SELECT sum(valuations.floatvalue[3]) FROM valuations, atoms, typecodes
+WHERE valuations.atom=atoms.uuid AND atoms.type=typecodes.type AND
+typecodes.typename='EvaluationLink';
+
+EvaluationLink: 557197874 = 557M pair obs, nearly double of before.
+WordNode: 503467934 = 503M -- more than double.
+LgWordCset: 503537347 = 503M -- double
+
+SentenceNode: 1487169 = 1.5M -- double
+ParseNode: 23131695 = 23M -- double
+
+1506102265 Bytes = 1.51 GB uncompressed
+256913537 Bytes = 257 GB compressed
+
+1cb778a18a51244c7a5c919337a38557  en_pairs_tthree.sql
+df1109d706bc5d088097713d7f85188e  en_pairs_tthree.sql.bz2
+
 ==================================================================
 ==================================================================
+
+
 ==================================================================
 
 Plan:
@@ -6744,6 +6811,50 @@ Count   (l_1)  1.6849E+6    5.1241E+7     50.05        398.2
 Length  (l_2)  1.2139E+6    6.4911E+6     36.06        50.44    
 RMS Count      1.0132E+6    6.4895E+6     30.10        50.42    
 
+
+===============
+Arghhhh Sanity check:
+the LgWordCset's in these files are:
+
+(LgWordCset 
+    (WordNode "this")
+    (LgAnd 
+        (LgConnector 
+            (LgConnectorNode "ANY")
+            (LgConnDirNode "-")
+            (LgConnMultiNode "@")
+        )
+
+vs.
+    (LgWordCset
+       (WordNode "playing")
+       (LgAnd
+          (PseudoConnector
+
+Ugh.  The load is polluted!
+
+Double check tone_mst...
+dd(use-modules (opencog) (opencog persist) (opencog persist-sql))
+(use-modules (opencog nlp) (opencog nlp learn) (opencog analysis))
+(sql-open "postgres:///en_pairs_tone_mst?user=ubuntu")
+(fetch-all-words)
+
+(define pca (make-pseudo-cset-api))
+(define psa (add-pair-stars pca))
+(psa 'fetch-pairs)
+
+So, tone, by itself, in sql, has:
+LgWordCset: 404882 = 405K  unique csets and
+LgWordCset: 125707119 << 126M disjunct observations.
+
+tone_mst has via SQL:
+   3975919 = 3.9M csets
+
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx here
+
+(cog-count-atoms 'LgWordCset)
+
+(cog-delete-recursive (LgConnMultiNode "@"))
 
 
 ---------- meanwhile, finish stats work
@@ -8042,6 +8153,44 @@ vp=0x160d2360,
     at ../../libguile/eval.c:508
 #8  0x00007ffff7ae19f5 in display_backtrace_body (a=<optimized out>)
 
+-----------------
+Another one:
+
+Thread 230572 "guile" received signal SIGSEGV, Segmentation fault.
+[Switching to Thread 0x7ffec77fe700 (LWP 3880)]
+scm_reverse (lst=lst@entry=0x80003e30) at ../../libguile/list.c:346
+#0  scm_reverse (lst=lst@entry=0x80003e30) at ../../libguile/list.c:346
+#1  0x00007ffff7b4d1ea in scm_string_concatenate_reverse (ls=0x80003e30, 
+    final_string=0x7fc19520, end=<optimized out>)
+    at ../../libguile/srfi-13.c:2465
+#2  0x00007ffff7b66381 in vm_debug_engine (
+    thread=0x7ffff73cd260 <GC_allocate_ml>, vp=0x7c1fd3f0, 
+    registers=0x7ffff73cd260 <GC_allocate_ml>, resume=1)
+    at ../../libguile/vm-engine.c:784
+#3  0x00007ffff7b702fa in scm_call_n (proc=0x7fffe7c9d4a8, 
+    argv=argv@entry=0x7ffec77fd540, nargs=nargs@entry=3)
+    at ../../libguile/vm.c:1271
+#4  0x00007ffff7af063f in scm_call_3 (proc=<optimized out>, 
+    arg1=<optimized out>, arg2=<optimized out>, arg3=<optimized out>)
+    at ../../libguile/eval.c:501
+#5  0x00007ffff7b66381 in vm_debug_engine (
+    thread=0x7ffff73cd260 <GC_allocate_ml>, vp=0x7c1fd3f0, 
+    registers=0x7ffff73cd260 <GC_allocate_ml>, resume=1)
+    at ../../libguile/vm-engine.c:784
+#6  0x00007ffff7b702fa in scm_call_n (proc=proc@entry=0x7cc865a0, 
+    argv=argv@entry=0x0, nargs=nargs@entry=0) at ../../libguile/vm.c:1271
+#7  0x00007ffff7af0599 in scm_call_0 (proc=proc@entry=0x7cc865a0)
+    at ../../libguile/eval.c:481
+#8  0x00007ffff7b5f149 in catch (tag=<optimized out>, thunk=0x7cc865a0, 
+    handler=0x7cc86580, pre_unwind_handler=0x7cc86560)
+    at ../../libguile/throw.c:137
+#9  0x00007fffecb61d89 in opencog::SchemeEval::do_eval(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (
+    this=0x7fff3c000980, expr=...)
+    at /home/ubuntu/src/atomspace/opencog/guile/SchemeEval.cc:576
+
+Well, that's different: for the first time ever, it is NOT in an
+exception context!!!
+
 
 
 
@@ -8256,6 +8405,28 @@ left-size: tot count /num-lefts<F8>x
 
 avg length
 ( err... left-length 'rigt-basis
+
+===============================================================
+
+(define pca (make-pseudo-cset-api))
+(define psa (add-pair-stars pca))
+(define pfa (add-pair-freq-api psa))
+(define pta (make-thresh-pca pfa))
+(define aw (get-all-cset-words))
+(define w (car aw))
+(define cset (cog-incoming-by-type w 'LgWordCset))
+(define dj (gdr (car cset)))
+
+(define feig (pta 'left-initial))
+(define lm (pta 'left-mult feig))
+(lm dj)
+
+(define lit (pta 'left-iterate feig))
+(lit w)
+
+(pta 'left-norm feig)
+
+
 
 
 

--- a/opencog/nlp/learn/scm/gram-class.scm
+++ b/opencog/nlp/learn/scm/gram-class.scm
@@ -14,7 +14,15 @@
 
 (use-modules (opencog) (opencog analysis))
 
-
 (define (do-it)
+	(let ((pca (make-pseudo-cset-api))
+			(psa (add-pair-stars pca))
+			(pfa (add-pair-freq-api psa))
+		)
+
+	(define pta (make-thresh-pca pfa))
+	(define all-words (get-all-cset-words))
+
+
 
 )

--- a/opencog/nlp/learn/scm/gram-class.scm
+++ b/opencog/nlp/learn/scm/gram-class.scm
@@ -1,0 +1,20 @@
+;
+; gram-class.scm
+;
+; Classify words into grammatical categories, using the "thresholding
+; PCA" (Principal Component Analsysis) algo. 
+;
+; ---------------------------------------------------------------------
+; OVERVIEW
+; --------
+; The overall algo is described in the language diary.  The bulk of the
+; computation is performed in the (opencog analysis) toolkit.
+;
+; ---------------------------------------------------------------------
+
+(use-modules (opencog) (opencog analysis))
+
+
+(define (do-it)
+
+)

--- a/opencog/nlp/learn/scm/gram-sim.scm
+++ b/opencog/nlp/learn/scm/gram-sim.scm
@@ -177,7 +177,7 @@
 		(if (eqv? 0 (modulo done 20))
 			(let* ((elapsed (- (current-time) start))
 					(frt (* done (- len done)))
-					(rate (* 0.001 (/ (- frt prev-f) (- elapsed prevt))))
+					(rate (* 0.001 (/ (- frt prevf) (- elapsed prevt))))
 					)
 				(format #t
 					 "Done ~A/~A frac=~5f% Time: ~A Done: ~4f% rate=~5f K prs/sec\n"
@@ -188,7 +188,7 @@
 					rate
 				)
 				(set! prevt elapsed)
-				(set! prev-f frt)
+				(set! prevf frt)
 			)))
 
 	; tail-recursive list-walker.
@@ -208,14 +208,8 @@
 
 	(launch WORD-LIST nthreads)
 
-	(format #t "Started ~d threads\n", nthreads)
+	(format #t "Started ~d threads\n" nthreads)
 )
-
-; If the similarity is less than this, it is not saved.
-; The current value is chosen by gut-feel, based on the current
-; dataset, which is small/crappy.  The appropriate value is
-; likely to be strongly dataset-dependent.
-(define cutoff 0.5)
 
 ; ---------------------------------------------------------------------
 ; Example usage:

--- a/opencog/nlp/learn/scm/link-pipeline.scm
+++ b/opencog/nlp/learn/scm/link-pipeline.scm
@@ -441,7 +441,8 @@
 				; (update-clique-pair-counts sent 6 #f)
 				(update-word-counts sent)
 				(update-lg-link-counts sent)
-				; (update-disjunct-counts sent)))
+				; (update-disjunct-counts sent)
+			))
 			(lambda (key . args) #f)))
 
 	; Loop -- process any that we find. This will typically race

--- a/opencog/nlp/learn/scm/link-pipeline.scm
+++ b/opencog/nlp/learn/scm/link-pipeline.scm
@@ -440,6 +440,9 @@
 					(process-sents)))))
 
 	; Manually run the garbage collector, every now and then.
+	; This helps keep RAM usage down, which is handy on small-RAM
+	; machines. However, it does cost CPU time, in exchange.
+	; Adjust `how-often` up or down to suit your whims.
 	(define maybe-gc
 		(let ((cnt 0)
 				(how-often 20)) ; every 20 times.

--- a/opencog/nlp/learn/scm/link-pipeline.scm
+++ b/opencog/nlp/learn/scm/link-pipeline.scm
@@ -439,9 +439,17 @@
 					(monitor-rate '())
 					(process-sents)))))
 
+	; Manually run the garbage collector, every now and then.
+	(define maybe-gc
+		(let ((cnt 0)
+				(how-often 20)) ; every 20 times.
+			(lambda ()
+				(set! cnt (+ cnt 1))
+				(if (eqv? 0 (modulo cnt how-often)) (gc)))))
+
 	(relex-parse plain-text) ;; send plain-text to server
 	(process-sents)
-	(gc) ;; need agressive gc to keep RAM under control.
+	(maybe-gc) ;; need agressive gc to keep RAM under control.
 )
 
 ; ---------------------------------------------------------------------

--- a/opencog/nlp/learn/scm/link-pipeline.scm
+++ b/opencog/nlp/learn/scm/link-pipeline.scm
@@ -414,13 +414,18 @@
 	; (see documentation for `word-inst-get-word`), the function
 	; `update-clique-pair-counts` might throw.  If it does throw,
 	; then avoid doing any counting at all for this sentence.
+	;
+	; Note: update-clique-pair-counts commented out, it generates
+	; HUGE amounts of data!
+	; Note: update-disjunct-counts commented out. It generates some
+	; data, but none of it will be interesting to most people.
 	(define (update-counts sent)
 		(catch 'wrong-type-arg
 			(lambda () (begin
 				; (update-clique-pair-counts sent)
 				(update-word-counts sent)
 				(update-lg-link-counts sent)
-				(update-disjunct-counts sent)))
+				; (update-disjunct-counts sent)))
 			(lambda (key . args) #f)))
 
 	; Loop -- process any that we find. This will typically race

--- a/opencog/nlp/learn/scm/make-disjuncts.scm
+++ b/opencog/nlp/learn/scm/make-disjuncts.scm
@@ -140,9 +140,9 @@
      (mst-parse-text 'The game is played on a level playing field')
   the word 'playing' might get this connector set:
 
-    (LgWordCset
+    (PseudoWordCset
        (WordNode \"playing\")
-       (LgAnd
+       (PseudoAnd
           (PseudoConnector
              (WordNode \"level\")
              (LgConnDirNode \"-\"))
@@ -218,9 +218,9 @@
 			rights))
 
 		; return the connector-set
-		(LgWordCset
+		(PseudoWordCset
 			(mst-seq-get-word seq)
-			(LgAnd (append left-cnc right-cnc)))
+			(PseudoAnd (append left-cnc right-cnc)))
 	)
 
 	(map

--- a/opencog/nlp/learn/scm/pseudo-csets.scm
+++ b/opencog/nlp/learn/scm/pseudo-csets.scm
@@ -17,9 +17,9 @@
 ; a bad example, because English should not connect this way. But
 ; it is an example...
 ;
-;    (LgWordCset
+;    (PseudoWordCset
 ;       (WordNode "playing")
-;       (LgAnd
+;       (PseudoAnd
 ;          (PseudoConnector
 ;             (WordNode "level")
 ;             (LgConnDirNode "-"))
@@ -27,14 +27,14 @@
 ;             (WordNode "field")
 ;             (LgConnDirNode "+"))))
 ;
-; The `LgAnd` part of this structure is refered to as the
+; The `PseudoAnd` part of this structure is refered to as the
 ; pseudo-disjunct, in that it resembles a normal linkgrammar
 ; disjunct, but has word appearing where connectors should be.
 ;
 ; Any given word may have dozens or hundreds or thousands of these
 ; connector sets. The totality of these sets, for a given, fixed word
 ; form a vector.  The disjunct is a basis element, and the raw
-; observational count on the `LgWordCset` is the magnitude of the
+; observational count on the `PseudoWordCset` is the magnitude of the
 ; of the vector in that basis direction.
 ;
 ; Note that these vectors are sparse: if a particular disjunct is
@@ -91,8 +91,8 @@
 		(define any-right (AnyNode "cset-disjunct"))
 
 		(define (get-left-type) 'WordNode)
-		(define (get-right-type) 'LgAnd)
-		(define (get-pair-type) 'LgWordCset)
+		(define (get-right-type) 'PseudoAnd)
+		(define (get-pair-type) 'PseudoWordCset)
 
 		; Getting the pair is trivial: we already got it.
 		(define (get-pair PAIR) PAIR)
@@ -115,7 +115,7 @@
 			(define all '())
 			(cog-map-type
 				(lambda (atom) (set! all (cons atom all)) #f)
-				'LgWordCset)
+				'PseudoWordCset)
 			all)
 
 		(define (get-all-csets)
@@ -127,7 +127,7 @@
 			(define start-time (current-time))
 			(fetch-incoming-set any-left)
 			(fetch-incoming-set any-right)
-			(load-atoms-of-type 'LgWordCset)
+			(load-atoms-of-type 'PseudoWordCset)
 			(format #t "Elapsed time to load csets: ~A secs\n"
 				(- (current-time) start-time)))
 
@@ -173,7 +173,7 @@
   in which case all the csets for that disjunct are returned.
 "
 	; Currently, its as simple as this...
-	(cog-incoming-by-type ITEM 'LgWordCset)
+	(cog-incoming-by-type ITEM 'PseudoWordCset)
 
 	; Should be this: XXX FIXME later
 	; (pseudo-cset-support-api 'right-stars ITEM)
@@ -231,7 +231,7 @@
 ; Return the cset, if it exists.  If it does not exist, return the
 ; empty list '()
 (define (have-cset? WORD DISJUNCT)
-	(cog-link 'LgWordCset WORD DISJUNCT))
+	(cog-link 'PseudoWordCset WORD DISJUNCT))
 
 (define-public (print-cset-list PORT LIST)
 "
@@ -254,11 +254,6 @@
 (define-public (get-all-disjuncts)
 "
   get-all-disjuncts -- Return all of the disjuncts in the atomspace.
-  Caution: this performs almost no sanity checks, and so could
-  easily return junk, if there are other LgAnd's in the atomspace.
-
-  The sanity check would be to make sure that the LgAnd has the desired
-  form, i.e. consisting entirely of PseudoDisjuncts.
 "
 	(pseudo-cset-stars 'right-basis)
 )
@@ -315,7 +310,7 @@
   DISJUNCT has been observed.  This is exactly equal to to wild-card
   summation over words N(*,d) = sum_w N(w,d) for d being the DISJUNCT.
 
-  DISJUNCT must be an LgAnd.
+  DISJUNCT must be an PseudoAnd.
 "
 	; Should be same as
 	; (pseudo-cset-support-api 'left-count DISJUNCT)
@@ -348,7 +343,7 @@
 (define-public (get-cset-frequency CSET)
 "
   get-cset-frequency -- Return the frequency (probability) with which
-  CSET has been observed. CSET must be a link of type LgWordCset.
+  CSET has been observed. CSET must be a link of type PseudoWordCset.
 "
 	(pseudo-cset-freq-api 'pair-freq CSET)
 )
@@ -364,7 +359,7 @@
 (define-public (cset-vec-dj-frequency DISJUNCT)
 "
   cset-vec-dj-frequency -- Return the frequency (probability) with
-  which DISJUNCT has been observed. DISJUNCT must be an LgAnd.
+  which DISJUNCT has been observed. DISJUNCT must be an PseudoAnd.
 "
 	(pseudo-cset-freq-api 'left-wild-freq DISJUNCT)
 )
@@ -475,7 +470,7 @@
 
 ; ---------------------------------------------------------------------
 ; Count the number of connectors in the disjunct.
-; But the disjunct is just an LgAnd of a bunch of connectors,
+; But the disjunct is just an PseudoAnd of a bunch of connectors,
 ; so this is easy.
 (define (dj-connectors DISJUNCT) (length (cog-outgoing-set DISJUNCT)))
 
@@ -537,7 +532,7 @@
   connector goes in direction DIR.  The DIR should be either
   (LgConnDirNode \"+\") or (LgConnDirNode \"-\").
 
-  ITEM can be either a WordNode, or a disjunct (LgAnd).
+  ITEM can be either a WordNode, or a disjunct (PseudoAnd).
 "
 	(define (con-count cset)
 		(* (get-count cset) (dj-connectors-dir (cset-get-disjunct cset) DIR)))
@@ -563,13 +558,8 @@
 (define-public (get-all-csets)
 "
   get-all-csets -- Return all of the connector-sets in the atomspace.
-  Caution: this performs almost no sanity checks, and so could
-  easily return junk, if there are other LgWordCsets's in the atomspace.
-
-  The sanity check would be to make sure that the LgAnd has the desired
-  form, i.e. consisting entirely of PseudoDisjuncts.
 "
-	(get-all-type 'LgWordCset)
+	(get-all-type 'PseudoWordCset)
 )
 
 ; ---------------------------------------------------------------------

--- a/opencog/nlp/types/atom_types.script
+++ b/opencog/nlp/types/atom_types.script
@@ -163,6 +163,7 @@ LG_LINK_INSTANCE_LINK <- LIST_LINK
 //
 MST_CONNECTOR <- LINK "MSTConnector"  // analogous to LG_CONNECTOR
 PSEUDO_CONNECTOR <- LINK  // with words, in place of connector letters.
+PSEUDO_WORD_CSET <- LIST_LINK  // Like LG_WORD_CSET, but with pseudo-connectors.
 
 // Analogous to LG_LINK_NODE and LG_DISJUNCT_NODE
 // The LINK_NODE is a pair of connected connectors (i.e. what is called

--- a/opencog/nlp/types/atom_types.script
+++ b/opencog/nlp/types/atom_types.script
@@ -162,13 +162,18 @@ LG_LINK_INSTANCE_LINK <- LIST_LINK
 // have MST as part of thier name.
 //
 MST_CONNECTOR <- LINK "MSTConnector"  // analogous to LG_CONNECTOR
-PSEUDO_CONNECTOR <- LINK  // with words, in place of connector letters.
-PSEUDO_WORD_CSET <- LIST_LINK  // Like LG_WORD_CSET, but with pseudo-connectors.
 
 // Analogous to LG_LINK_NODE and LG_DISJUNCT_NODE
 // The LINK_NODE is a pair of connected connectors (i.e. what is called
 // "the intersection" in the LG code-base/documentation)
 MST_LINK_NODE <- PREDICATE_NODE "MSTLinkNode"
+
+// Pseudo-connectors get their own distinct types.   This makes it
+// easier to perform data analysis; it also avoids confusion when
+// loading from the database.
+PSEUDO_WORD_CSET <- LIST_LINK // Like LG_WORD_CSET, but with pseudo-connectors.
+PSEUDO_AND <- LIST_LINK       // Like LG_AND, but with pseudo-connectors.
+PSEUDO_CONNECTOR <- LINK      // with words, in place of connector letters.
 
 // ---------------------------------------------------------------
 // Types used in the Lojban Parser


### PR DESCRIPTION
The same atom types were being used for two different kinds of data, making the dimensional reduction step problematic. One could hack around this, but that would be ugly; better to start with a clean slate.  If you have existing datasets with MST data in them, you may want to regenerate those. Either that, or manually remove all uses of LgConnector from your dataset before doing any processing.

Also: reduce by half the amount of data collected: this should make Ben and Curtis happier about performance -- it might double performance, I don't know.

Also: reduce the amount of forced GC. Before, it forced a GC round after every sentence, but this scandalized Curtis. New code forces a manual GC round every 30 sentences.  This will result in more RAM being used, though, so small-RAM machines may suffer.

Also: optionally collect clique-pair counts, to make Ben happy. Disabled by default, to avoid generating too much data. 