### PR TITLE
Simplify and shorten the old dictionary reader code

### DIFF
--- a/opencog/nlp/lg-dict/LGDictEntry.cc
+++ b/opencog/nlp/lg-dict/LGDictEntry.cc
@@ -27,7 +27,6 @@
 #include "LGDictReader.h"
 
 using namespace opencog;
-using namespace opencog::nlp;
 
 /// The expected format of an LgDictEntry is:
 ///
@@ -110,8 +109,10 @@ Handle LGDictEntry::execute(AtomSpace* as) const
 			"LgDictEntry requires valid dictionary! %s was given.",
 			ldn->getName().c_str());
 
-	LGDictReader reader(dict, as);
-	reader.getDictEntry(_outgoing[0]->getName());
+	LGDictReader reader;
+	HandleSeq djs = reader.getDictEntry(dict, _outgoing[0]->getName());
+
+	for (const Handle& dj: djs) as->add_atom(dj);
 
 	return _outgoing[0];
 }

--- a/opencog/nlp/lg-dict/LGDictEntry.cc
+++ b/opencog/nlp/lg-dict/LGDictEntry.cc
@@ -109,9 +109,7 @@ Handle LGDictEntry::execute(AtomSpace* as) const
 			"LgDictEntry requires valid dictionary! %s was given.",
 			ldn->getName().c_str());
 
-	LGDictReader reader;
-	HandleSeq djs = reader.getDictEntry(dict, _outgoing[0]->getName());
-
+	HandleSeq djs = getDictEntry(dict, _outgoing[0]->getName());
 	for (const Handle& dj: djs) as->add_atom(dj);
 
 	return _outgoing[0];

--- a/opencog/nlp/lg-dict/LGDictExpContainer.cc
+++ b/opencog/nlp/lg-dict/LGDictExpContainer.cc
@@ -211,18 +211,24 @@ void LGDictExpContainer::basic_normal_order()
  */
 HandleSeq LGDictExpContainer::to_handle(AtomSpace *as, Handle hWordNode)
 {
+    static Handle multi = createNode(LG_CONN_MULTI_NODE, "@");
+    static Handle optnl = createLink(LG_CONNECTOR,
+                             createNode(LG_CONNECTOR_NODE, "0"));
+
     if (m_type == CONNECTOR_type)
     {
-        if (m_string == "OPTIONAL")
-            return { as->add_link(LG_CONNECTOR, as->add_node(LG_CONNECTOR_NODE, "0")) };
+        // XXX FIXME this does not smell right; optionals should get
+        // blown up into pairs of disjuncts, one with and one without.
+        if (m_string == "OPTIONAL") return optnl;
 
-        Handle connector = as->add_node(LG_CONNECTOR_NODE, m_string);
-        Handle direction = as->add_node(LG_CONN_DIR_NODE, std::string(1, m_direction));
+        Handle connector(createNode(LG_CONNECTOR_NODE, m_string));
+        Handle direction(createNode(LG_CONN_DIR_NODE,
+                          std::string(1, m_direction)));
 
         if (m_multi)
-            return { as->add_link(LG_CONNECTOR, connector, direction, as->add_node(LG_CONN_MULTI_NODE, "@")) };
+            return createLink(LG_CONNECTOR, connector, direction, multi);
         else
-            return { as->add_link(LG_CONNECTOR, connector, direction) };
+            return createLink(LG_CONNECTOR, connector, direction);
     }
 
     HandleSeq outgoing;
@@ -234,7 +240,7 @@ HandleSeq LGDictExpContainer::to_handle(AtomSpace *as, Handle hWordNode)
     }
 
     if (m_type == AND_type)
-        return { as->add_link(LG_AND, outgoing) };
+        return createLink(LG_AND, outgoing);
 
     // remove repeated atoms from OR
     if (m_type == OR_type)
@@ -244,7 +250,7 @@ HandleSeq LGDictExpContainer::to_handle(AtomSpace *as, Handle hWordNode)
 
         HandleSeq qDisjuncts;
         for (const Handle& h : outgoing)
-            qDisjuncts.push_back(as->add_link(LG_DISJUNCT, hWordNode, h));
+            qDisjuncts.push_back(createLink(LG_DISJUNCT, hWordNode, h));
 
         return qDisjuncts;
     }

--- a/opencog/nlp/lg-dict/LGDictExpContainer.cc
+++ b/opencog/nlp/lg-dict/LGDictExpContainer.cc
@@ -26,7 +26,6 @@
 #include <opencog/nlp/types/atom_types.h>
 #include "LGDictExpContainer.h"
 
