### PR TITLE
Add empty pattern miner inference control utest

### DIFF
--- a/tests/learning/PatternMiner/PatternMinerUTest.cxxtest
+++ b/tests/learning/PatternMiner/PatternMinerUTest.cxxtest
@@ -51,7 +51,8 @@ public:
 	void tearDown();
 
 	// Test extracted from opencog/learning/PatternMiner/TestPatternMinerAgent.cc
-	void test_PatternMiner();
+	void test_PatternMiner_SodaDrinker();
+	void test_PatternMiner_InferenceControl();
 };
 
 PatternMinerUTest::PatternMinerUTest() : _scm(&_as)
@@ -97,7 +98,7 @@ void PatternMinerUTest::tearDown()
 
 }
 
-void PatternMinerUTest::test_PatternMiner()
+void PatternMinerUTest::test_PatternMiner_SodaDrinker()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 	// Load ugly_male_soda-drinker_corpus.scm
@@ -125,6 +126,23 @@ void PatternMinerUTest::test_PatternMiner()
 		logger().info("Failed: The result top 3-gram pattern count is wrong!");
 		TS_FAIL("The result top 3-gram pattern count is wrong!");
 	}
+
+	logger().info("End TEST: %s", __FUNCTION__);
+
+}
+
+void PatternMinerUTest::test_PatternMiner_InferenceControl()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+	// Load inference_control_corpus.scm
+	// _scm.eval("(load-from-path \"inference_control_corpus.scm\")");
+
+	// // Run the pattern miner
+	// PatternMiner pm(&_as);
+	// pm.runPatternMiner(false);
+
+	// Test the result: check the final top 3-gram pattern
+	// TODO
 
 	logger().info("End TEST: %s", __FUNCTION__);
 


### PR DESCRIPTION
Merge this empty pattern miner inference control utest now because entering a long digression.