### PR TITLE
Simplify handle set

### DIFF
--- a/opencog/attention/HebbianCreationAgent.cc
+++ b/opencog/attention/HebbianCreationAgent.cc
@@ -68,7 +68,7 @@ void HebbianCreationAgent::run()
 
     // Retrieve the atoms in the AttentionalFocus
     
-    OrderedHandleSet attentionalFocus;
+    HandleSet attentionalFocus;
     _bank->get_handle_set_in_attentional_focus(std::inserter(attentionalFocus,attentionalFocus.begin()));
   
     HandleSeq topStiInAF;
@@ -104,14 +104,14 @@ void HebbianCreationAgent::run()
     HandleSeq existingAsTargetHS =
             get_source_neighbors(source, ASYMMETRIC_HEBBIAN_LINK);
 
-    OrderedHandleSet existingAsSource(existingAsSourceHS.begin(),existingAsSourceHS.end());
-    OrderedHandleSet existingAsTarget(existingAsTargetHS.begin(),existingAsTargetHS.end());
+    HandleSet existingAsSource(existingAsSourceHS.begin(),existingAsSourceHS.end());
+    HandleSet existingAsTarget(existingAsTargetHS.begin(),existingAsTargetHS.end());
 
     // Get the set differences between the AttentionalFocus
     // and the sets of existing sources and targets