-using namespace opencog::nlp;
 using namespace opencog;
 
 /**

--- a/opencog/nlp/lg-dict/LGDictExpContainer.cc
+++ b/opencog/nlp/lg-dict/LGDictExpContainer.cc
@@ -208,7 +208,7 @@ void LGDictExpContainer::basic_normal_order()
  * @param as   pointer to the AtomSpace
  * @return     handle to the atom
  */
-HandleSeq LGDictExpContainer::to_handle(AtomSpace *as, Handle hWordNode)
+HandleSeq LGDictExpContainer::to_handle(const Handle& hWordNode)
 {
     static Handle multi(createNode(LG_CONN_MULTI_NODE, "@"));
     static Handle optnl(createLink(LG_CONNECTOR,
@@ -234,7 +234,7 @@ HandleSeq LGDictExpContainer::to_handle(AtomSpace *as, Handle hWordNode)
 
     for (auto& exp: m_subexps)
     {
-        HandleSeq q = exp.to_handle(as, hWordNode);
+        HandleSeq q = exp.to_handle(hWordNode);
         outgoing.insert(outgoing.end(), q.begin(), q.end());
     }
 

--- a/opencog/nlp/lg-dict/LGDictExpContainer.h
+++ b/opencog/nlp/lg-dict/LGDictExpContainer.h
@@ -45,7 +45,7 @@ public:
     LGDictExpContainer(Exp_type, Exp* exp);
     LGDictExpContainer(Exp_type, std::vector<LGDictExpContainer>);
 
-    HandleSeq to_handle(AtomSpace* as, Handle h);
+    HandleSeq to_handle(const Handle& h);
 
 private:
     void basic_flatten();

--- a/opencog/nlp/lg-dict/LGDictExpContainer.h
+++ b/opencog/nlp/lg-dict/LGDictExpContainer.h
@@ -31,8 +31,6 @@
 
 namespace opencog
 {
-namespace nlp
-{
 
 /**
  * Link Grammar expression container.
@@ -61,6 +59,6 @@ private:
     std::vector<LGDictExpContainer> m_subexps;
 };
 
-}}
+}
 
 #endif // _OPENCOG_LG_DICT_EXP_H

--- a/opencog/nlp/lg-dict/LGDictReader.cc
+++ b/opencog/nlp/lg-dict/LGDictReader.cc
@@ -23,24 +23,12 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/nlp/types/atom_types.h>
 #include <opencog/atoms/base/Link.h>
-
+#include <opencog/atoms/base/Node.h>
+#include <opencog/nlp/types/atom_types.h>
 #include "LGDictReader.h"
 
-using namespace opencog::nlp;
 using namespace opencog;
-
-/**
- * Constructor of the LGDictReader class.
- *
- * @param pDict   the Dictionary to read from
- * @param pAS     the AtomSpace where atoms will be created
- */
-LGDictReader::LGDictReader(Dictionary pDict, AtomSpace* pAS)
-    : _dictionary(pDict), _as(pAS)
-{
-}
 
 /**
  * Method to construct LG dictionary atom.
@@ -69,7 +57,8 @@ LGDictReader::LGDictReader(Dictionary pDict, AtomSpace* pAS)
  * @param word   the input word string
  * @return       the handle to the newly created atom
  */
-HandleSeq LGDictReader::getDictEntry(const std::string& word)
+HandleSeq LGDictReader::getDictEntry(Dictionary _dictionary,
+                                     const std::string& word)
 {
     // See if we know about this word, or not.
     Dict_node* dn_head = dictionary_lookup_list(_dictionary, word.c_str());

--- a/opencog/nlp/lg-dict/LGDictReader.cc
+++ b/opencog/nlp/lg-dict/LGDictReader.cc
@@ -31,67 +31,12 @@
 using namespace opencog;
 
 /**
- * Method to construct LG dictionary atom.
- *
- * Given a word string, construct the corresponding atom representing
- * the Link Grammar's dictionary entry.
- *
- * The returned expression is in the form of an opencog-style
- * prefix-notation boolean expression.  Note that it is not in any
- * particular kind of normal form.  In particular, some AND nodes
- * may have only one child: these can be removed.
- *
- * Note that the order of the connectors is important: while linking,
- * these must be satisfied in left-to-right, nested order.
- *
- * Optional clauses are indicated by OR-ing with null, where "null"
- * is a CONNECTOR Node with string-value "0".  Optional clauses are
- * not necessarily in any sort of normal form; the null connector can
- * appear anywhere.
-*
-* XXX FIXME -- this gives incorrect results if the word has non-trivial
-* morphology e.g. if its Russian, and can be split into a stem and a
-* suffix.  The problem is that in LG, both stem and suffix count as
-* distinct words, and so word splitting must be done first.
- *
- * @param word   the input word string
- * @return       the handle to the newly created atom
- */
-HandleSeq LGDictReader::getDictEntry(Dictionary _dictionary,
-                                     const std::string& word)
-{
-    // See if we know about this word, or not.
-    Dict_node* dn_head = dictionary_lookup_list(_dictionary, word.c_str());
-
-    HandleSeq outgoing;
-
-// XXX FIXME -- if dn_head is null, then we should check regexes.
-// Currently, LG does not do this automatically, but it almost surely
-// should. i.e. the LG public API needs to also handle regexes
-// automatically.
-    if (!dn_head) return outgoing;
-
-    Handle hWord(createNode(WORD_NODE, word));
-
-    for (Dict_node* dn = dn_head; dn; dn = dn->right)
-    {
-        Exp* exp = dn->exp;
-        HandleSeq qLG = lg_exp_to_container(exp).to_handle(hWord);
-
-        outgoing.insert(outgoing.end(), qLG.begin(), qLG.end());
-    }
-
-    free_lookup_list(_dictionary, dn_head);
-    return outgoing;
-}
-
-/**
- * Helper method for storing LG expression trees in custom container.
+ * Helper function for storing LG expression trees in custom container.
  *
  * @param exp   the input expression trees
  * @return      the flatten container
  */
-LGDictExpContainer LGDictReader::lg_exp_to_container(Exp* exp)
+static LGDictExpContainer lg_exp_to_container(Exp* exp)
 {
     if (CONNECTOR_type == exp->type)
         return LGDictExpContainer(CONNECTOR_type, exp);
@@ -125,4 +70,59 @@ LGDictExpContainer LGDictReader::lg_exp_to_container(Exp* exp)
         subcontainers.push_back(lg_exp_to_container(el->e));
 
     return LGDictExpContainer(exp->type, subcontainers);
+}
+
+/**
+ * Function to return LG dictionary entries.
+ *
+ * Given a word string, construct the corresponding atom representing
+ * the Link Grammar's dictionary entry.
+ *
+ * The returned expression is in the form of an opencog-style
+ * prefix-notation boolean expression.  Note that it is not in any
+ * particular kind of normal form.  In particular, some AND nodes
+ * may have only one child: these can be removed.
+ *
+ * Note that the order of the connectors is important: while linking,
+ * these must be satisfied in left-to-right, nested order.
+ *
+ * Optional clauses are indicated by OR-ing with null, where "null"
+ * is a CONNECTOR Node with string-value "0".  Optional clauses are
+ * not necessarily in any sort of normal form; the null connector can
+ * appear anywhere.
+*
+* XXX FIXME -- this gives incorrect results if the word has non-trivial
+* morphology e.g. if its Russian, and can be split into a stem and a
+* suffix.  The problem is that in LG, both stem and suffix count as
+* distinct words, and so word splitting must be done first.
+ *
+ * @param word   the input word string
+ * @return       the handle to the newly created atom
+ */
+HandleSeq getDictEntry(Dictionary _dictionary,
+                       const std::string& word)
+{
+    // See if we know about this word, or not.
+    Dict_node* dn_head = dictionary_lookup_list(_dictionary, word.c_str());
+
+    HandleSeq outgoing;
+
+// XXX FIXME -- if dn_head is null, then we should check regexes.
+// Currently, LG does not do this automatically, but it almost surely
+// should. i.e. the LG public API needs to also handle regexes
+// automatically.
+    if (!dn_head) return outgoing;
+
+    Handle hWord(createNode(WORD_NODE, word));
+
+    for (Dict_node* dn = dn_head; dn; dn = dn->right)
+    {
+        Exp* exp = dn->exp;
+        HandleSeq qLG = lg_exp_to_container(exp).to_handle(hWord);
+
+        outgoing.insert(outgoing.end(), qLG.begin(), qLG.end());
+    }
+
+    free_lookup_list(_dictionary, dn_head);
+    return outgoing;
 }

--- a/opencog/nlp/lg-dict/LGDictReader.cc
+++ b/opencog/nlp/lg-dict/LGDictReader.cc
@@ -43,13 +43,6 @@ LGDictReader::LGDictReader(Dictionary pDict, AtomSpace* pAS)
 }
 
 /**
- * Destructor of the LGDictReader class.
- */
-LGDictReader::~LGDictReader()
-{
-}
-
-/**
  * Method to construct LG dictionary atom.
  *
  * Given a word string, construct the corresponding atom representing

--- a/opencog/nlp/lg-dict/LGDictReader.cc
+++ b/opencog/nlp/lg-dict/LGDictReader.cc
@@ -82,12 +82,12 @@ HandleSeq LGDictReader::getDictEntry(const std::string& word)
 // automatically.
     if (!dn_head) return outgoing;
 
-    Handle hWord = _as->add_node(WORD_NODE, word);
+    Handle hWord(createNode(WORD_NODE, word));
 
     for (Dict_node* dn = dn_head; dn; dn = dn->right)
     {
         Exp* exp = dn->exp;
-        HandleSeq qLG = lg_exp_to_container(exp).to_handle(_as, hWord);
+        HandleSeq qLG = lg_exp_to_container(exp).to_handle(hWord);
 
         outgoing.insert(outgoing.end(), qLG.begin(), qLG.end());
     }

--- a/opencog/nlp/lg-dict/LGDictReader.cc
+++ b/opencog/nlp/lg-dict/LGDictReader.cc
@@ -99,8 +99,8 @@ static LGDictExpContainer lg_exp_to_container(Exp* exp)
  * @param word   the input word string
  * @return       the handle to the newly created atom
  */
-HandleSeq getDictEntry(Dictionary _dictionary,
-                       const std::string& word)
+HandleSeq opencog::getDictEntry(Dictionary _dictionary,
+                                const std::string& word)
 {
     // See if we know about this word, or not.
     Dict_node* dn_head = dictionary_lookup_list(_dictionary, word.c_str());

--- a/opencog/nlp/lg-dict/LGDictReader.h
+++ b/opencog/nlp/lg-dict/LGDictReader.h
@@ -25,14 +25,9 @@
 #define _OPENCOG_LG_DICT_READER_H
 
 #include <link-grammar/dict-api.h>
-
-#include <opencog/atomspace/AtomSpace.h>
-
 #include "LGDictExpContainer.h"
 
 namespace opencog
-{
-namespace nlp
 {
 
 /**
@@ -44,17 +39,12 @@ namespace nlp
 class LGDictReader
 {
 public:
-    LGDictReader(Dictionary, AtomSpace*);
-    HandleSeq getDictEntry(const std::string& word);
+    HandleSeq getDictEntry(Dictionary, const std::string& word);
 
 private:
     LGDictExpContainer lg_exp_to_container(Exp*);
-
-    Dictionary _dictionary;
-    AtomSpace* _as;
 };
 
-}
 }
 
 #endif // _OPENCOG_LG_DICT_READER_H

--- a/opencog/nlp/lg-dict/LGDictReader.h
+++ b/opencog/nlp/lg-dict/LGDictReader.h
@@ -31,19 +31,11 @@ namespace opencog
 {
 
 /**
- * Link Grammar dictionary reader.
+ * Link Grammar dictionary entry reader.
  *
- * A helper class for reading the LG dictionary's entry for a specific
- * word, and for creating the corresponding atom.
+ * Return a list of Link Grammar disjuncts for the word.
  */
-class LGDictReader
-{
-public:
-    HandleSeq getDictEntry(Dictionary, const std::string& word);
-
-private:
-    LGDictExpContainer lg_exp_to_container(Exp*);
-};
+HandleSeq getDictEntry(Dictionary, const std::string& word);
 
 }
 

--- a/opencog/nlp/lg-dict/LGDictReader.h
+++ b/opencog/nlp/lg-dict/LGDictReader.h
@@ -45,8 +45,6 @@ class LGDictReader
 {
 public:
     LGDictReader(Dictionary, AtomSpace*);
-    ~LGDictReader();
-
     HandleSeq getDictEntry(const std::string& word);
 
 private:

--- a/opencog/nlp/lg-dict/README.md
+++ b/opencog/nlp/lg-dict/README.md
@@ -105,13 +105,6 @@ some pretty important.
   `lg-get-dict-entry` could be redesigned to return a LinkValue,
   instead?
 
-* Many of the utilities take an explicit AtomSpace argument, and poke
-  atoms into the atomspace. This is not really needed; they could more
-  easily just return assorted atoms to the user, who could then perform
-  a single bulk insert into whatever atomspace they need/desire. This
-  would result in faster, more efficient code, since bulk inserts are
-  faster than piecemeal inserts.
-
 * The `lg-get-dict-entry` and `lg-dict-entry` methods fail to perform
   regex lookup of the word. Properly, this is a bug in the link-grammar
   API for word lookup; regexes should have been handled automatically.


### PR DESCRIPTION
The dictionary reader code seemed to be old and crufty. Make it smaller, simpler.