### PR TITLE
Add settings to run PatternMinerUTest::test_PatternMiner completely

### DIFF
--- a/tests/learning/PatternMiner/PatternMinerUTest.cxxtest
+++ b/tests/learning/PatternMiner/PatternMinerUTest.cxxtest
@@ -54,7 +54,12 @@ public:
 	void test_PatternMiner();
 };
 
-PatternMinerUTest::PatternMinerUTest() : _scm(&_as) {}
+PatternMinerUTest::PatternMinerUTest() : _scm(&_as)
+{
+	logger().set_level(Logger::DEBUG);
+	logger().set_timestamp_flag(false);
+	logger().set_print_to_stdout_flag(true);
+}
 PatternMinerUTest::~PatternMinerUTest() {}
 
 void PatternMinerUTest::setUp()
@@ -63,7 +68,7 @@ void PatternMinerUTest::setUp()
 	config().set("Pattern_Max_Gram", "4");
 	config().set("Enable_Frequent_Pattern", "true");
 	config().set("Enable_Interesting_Pattern", "true");
-	config().set("Interestingness_Evaluation_method", "surprisingness");
+	config().set("Enable_surprisingness", "true");
 	config().set("enable_filter_leaves_should_not_be_vars", "true");
 	config().set("enable_filter_links_should_connect_by_vars", "true");
 	config().set("enable_filter_not_inheritant_from_same_var", "true");
@@ -73,6 +78,8 @@ void PatternMinerUTest::setUp()
 	config().set("enable_filter_node_types_should_not_be_vars", "true");
 	config().set("node_types_should_not_be_vars", "PredicateNode");
 	config().set("Pattern_mining_mode", "Depth_First");
+	config().set("Max_thread_num", "4");
+
 
 	// Configure scheme load-paths that are common for all tests.
 	_scm.eval("(add-to-load-path \"" PROJECT_SOURCE_DIR
@@ -118,8 +125,6 @@ void PatternMinerUTest::test_PatternMiner()
 		logger().info("Failed: The result top 3-gram pattern count is wrong!");
 		TS_FAIL("The result top 3-gram pattern count is wrong!");
 	}
-
-
 
 	logger().info("End TEST: %s", __FUNCTION__);
 


### PR DESCRIPTION
Although it still fails. I'm getting
```
Error: Test failed: The result top 3-gram pattern is wrong!
[INFO] The result top 3-gram pattern: 
(InheritanceLink )
  (ConceptNode Abe)
  (PatternVariableNode $var_1)

(InheritanceLink )
  (ConceptNode Davion)
  (PatternVariableNode $var_1)

(InheritanceLink )
  (ConceptNode Hessley)
  (PatternVariableNode $var_1)


[INFO] Failed: The result top 3-gram pattern is wrong! The right one should be:
(InheritanceLink )
  (VariableNode $var_1)
  (ConceptNode man)

(InheritanceLink )
  (VariableNode $var_1)
  (ConceptNode soda drinker)

(InheritanceLink )
  (VariableNode $var_1)
  (ConceptNode ugly)
```

@shujingke any idea?

Also, why such a string representation (with a link between parenthesis)?