### PR TITLE
Remove dead code

### DIFF
--- a/opencog/attention/atom_types_init.cc
+++ b/opencog/attention/atom_types_init.cc
@@ -20,15 +20,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/cogserver/server/Module.h>
-
 #include "opencog/attention/atom_types.definitions"
 
 #define INHERITANCE_FILE "opencog/attention/atom_types.inheritance"
 #define INITNAME attention_types_init
 
 #include <opencog/atoms/base/atom_types.cc>
-
-using namespace opencog;
-TRIVIAL_MODULE(AttentionTypesModule)
-DECLARE_MODULE(AttentionTypesModule)

--- a/opencog/cogserver/server/Module.h
+++ b/opencog/cogserver/server/Module.h
@@ -53,33 +53,6 @@ namespace opencog
     }
 
 /**
- * TRIVIAL_MODULE -- Declare a trivial module called MODNAME.
- * This defines the class object, with trivial costructor and 
- * destructor. The primary users of this are expected to be 
- * any .so's that need to define new atom types.  These will
- * be treated as modules, so that the atom types get defined
- * at module load time, rather than later.
- *
- * Here's the technical issue being solved here:
- * 1) Atom types must be defined before use.
- * 2) Atom types get used during scheme (and python!) preloads
- * 3) ergo, shared lib init() ctors must be called before preload.
- * 4) The ctors are not called until some function in the .so is called.
- * 5) dlopen() will cause the init() ctor to run!
- * So the trivial module solves 5) and ergo fixes 1).
- */
-#define TRIVIAL_MODULE(MODNAME)                                       \
-    namespace opencog {                                               \
-    class MODNAME : public Module {                                   \
-    public:                                                           \
-        MODNAME(CogServer& cs) : Module(cs) {}                        \
-        virtual ~MODNAME() {}                                         \
-        const char * id(void);                                        \
-        virtual void init(void) {}                                    \
-    };}
-
-
-/**
  * This class defines the base abstract class that should be extended
  * by all opencog modules.
  *

--- a/opencog/embodiment/atom_types_init.cc
+++ b/opencog/embodiment/atom_types_init.cc
@@ -19,8 +19,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/cogserver/server/Module.h>
-
 #include "opencog/spacetime/atom_types.definitions"
 #include "opencog/embodiment/atom_types.definitions"
 
@@ -29,8 +27,3 @@
 #define INITNAME embodiment_types_init
 
 #include <opencog/atoms/base/atom_types.cc>
-
-using namespace opencog;
-TRIVIAL_MODULE(EmbodimentTypesModule)
-DECLARE_MODULE(EmbodimentTypesModule)
-

--- a/opencog/learning/PatternMiner/types/PatternMinerTypes.cc
+++ b/opencog/learning/PatternMiner/types/PatternMinerTypes.cc
@@ -5,15 +5,9 @@
  *
  * Copyright (c) 2009, 2017 Shujing Ke
  */
-
-#include <opencog/cogserver/server/Module.h>
 #include "opencog/learning/PatternMiner/types/atom_types.definitions"
 
 #define INHERITANCE_FILE "opencog/learning/PatternMiner/types/atom_types.inheritance"
 #define INITNAME patternminer_types_init
 
 #include <opencog/atoms/base/atom_types.cc>
-
-using namespace opencog;
-TRIVIAL_MODULE(PatternMinerTypesModule)
-DECLARE_MODULE(PatternMinerTypesModule)

--- a/opencog/nlp/types/NLPTypes.cc
+++ b/opencog/nlp/types/NLPTypes.cc
@@ -6,14 +6,9 @@
  * Copyright (c) 2009, 2014 Linas Vepstas <linasvepstas@gmail.com>
  */
 
-#include <opencog/cogserver/server/Module.h>
 #include "opencog/nlp/types/atom_types.definitions"
 
 #define INHERITANCE_FILE "opencog/nlp/types/atom_types.inheritance"
 #define INITNAME nlp_types_init
 
 #include <opencog/atoms/base/atom_types.cc>
-
-using namespace opencog;
-TRIVIAL_MODULE(NLPTypesModule)
-DECLARE_MODULE(NLPTypesModule)

--- a/opencog/spacetime/atom_types_init.cc
+++ b/opencog/spacetime/atom_types_init.cc
@@ -21,14 +21,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/cogserver/server/Module.h>
 #include "opencog/spacetime/atom_types.definitions"
 
 #define INHERITANCE_FILE "opencog/spacetime/atom_types.inheritance"
 #define INITNAME spacetime_types_init
 
 #include <opencog/atoms/base/atom_types.cc>
-
-using namespace opencog;
-TRIVIAL_MODULE(SpacetimeTypesModule)
-DECLARE_MODULE(SpacetimeTypesModule)


### PR DESCRIPTION
The need for this mechanism went away when the idea of preloading was removed. This extra code does nothing at all, and is un-needed.