-    OrderedHandleSet needToBeSource = set_difference(attentionalFocus,
+    HandleSet needToBeSource = set_difference(attentionalFocus,
                                               existingAsSource);
-    OrderedHandleSet needToBeTarget = set_difference(attentionalFocus,
+    HandleSet needToBeTarget = set_difference(attentionalFocus,
                                               existingAsTarget);
 
     int count = 0;

--- a/opencog/learning/PatternMiner/PatternMiner.cc
+++ b/opencog/learning/PatternMiner/PatternMiner.cc
@@ -848,7 +848,7 @@ bool PatternMiner::isIgnoredContent(string keyword)
     return false;
 }
 
-bool PatternMiner::doesLinkContainNodesInKeyWordNodes(const Handle& link, const set<Handle>& keywordNodes)
+bool PatternMiner::doesLinkContainNodesInKeyWordNodes(const Handle& link, const HandleSet& keywordNodes)
 {
     HandleSeq outgoingLinks = link->getOutgoingSet();
 

--- a/opencog/learning/PatternMiner/PatternMiner.cc
+++ b/opencog/learning/PatternMiner/PatternMiner.cc
@@ -427,7 +427,7 @@ void PatternMiner::extractAllNodesInLink(Handle link, map<Handle,Handle>& valueT
     }
 }
 
-void PatternMiner::extractAllVariableNodesInAnInstanceLink(Handle& instanceLink, Handle& patternLink, OrderedHandleSet& allVarNodes)
+void PatternMiner::extractAllVariableNodesInAnInstanceLink(Handle& instanceLink, Handle& patternLink, HandleSet& allVarNodes)
 {
 
     HandleSeq ioutgoingLinks = instanceLink->getOutgoingSet();
@@ -509,7 +509,7 @@ void PatternMiner::extractAllNodesInLink(Handle link, map<Handle, unsigned int>&
     }
 }
 
-void PatternMiner::extractAllNodesInLink(Handle link, OrderedHandleSet& allNodes, AtomSpace* _fromAtomSpace)
+void PatternMiner::extractAllNodesInLink(Handle link, HandleSet& allNodes, AtomSpace* _fromAtomSpace)
 {
     HandleSeq outgoingLinks = link->getOutgoingSet();
 
@@ -529,7 +529,7 @@ void PatternMiner::extractAllNodesInLink(Handle link, OrderedHandleSet& allNodes
     }
 }
 
-void PatternMiner::extractAllVariableNodesInLink(Handle link, OrderedHandleSet& allNodes, AtomSpace* _atomSpace)
+void PatternMiner::extractAllVariableNodesInLink(Handle link, HandleSet& allNodes, AtomSpace* _atomSpace)
 {
     HandleSeq outgoingLinks = link->getOutgoingSet();
 
@@ -680,7 +680,7 @@ void PatternMiner::findAllInstancesForGivenPatternInNestedAtomSpace(HTreeNode* H
     Handle hAndLink = _atomSpace->add_link(AND_LINK, HNode->pattern);
 
     // add variable atoms
-    OrderedHandleSet allVariableNodesInPattern;
+    HandleSet allVariableNodesInPattern;
     for (unsigned int i = 0; i < HNode->pattern.size(); ++i)
     {
         extractAllVariableNodesInLink(HNode->pattern[i],allVariableNodesInPattern, _atomSpace);
@@ -1638,14 +1638,14 @@ bool PatternMiner::containsLoopVariable(HandleSeq& inputPattern)
 bool PatternMiner::filters(HandleSeq& inputLinks, HandleSeqSeq& oneOfEachSeqShouldBeVars, HandleSeq& leaves, HandleSeq& shouldNotBeVars, HandleSeq& shouldBeVars, AtomSpace* _atomSpace)
 {
 
-    OrderedHandleSet allNodesInEachLink[inputLinks.size()];
+    HandleSet allNodesInEachLink[inputLinks.size()];
 
-    OrderedHandleSet all2ndOutgoingsOfInherlinks;
+    HandleSet all2ndOutgoingsOfInherlinks;
 
     // map<predicate, set<value> >
-    map<Handle, OrderedHandleSet > predicateToValueOfEvalLinks;
+    map<Handle, HandleSet > predicateToValueOfEvalLinks;
 
-    OrderedHandleSet  all1stOutgoingsOfEvalLinks;
+    HandleSet  all1stOutgoingsOfEvalLinks;
 
 
     for (unsigned int i = 0; i < inputLinks.size(); ++i)
@@ -1685,10 +1685,10 @@ bool PatternMiner::filters(HandleSeq& inputLinks, HandleSeqSeq& oneOfEachSeqShou
 
                 if (enable_filter_not_same_var_from_same_predicate)
                 {
-                    map<Handle, OrderedHandleSet >::iterator it = predicateToValueOfEvalLinks.find(predicateNode);
+                    map<Handle, HandleSet >::iterator it = predicateToValueOfEvalLinks.find(predicateNode);
                     if (it != predicateToValueOfEvalLinks.end())
                     {
-                        OrderedHandleSet& values = (it->second);
+                        HandleSet& values = (it->second);
                         if (values.find(valueNode) != values.end())
                             return true;
                         else
@@ -1696,9 +1696,9 @@ bool PatternMiner::filters(HandleSeq& inputLinks, HandleSeqSeq& oneOfEachSeqShou
                     }
                     else
                     {
-                        OrderedHandleSet newValues;
+                        HandleSet newValues;
                         newValues.insert(valueNode);
-                        predicateToValueOfEvalLinks.insert(std::pair<Handle, OrderedHandleSet >(predicateNode,newValues));
+                        predicateToValueOfEvalLinks.insert(std::pair<Handle, HandleSet >(predicateNode,newValues));
                     }
                 }
 
@@ -1812,7 +1812,7 @@ bool PatternMiner::splitDisconnectedLinksIntoConnectedGroups(HandleSeq& inputLin
     if(inputLinks.size() < 2)
         return false;
 
-    OrderedHandleSet allNodesInEachLink[inputLinks.size()];
+    HandleSet allNodesInEachLink[inputLinks.size()];
     for (unsigned int i = 0; i < inputLinks.size(); ++i)
     {
         extractAllVariableNodesInLink(inputLinks[i],allNodesInEachLink[i], atomSpace);
@@ -3983,9 +3983,9 @@ void PatternMiner::testPatternMatcher()
 }
 
 
-OrderedHandleSet PatternMiner::_getAllNonIgnoredLinksForGivenNode(Handle keywordNode, OrderedHandleSet& allSubsetLinks)
+HandleSet PatternMiner::_getAllNonIgnoredLinksForGivenNode(Handle keywordNode, HandleSet& allSubsetLinks)
 {
-    OrderedHandleSet newHandles;
+    HandleSet newHandles;
     IncomingSet incomings = keywordNode->getIncomingSet(originalAtomSpace);
 
     // cout << "\n " << incomings.size() << " incomings found for keyword: " << keywordNode->toShortString() << std::endl;
@@ -4030,14 +4030,14 @@ OrderedHandleSet PatternMiner::_getAllNonIgnoredLinksForGivenNode(Handle keyword
     return newHandles;
 }
 
-OrderedHandleSet PatternMiner::_extendOneLinkForSubsetCorpus(OrderedHandleSet& allNewLinksLastGram, OrderedHandleSet& allSubsetLinks, set<Handle>& extractedNodes)
+HandleSet PatternMiner::_extendOneLinkForSubsetCorpus(HandleSet& allNewLinksLastGram, HandleSet& allSubsetLinks, set<Handle>& extractedNodes)
 {
-    OrderedHandleSet allNewConnectedLinksThisGram;
+    HandleSet allNewConnectedLinksThisGram;
     // only extend the links in allNewLinksLastGram. allNewLinksLastGram is a part of allSubsetLinks
     for (Handle link : allNewLinksLastGram)
     {
         // find all nodes in this link
-        OrderedHandleSet allNodes;
+        HandleSet allNodes;
         extractAllNodesInLink(link, allNodes, originalAtomSpace);
 
         for (Handle neighborNode : allNodes)
@@ -4054,7 +4054,7 @@ OrderedHandleSet PatternMiner::_extendOneLinkForSubsetCorpus(OrderedHandleSet& a
             else
                 extractedNodes.insert(neighborNode);
 
-            OrderedHandleSet newConnectedLinks;
+            HandleSet newConnectedLinks;
             newConnectedLinks = _getAllNonIgnoredLinksForGivenNode(neighborNode, allSubsetLinks);
             allNewConnectedLinksThisGram.insert(newConnectedLinks.begin(),newConnectedLinks.end());
             allSubsetLinks.insert(newConnectedLinks.begin(),newConnectedLinks.end());
@@ -4066,7 +4066,7 @@ OrderedHandleSet PatternMiner::_extendOneLinkForSubsetCorpus(OrderedHandleSet& a
 }
 
 // allSubsetLinks is  output
-void PatternMiner::findAllLinksContainKeyWords(vector<string>& subsetKeywords, unsigned int max_connection, bool logic_contain, OrderedHandleSet& allSubsetLinks)
+void PatternMiner::findAllLinksContainKeyWords(vector<string>& subsetKeywords, unsigned int max_connection, bool logic_contain, HandleSet& allSubsetLinks)
 {
     allSubsetLinks.clear();
     set<Handle> extractedNodes;
@@ -4152,7 +4152,7 @@ void PatternMiner::findAllLinksContainKeyWords(vector<string>& subsetKeywords, u
             else
                 continue;
 
-            OrderedHandleSet newConnectedLinks = _getAllNonIgnoredLinksForGivenNode(keywordNode, allSubsetLinks);
+            HandleSet newConnectedLinks = _getAllNonIgnoredLinksForGivenNode(keywordNode, allSubsetLinks);
 
             allSubsetLinks.insert(newConnectedLinks.begin(), newConnectedLinks.end());
 
@@ -4161,7 +4161,7 @@ void PatternMiner::findAllLinksContainKeyWords(vector<string>& subsetKeywords, u
     }
 
     unsigned int order = 0;
-    OrderedHandleSet allNewConnectedLinksThisGram = allSubsetLinks;
+    HandleSet allNewConnectedLinksThisGram = allSubsetLinks;
 
     while (order < max_connection)
     {
@@ -4174,7 +4174,7 @@ void PatternMiner::findAllLinksContainKeyWords(vector<string>& subsetKeywords, u
 void PatternMiner::selectSubsetAllEntityLinksContainsKeywords(vector<string>& subsetKeywords)
 {
     std::cout << "\nSelecting a subset from loaded corpus in Atomspace for the Entities contain following value keywords." << std::endl ;
-    OrderedHandleSet allSubsetLinks;
+    HandleSet allSubsetLinks;
     string topicsStr = "";
 
     for (string keyword : subsetKeywords)
@@ -4186,7 +4186,7 @@ void PatternMiner::selectSubsetAllEntityLinksContainsKeywords(vector<string>& su
 
     findAllLinksContainKeyWords(subsetKeywords, 0, false, allSubsetLinks);
 
-    OrderedHandleSet allEntityNodes;
+    HandleSet allEntityNodes;
     for (Handle link : allSubsetLinks)
     {  
         Handle firstOutgoing = link->getOutgoingAtom(1);
@@ -4207,7 +4207,7 @@ void PatternMiner::selectSubsetAllEntityLinksContainsKeywords(vector<string>& su
     int processEntityNum = 0;
     for (Handle entityNode : allEntityNodes)
     {
-        OrderedHandleSet allLinks = _getAllNonIgnoredLinksForGivenNode(entityNode, allSubsetLinks);
+        HandleSet allLinks = _getAllNonIgnoredLinksForGivenNode(entityNode, allSubsetLinks);
 
         allSubsetLinks.insert(allLinks.begin(), allLinks.end());
         processEntityNum ++;
@@ -4248,7 +4248,7 @@ void PatternMiner::selectSubsetAllEntityLinksContainsKeywords(vector<string>& su
 void PatternMiner::_selectSubsetFromCorpus(vector<string>& subsetKeywords, unsigned int max_connection, bool logic_contain)
 {
     std::cout << "\nSelecting a subset from loaded corpus in Atomspace for the following keywords within " << max_connection << " distance:" << std::endl ;
-    OrderedHandleSet allSubsetLinks;
+    HandleSet allSubsetLinks;
     string topicsStr = "";
 
     for (string keyword : subsetKeywords)

--- a/opencog/learning/PatternMiner/PatternMiner.h
+++ b/opencog/learning/PatternMiner/PatternMiner.h
@@ -171,7 +171,7 @@ protected:
 
     // = true will filter out atoms with labels contain keyword, = fasle will only filter out atoms with labels equal to any keyword
     bool keyword_black_logic_is_contain;
-    set<Handle> black_keyword_Handles; // only use when keyword_black_logic_is_contain = false
+    HandleSet black_keyword_Handles; // only use when keyword_black_logic_is_contain = false
 
     QUERY_LOGIC keyword_white_list_logic;
 
@@ -203,8 +203,8 @@ protected:
 
     vector<vector<vector<unsigned int>>> components_ngram[3];
 
-    vector<Handle> allLinksContainWhiteKeywords;
-    set<Handle> havenotProcessedWhiteKeywordLinks;
+    HandleSeq allLinksContainWhiteKeywords;
+    HandleSet havenotProcessedWhiteKeywordLinks;
 
    // [gram], this to avoid different threads happen to work on the same links.
    // each string is composed the handles of a group of fact links in the observingAtomSpace in the default hash order using std set
@@ -350,7 +350,7 @@ protected:
 
     HandleSet _getAllNonIgnoredLinksForGivenNode(Handle keywordNode, HandleSet& allSubsetLinks);
 
-    HandleSet _extendOneLinkForSubsetCorpus(HandleSet& allNewLinksLastGram, HandleSet& allSubsetLinks, set<Handle>& extractedNodes);
+    HandleSet _extendOneLinkForSubsetCorpus(HandleSet& allNewLinksLastGram, HandleSet& allSubsetLinks, HandleSet& extractedNodes);
 
     // will write the subset to a scm file
     void _selectSubsetFromCorpus(vector<string>& subsetKeywords, unsigned int max_connection, bool logic_contain = true);
@@ -361,7 +361,7 @@ protected:
 
     bool containIgnoredContent(Handle link );
 
-    bool doesLinkContainNodesInKeyWordNodes(const Handle& link, const set<Handle>& keywordNodes);
+    bool doesLinkContainNodesInKeyWordNodes(const Handle& link, const HandleSet& keywordNodes);
 
     vector<string> keyword_black_list;
     vector<string> keyword_white_list;

--- a/opencog/learning/PatternMiner/PatternMiner.h
+++ b/opencog/learning/PatternMiner/PatternMiner.h
@@ -254,16 +254,16 @@ protected:
 
     // valueToVarMap:  the ground value node in the orginal Atomspace to the variable handle in pattenmining Atomspace
     void extractAllNodesInLink(Handle link, map<Handle,Handle>& valueToVarMap, AtomSpace* _fromAtomSpace);
-    void extractAllNodesInLink(Handle link, OrderedHandleSet& allNodes, AtomSpace* _fromAtomSpace);
+    void extractAllNodesInLink(Handle link, HandleSet& allNodes, AtomSpace* _fromAtomSpace);
     void extractAllNodesInLink(Handle link, map<Handle, unsigned int> &allNodes, AtomSpace* _fromAtomSpace, unsigned index); // just find all the nodes in the original atomspace for this link
-    void extractAllVariableNodesInLink(Handle link, OrderedHandleSet& allNodes, AtomSpace* _atomSpace);
+    void extractAllVariableNodesInLink(Handle link, HandleSet& allNodes, AtomSpace* _atomSpace);
 
     // if a link contains only variableNodes , no const nodes
     bool onlyContainVariableNodes(Handle link, AtomSpace* _atomSpace);
 
     bool containVariableNodes(Handle link, AtomSpace* _atomSpace);
 
-    void extractAllPossiblePatternsFromInputLinksBF(HandleSeq& inputLinks,  HTreeNode* parentNode,OrderedHandleSet& sharedNodes, unsigned int gram);
+    void extractAllPossiblePatternsFromInputLinksBF(HandleSeq& inputLinks,  HTreeNode* parentNode,HandleSet& sharedNodes, unsigned int gram);
 
 //    // vector<HTreeNode *> &allHTreeNodes is output all the HTreeNodes found
 //    void extractAllPossiblePatternsFromInputLinksDF(HandleSeq& inputLinks,unsigned int sharedLinkIndex, AtomSpace* _fromAtomSpace,
@@ -281,12 +281,12 @@ protected:
 
     HandleSeq swapLinksBetweenTwoAtomSpaceBF(AtomSpace* fromAtomSpace, AtomSpace* toAtomSpace, HandleSeq& fromLinks, HandleSeq& outVariableNodes, HandleSeq& linksWillBeDel);
 
-    void extractAllVariableNodesInAnInstanceLink(Handle& instanceLink, Handle& patternLink, OrderedHandleSet& allVarNodes);
+    void extractAllVariableNodesInAnInstanceLink(Handle& instanceLink, Handle& patternLink, HandleSet& allVarNodes);
 
     void extractAllVariableNodesInAnInstanceLink(Handle& instanceLink, Handle& patternLink, map<Handle, unsigned int>& allVarNodes, unsigned index);
 
     void extendAllPossiblePatternsForOneMoreGramDF(HandleSeq &instance, AtomSpace* _fromAtomSpace, unsigned int gram,
-                                                   vector<HTreeNode*>& allLastGramHTreeNodes, map<HandleSeq, vector<HTreeNode*> >& allFactLinksToPatterns, vector<OrderedHandleSet>& newConnectedLinksFoundThisGram);
+                                                   vector<HTreeNode*>& allLastGramHTreeNodes, map<HandleSeq, vector<HTreeNode*> >& allFactLinksToPatterns, vector<HandleSet>& newConnectedLinksFoundThisGram);
 
     void extendAllPossiblePatternsForOneMoreGramBF(HandleSeq &instance, HTreeNode* curHTreeNode, unsigned int gram);
 
@@ -348,14 +348,14 @@ protected:
 
     void removeLinkAndItsAllSubLinks(AtomSpace *_atomspace, Handle link);
 
-    OrderedHandleSet _getAllNonIgnoredLinksForGivenNode(Handle keywordNode, OrderedHandleSet& allSubsetLinks);
+    HandleSet _getAllNonIgnoredLinksForGivenNode(Handle keywordNode, HandleSet& allSubsetLinks);
 
-    OrderedHandleSet _extendOneLinkForSubsetCorpus(OrderedHandleSet& allNewLinksLastGram, OrderedHandleSet& allSubsetLinks, set<Handle>& extractedNodes);
+    HandleSet _extendOneLinkForSubsetCorpus(HandleSet& allNewLinksLastGram, HandleSet& allSubsetLinks, set<Handle>& extractedNodes);
 
     // will write the subset to a scm file
     void _selectSubsetFromCorpus(vector<string>& subsetKeywords, unsigned int max_connection, bool logic_contain = true);
 
-    void findAllLinksContainKeyWords(vector<string>& subsetKeywords, unsigned int max_connection, bool logic_contain, OrderedHandleSet& foundLinks);
+    void findAllLinksContainKeyWords(vector<string>& subsetKeywords, unsigned int max_connection, bool logic_contain, HandleSet& foundLinks);
 
     bool isIgnoredContent(string keyword);
 

--- a/opencog/learning/PatternMiner/PatternMinerBF.cc
+++ b/opencog/learning/PatternMiner/PatternMinerBF.cc
@@ -63,7 +63,7 @@ void PatternMiner::extendAllPossiblePatternsForOneMoreGramBF(HandleSeq &instance
 
     // First, extract all the variable nodes in the instance links
     // we only extend one more link on the nodes that are considered as varaibles for this pattern
-    OrderedHandleSet allVarNodes;
+    HandleSet allVarNodes;
 
     HandleSeq::iterator patternLinkIt = curHTreeNode->pattern.begin();
     for (Handle link : instance)
@@ -72,7 +72,7 @@ void PatternMiner::extendAllPossiblePatternsForOneMoreGramBF(HandleSeq &instance
         patternLinkIt ++;
     }
 
-    OrderedHandleSet::iterator varIt;
+    HandleSet::iterator varIt;
 
     for(varIt = allVarNodes.begin(); varIt != allVarNodes.end(); ++ varIt)
     {
@@ -120,7 +120,7 @@ void PatternMiner::extendAllPossiblePatternsForOneMoreGramBF(HandleSeq &instance
 }
 
 void PatternMiner::extractAllPossiblePatternsFromInputLinksBF(HandleSeq& inputLinks,  HTreeNode* parentNode,
-                                                                          OrderedHandleSet& sharedNodes, unsigned int gram)
+                                                              HandleSet& sharedNodes, unsigned int gram)
 {
     map<Handle,Handle> valueToVarMap;  // the ground value node in the orginal Atomspace to the variable handle in pattenmining Atomspace
 
@@ -393,7 +393,7 @@ void PatternMiner::growTheFirstGramPatternsTaskBF()
         originalLinks.push_back(cur_link);
 
         // Extract all the possible patterns from this originalLinks, not duplicating the already existing patterns
-        OrderedHandleSet sharedNodes;
+        HandleSet sharedNodes;
         extractAllPossiblePatternsFromInputLinksBF(originalLinks, 0, sharedNodes, 1);
 
     }
@@ -647,7 +647,7 @@ void PatternMiner::findAllInstancesForGivenPatternBF(HTreeNode* HNode)
 
    HandleSeq patternToMatch = swapLinksBetweenTwoAtomSpaceBF(atomSpace, originalAtomSpace, HNode->pattern, variableNodes, linksWillBeDel);
 
-//   OrderedHandleSet allNodesInPattern;
+//   HandleSet allNodesInPattern;
 //   for (unsigned int i = 0; i < HNode->pattern.size(); ++i)
 //   {
 //       extractAllVariableNodesInLink(HNode->pattern[i],allNodesInPattern, atomSpace);

--- a/opencog/learning/PatternMiner/PatternMinerDF.cc
+++ b/opencog/learning/PatternMiner/PatternMinerDF.cc
@@ -110,7 +110,7 @@ using namespace opencog;
 //        {
 //            map<HandleSeq, vector<HTreeNode*> > ::iterator it = allLastGramLinksToPatterns.begin();
 //            map<HandleSeq, vector<HTreeNode*> > allThisGramLinksToPatterns;
-//            vector<OrderedHandleSet> newConnectedLinksFoundThisGram;
+//            vector<HandleSet> newConnectedLinksFoundThisGram;
 
 //            for(; it != allLastGramLinksToPatterns.end(); ++ it)
 //            {
@@ -965,7 +965,7 @@ void PatternMiner::extendAPatternForOneMoreGramRecursively(const Handle &extende
 
                             // check if these fact links already been processed before or by other thread
 
-                            OrderedHandleSet originalLinksSet(inputLinks.begin(), inputLinks.end());
+                            HandleSet originalLinksSet(inputLinks.begin(), inputLinks.end());
                             originalLinksSet.insert(extendedHandle);
 
                             for (Handle h  : originalLinksSet)
@@ -1030,7 +1030,7 @@ void PatternMiner::extendAPatternForOneMoreGramRecursively(const Handle &extende
 // this function is old
 // allLastGramHTreeNodes is input, allFactLinksToPatterns is output - the links fact to all its pattern HTreeNodes
 //void PatternMiner::extendAllPossiblePatternsForOneMoreGramDF(HandleSeq &instance, AtomSpace* _fromAtomSpace, unsigned int gram,
-//     vector<HTreeNode*>& allLastGramHTreeNodes, map<HandleSeq, vector<HTreeNode*> >& allFactLinksToPatterns, vector<OrderedHandleSet>& newConnectedLinksFoundThisGram)
+//     vector<HTreeNode*>& allLastGramHTreeNodes, map<HandleSeq, vector<HTreeNode*> >& allFactLinksToPatterns, vector<HandleSet>& newConnectedLinksFoundThisGram)
 //{
 
 //    // First, extract all the variable nodes in the instance links
@@ -1107,14 +1107,14 @@ void PatternMiner::extendAPatternForOneMoreGramRecursively(const Handle &extende
 
 //            // Extract all the possible patterns from this originalLinks, not duplicating the already existing patterns
 
-//            vector<OrderedHandleSet >::iterator newExtendIt;
-//            OrderedHandleSet originalLinksToSet(originalLinks.begin(),originalLinks.end());
+//            vector<HandleSet >::iterator newExtendIt;
+//            HandleSet originalLinksToSet(originalLinks.begin(),originalLinks.end());
 //            bool alreadyExtracted = false;
 
 //            // check if these links have been extracted
 //            for(newExtendIt = newConnectedLinksFoundThisGram.begin(); newExtendIt != newConnectedLinksFoundThisGram.end(); ++newExtendIt)
 //            {
-//                OrderedHandleSet& exitstingLinks = (OrderedHandleSet&)(*newExtendIt);
+//                HandleSet& exitstingLinks = (HandleSet&)(*newExtendIt);
 //                if (exitstingLinks == originalLinksToSet)
 //                {
 //                    alreadyExtracted = true;
@@ -1127,7 +1127,7 @@ void PatternMiner::extendAPatternForOneMoreGramRecursively(const Handle &extende
 //            if (! alreadyExtracted)
 //            {
 //                newConnectedLinksFoundThisGram.push_back(originalLinksToSet);
-////                OrderedHandleSet sharedNodes; // only the current extending shared node is in sharedNodes for Depth first
+////                HandleSet sharedNodes; // only the current extending shared node is in sharedNodes for Depth first
 ////                sharedNodes.insert(extendNode);
 //                vector<HTreeNode*> allThisGramHTreeNodes;
 //                extractAllPossiblePatternsFromInputLinksDF(originalLinks, (unsigned int)(varIt->second), _fromAtomSpace, allLastGramHTreeNodes, allThisGramHTreeNodes, gram);

--- a/opencog/learning/PatternMiner/PatternMinerDistributedWorker.cc
+++ b/opencog/learning/PatternMiner/PatternMinerDistributedWorker.cc
@@ -211,7 +211,7 @@ void DistributedPatternMiner::startMiningWork()
 
             cout << "Finding all Links contains these keywords...\n";
 
-            set<Handle> allLinksContainWhiteKeywordsSet;
+            HandleSet allLinksContainWhiteKeywordsSet;
             findAllLinksContainKeyWords(keyword_white_list, 0, true, allLinksContainWhiteKeywordsSet);
 
             std::copy(allLinksContainWhiteKeywordsSet.begin(), allLinksContainWhiteKeywordsSet.end(), std::back_inserter(allLinksContainWhiteKeywords));

--- a/opencog/nlp/fuzzy/Fuzzy.cc
+++ b/opencog/nlp/fuzzy/Fuzzy.cc
@@ -212,7 +212,7 @@ void Fuzzy::calculate_tfidf(const HandleSeq& word_insts)
         // No. of times this word exists in the sentence
         int word_cnt = std::count_if(word_insts.begin(), word_insts.end(), word_match);
 
-        OrderedHandleSet hs;
+        HandleSet hs;
         for (const Handle& l : get_source_neighbors(w, LEMMA_LINK))
         {
             for (const Handle& p : get_target_neighbors(l, WORD_INSTANCE_LINK))

--- a/opencog/nlp/fuzzy/Fuzzy.h
+++ b/opencog/nlp/fuzzy/Fuzzy.h
@@ -75,7 +75,7 @@ class Fuzzy :
 
         // The solutions
         RankedHandleSeq solns;
-        OrderedHandleSet solns_seen;
+        HandleSet solns_seen;
 
         // Some caches
         std::map<Handle, double> tfidf_weights;

--- a/opencog/nlp/sureal/SuRealPMCB.cc
+++ b/opencog/nlp/sureal/SuRealPMCB.cc
@@ -42,7 +42,7 @@ using namespace std;
  * @param pAS            the corresponding AtomSpace
  * @param vars           the set of nodes that should be treated as variables
  */
-SuRealPMCB::SuRealPMCB(AtomSpace* pAS, const OrderedHandleSet& vars, bool use_cache) :
+SuRealPMCB::SuRealPMCB(AtomSpace* pAS, const HandleSet& vars, bool use_cache) :
     InitiateSearchCB(pAS),
     DefaultPatternMatchCB(pAS),
     m_as(pAS),
@@ -509,7 +509,7 @@ bool SuRealPMCB::grounding(const std::map<Handle, Handle> &var_soln, const std::
         }
     }
 
-    OrderedHandleSet qSolnSetLinks;
+    HandleSet qSolnSetLinks;
 
     // get the R2L-SetLinks that are related to these InterpretationNodes
     for (Handle& hItprNode : qItprNode)

--- a/opencog/nlp/sureal/SuRealPMCB.h
+++ b/opencog/nlp/sureal/SuRealPMCB.h
@@ -47,7 +47,7 @@ class SuRealPMCB :
     public DefaultPatternMatchCB
 {
 public:
-    SuRealPMCB(AtomSpace* as, const OrderedHandleSet& vars, bool use_cache);
+    SuRealPMCB(AtomSpace* as, const HandleSet& vars, bool use_cache);
     ~SuRealPMCB();
 
     virtual bool variable_match(const Handle& hPat, const Handle& hSoln);
@@ -70,14 +70,14 @@ private:
 
     AtomSpace* m_as;
     bool m_use_cache;
-    OrderedHandleSet m_vars;   // store nodes that are variables
+    HandleSet m_vars;   // store nodes that are variables
 
     std::unordered_map<Handle, HandleSeq> m_disjuncts;   // store the disjuncts of nodes in the pattern
 
     std::unordered_map<Handle, Handle> m_words;   // store the corresponding WordNodes of the nodes in the pattern
 
-    OrderedHandleSet m_interp;   // store a set of InterpretationNodes correspond to some clauses accepted in clause_match()
-    OrderedHandleSet m_targets;   // store a set of target InterpretationNodes
+    HandleSet m_interp;   // store a set of InterpretationNodes correspond to some clauses accepted in clause_match()
+    HandleSet m_targets;   // store a set of target InterpretationNodes
 
     struct CandHandle
     {

--- a/opencog/nlp/sureal/SuRealSCM.cc
+++ b/opencog/nlp/sureal/SuRealSCM.cc
@@ -156,7 +156,7 @@ HandleSeqSeq SuRealSCM::do_sureal_match(Handle h, bool use_cache)
 
     AtomSpace* pAS = SchemeSmob::ss_get_env_as("sureal-match");
 
-    OrderedHandleSet sVars;
+    HandleSet sVars;
 
     // Extract the graph under the SetLink; this is done so that the content
     // of the SetLink could be matched to another SetLink with differnet arity.

--- a/opencog/nlp/wsd/EdgeUtils.h
+++ b/opencog/nlp/wsd/EdgeUtils.h
@@ -18,7 +18,7 @@ namespace opencog {
 class EdgeUtils
 {
 	public:
-		OrderedHandleSet words;
+		HandleSet words;
 		bool look_at_relation(const std::string &, const Handle&, const Handle&);
 		bool look_at_word(const Handle&);
 };

--- a/opencog/nlp/wsd/MihalceaEdge.cc
+++ b/opencog/nlp/wsd/MihalceaEdge.cc
@@ -91,10 +91,10 @@ void MihalceaEdge::annotate_parse(const Handle& h)
 	struct timeval start;
 	gettimeofday(&start, NULL);
 #endif
-	OrderedHandleSet::const_iterator f;
+	HandleSet::const_iterator f;
 	for (f = words.begin(); f != words.end(); ++f)
 	{
-		OrderedHandleSet::const_iterator s = f;
+		HandleSet::const_iterator s = f;
 		++s;
 		for (; s != words.end(); ++s)
 		{
@@ -126,7 +126,7 @@ void MihalceaEdge::annotate_parse_pair(const Handle& ha, const Handle& hb)
 {
 	words.clear();
 	foreach_word_instance(ha, &EdgeUtils::look_at_word, (EdgeUtils *) this);
-	OrderedHandleSet pa_words = words;
+	HandleSet pa_words = words;
 	words.clear();
 	foreach_word_instance(hb, &EdgeUtils::look_at_word, (EdgeUtils *) this);
 
@@ -143,10 +143,10 @@ void MihalceaEdge::annotate_parse_pair(const Handle& ha, const Handle& hb)
 	struct timeval start;
 	gettimeofday(&start, NULL);
 #endif
-	OrderedHandleSet::const_iterator ia;
+	HandleSet::const_iterator ia;
 	for (ia = pa_words.begin(); ia != pa_words.end(); ++ia)
 	{
-		OrderedHandleSet::const_iterator ib;
+		HandleSet::const_iterator ib;
 		for (ib = words.begin(); ib != words.end(); ++ib)
 		{
 			annotate_word_pair(*ia, *ib);

--- a/opencog/nlp/wsd/Sweep.cc
+++ b/opencog/nlp/wsd/Sweep.cc
@@ -101,10 +101,10 @@ bool Sweep::mark_sense(const Handle& sense, const Handle& edge)
 	return false;
 }
  
-void Sweep::delete_edges(OrderedHandleSet &edges)
+void Sweep::delete_edges(HandleSet &edges)
 {
 	// Remove all of the senses
-	OrderedHandleSet::iterator it;
+	HandleSet::iterator it;
 	for (it=edges.begin(); it != edges.end(); ++it)
 	{
 		Handle edge_h = *it;

--- a/opencog/nlp/wsd/Sweep.h
+++ b/opencog/nlp/wsd/Sweep.h
@@ -22,14 +22,14 @@ class Sweep
 {
 	private:
 		AtomSpace *atom_space;
-		OrderedHandleSet maxgraph;
-		OrderedHandleSet curgraph;
-		OrderedHandleSet maxedges;
-		OrderedHandleSet curedges;
+		HandleSet maxgraph;
+		HandleSet curgraph;
+		HandleSet maxedges;
+		HandleSet curedges;
 		bool mark_word(const Handle&);
 		bool start_mark_sense(const Handle&, const Handle&);
 		bool mark_sense(const Handle&, const Handle&);
-		void delete_edges(OrderedHandleSet &);
+		void delete_edges(HandleSet &);
 	public:
 		void set_atom_space(AtomSpace *);
 		void sweep_parse(const Handle&);

--- a/opencog/spatial/3DSpaceMap/EntityRecorder.h
+++ b/opencog/spatial/3DSpaceMap/EntityRecorder.h
@@ -40,7 +40,7 @@ namespace opencog
             // when calling removeNoneBlockEntity()
             BlockVector getLastAppearedLocation(const Handle& entityHandle) const;
             Handle getEntity(const BlockVector& pos) const;
-            const OrderedHandleSet& getAllAvatarList() const{return mAllAvatarList;};
+            const HandleSet& getAllAvatarList() const{return mAllAvatarList;};
 
             template<typename Out>
                 Out findAllEntities(Out out) const
@@ -66,8 +66,8 @@ namespace opencog
         private:
 
             Handle mSelfAgentEntity;
-            OrderedHandleSet mAllNoneBlockEntities;
-            OrderedHandleSet mAllAvatarList;
+            HandleSet mAllNoneBlockEntities;
+            HandleSet mAllAvatarList;
             multimap<BlockVector, Handle> mPosToNoneBlockEntityMap;
             //Note that even the entity isn't on the map, we still record it here
             map< Handle, vector< pair<unsigned long,BlockVector> > > mNoneBlockEntitieshistoryLocations;

--- a/opencog/visualization/tulip/TulipWriter.cc
+++ b/opencog/visualization/tulip/TulipWriter.cc
@@ -72,7 +72,7 @@ void TulipWriter::writeCluster(Handle setLink)
     a.get_handles_by_type(back_inserter(linkHandles), (Type) LINK, true );
 
     // Output setLink as a cluster
-    OrderedHandleSet inSet;
+    HandleSet inSet;
     if (setLink != Handle::UNDEFINED) {
         HandleSeq setLinks = setLink->getOutgoingSet();
         for (Handle h : setLinks) {
@@ -90,7 +90,7 @@ void TulipWriter::writeCluster(Handle setLink)
     myfile << "(cluster 2 \"Not in set\"" << endl;
     myfile << " (nodes ";
     for (Handle h : nodeHandles) {
-        OrderedHandleSet::iterator si = inSet.find(h);
+        HandleSet::iterator si = inSet.find(h);
         if (si == inSet.end()) myfile << h.value() << " ";
     }
     for (Handle h : linkHandles) {
@@ -101,7 +101,7 @@ void TulipWriter::writeCluster(Handle setLink)
     // TODO : also output the appropriate fake edges
 //    myfile << " (edges ";
 //    for (Handle h : linkHandles) {
-//        OrderedHandleSet::iterator si = inSet.find(h);
+//        HandleSet::iterator si = inSet.find(h);
 //        if (si == inSet.end()) {
 //            myfile << h << " ";
 //        }

--- a/tests/pln/rules/PLNRulesUTest.cxxtest
+++ b/tests/pln/rules/PLNRulesUTest.cxxtest
@@ -654,7 +654,7 @@ void PLNRulesUTest::test_closed_lambda_introduction()
 
 	// Rather than enumerating all possible constructions we just make
 	// sure the one that matters is in there.
-	std::set<Handle> sss;
+	HandleSet sss;
 	for (auto h : results->getOutgoingSet()) sss.insert(h);
 	TS_ASSERT(is_in(expected, sss));
 }


### PR DESCRIPTION
Addressing https://github.com/opencog/atomspace/issues/1287

Rename `OrderedHandleSet` to `HandleSet` that can be considered the default handle set container (smaller RAM usage and faster iteration, however `UnorderedHandleSet` has faster insertion).