### PR TITLE
Bug-fix the new Link Grammar interfaces.

### DIFF
--- a/opencog/nlp/learn/README
+++ b/opencog/nlp/learn/README
@@ -483,13 +483,15 @@ you can start exploring.
 ```
   (use-modules (opencog) (opencog persist) (opencog persist-sql))
   (use-modules (opencog nlp) (opencog nlp learn))
+  (use-modules (opencog matrix))
   (sql-open "postgres:///en_pairs_sim?user=linas")
   (fetch-all-words)
   (length (get-all-words))
   ; This reports 396262 for one my DB's has.
 
   (define pca (make-pseudo-cset-api))
-  (pca 'fetch-pairs)
+  (define psa (add-pair-stars pca))
+  (psa 'fetch-pairs)
   (define all-cset-words (get-all-cset-words))
   (length all-cset-words)
   ; This reports 37413 in for my `en_pairs_sim`.
@@ -516,6 +518,15 @@ you can start exploring.
   The `lang-learn-diary/disjunct-stats.scm` file contains ad-hoc code
   used to prepare the summary report.  To use it, just cut-n-paste to
   the guile prompt, to get it to do things.
+
+  The marginal entropies and the mutual information between words and
+  disjuncts can be computed in the same way that it's done for
+  word-pairs:
+```
+  (define pca (make-pseudo-cset-api))
+  (define psa (add-pair-stars pca))
+  (batch-pairs psa)
+```
 
 
 Precomputed LXC containers
@@ -596,9 +607,6 @@ TODO List
 =========
 * Count single-word probabilities.
 * Resume work on morphology.
-* Create an LXC container for public use. DONE.
-  But not updated....
-* Prune low observation counts.
 * Implement sql-delete.
 
 DONE
@@ -633,6 +641,10 @@ DONE
 * Fix (WordNode "…!ANY-PUNCT") Done.
 * Rework pipeline to use literary English sources. DONE.
   New scripts in the `download` directory.
+* Prune low observation counts. Well, no that is a bad idea.
+  However, the (opencog matrix) code now includes data filters.
+* Create an LXC container for public use. DONE.
+  But not updated.... Well no one is interested in thsi so punt.
 
 
 Some typical entropies for word-pairs

--- a/opencog/nlp/learn/README
+++ b/opencog/nlp/learn/README
@@ -352,14 +352,18 @@ functions defined in `(opencog nlp learn)`.
 
 ```
 	(use-modules (opencog) (opencog persist) (opencog persist-sql))
+	(use-modules (opencog matrix))
 	(use-modules (opencog nlp) (opencog nlp learn))
 	(sql-open "postgres:///en_pairs?user=ubuntu&password=asdf")
-	(batch-all-pairs)
+	(define ala (make-any-link-api))
+	(define asa (add-pair-stars ala))
+	(batch-pairs asa)
+	(print-matrix-summary-report asa)
 ```
 
-If tracing is turned on, a trace file is written to `/tmp/progress`.
 Batch-counting might take hours or longer, depending on your dataset
-size.
+size. The batching routine will print to stdout, giving a hint of
+the rate of progress.
 
 Example stats and performance:
 current fr_pairs db has 16785 words and 177960 pairs.

--- a/opencog/nlp/learn/notes
+++ b/opencog/nlp/learn/notes
@@ -13228,7 +13228,34 @@ wtf:
  fatal flex scanner internal error--end of buffer missed
 en_pairs_rfive_mi
 
-Need lock.
+Need lock. DONE.
+--------------
+
+also -- dump the all-atoms thing!!!!
+
+line 460 of compute-mi.scm do-one-pair
+(right-loop
+(WordNode "fields" 
+
+(define psf (add-pair-freq-api psa))
+(define (dop lipr)
+	(format #t "yo ~A" lipr )
+	(format #t "has ~A\n" (psf 'pair-freq lipr))
+)
+(for-each dop rs)
+
+(Section
+   (WordNode "fields")
+   (ConnectorSeq
+      (Connector (WordNode "the" ) (ConnectorDir "-"))
+      (Connector (WordNode "broad" ) (ConnectorDir "-"))
+      (Connector (WordNode "rice" ) (ConnectorDir "+"))
+      (Connector (WordNode "passes" ) (ConnectorDir "+"))
+      (Connector (WordNode "." ) (ConnectorDir "+"))
+   )
+)
+
+(psf 'set-pair-freq fa  1.285376022487705e-8)
 
 
 =========================================================================
@@ -13262,10 +13289,10 @@ Bugs: while mst parsing, guile goes GC-crazy after a while, and
 
 Items: create LG feederbacker
 
-Bugs; get rid of [!] in words
+Bugs; get rid of [!] in words DONE
 
 Bugs: cleanup zen due to above
 Bugs: clean up zh due to above
 Bugs: cleanup embedded daashes in en 
 
-Bugs
+Bugs: get rid of all-atoms in matrix

--- a/opencog/nlp/learn/notes
+++ b/opencog/nlp/learn/notes
@@ -7052,6 +7052,35 @@ c4df6f2da0c476a561cbea82981a6853  zen_pairs_mst.sql
 ff7cb1628cb7aad0a59c71b98a626121  zen_pairs_mst.sql.bz2
 
 ==================================================================
+zen_pairs_three
+---------------
+Mandarin word-pairs. Segmentation into words done by Ruiting. Does
+NOT include pair-MI stats. This is the alpha-segmented-1 texts plus
+100 texts from alpha-segmented-2 (aka alpha-segmented-2-part1)
+
+STATUS: good
+DATE: 13 August 2017
+REASON: No known defects.
+
+                        List of relations
+ Schema |    Name    | Type  | Owner  |    Size    | Description 
+--------+------------+-------+--------+------------+-------------
+ public | atoms      | table | ubuntu | 2623 MB    | 
+ public | spaces     | table | ubuntu | 40 kB      | 
+ public | typecodes  | table | ubuntu | 56 kB      | 
+ public | valuations | table | ubuntu | 2221 MB    | 
+ public | values     | table | ubuntu | 8192 bytes | 
+
+select count(*) from atoms;      -- 29749942 == 29.7M atoms
+select count(*) from valuations; -- 18890832 == 18.9M valuations
+
+1735058352 bytes uncompressed = 1.7GB
+ 290672147 bytes compresed = 291MB
+
+71f266f7b85661f36f73fbf0d63e2699  zen_pairs_three.sql
+76e4bdce961b0bc760ad33329fee65e5  zen_pairs_three.sql.bz2
+
+==================================================================
 ==================================================================
 ==================================================================
 ==================================================================
@@ -13067,6 +13096,19 @@ update-lg-link-counts -- just needs the Evals for links
 No one needs the link instances.  DONE
 
 remove use-relex-server DONE
+-----------
+Bugs: the mst parse algo is O^5 and yuret gives a nice O^3 also
+False. Curtis was mistaken when he said this. DONE.
+
+--------
+/dev/md127 on /data 
+/dev/md127 on /home2/linas/lxc-local-containers/learn-en/rootfs/var/lib/postgres
+fstab!!!
+
+cd /home2/linas/lxc-local-containers/learn-zh
+cp -pr --parents rootfs/var/lib/postgresql /data/lxc-databases/learn-zh/
+
+
 =========================================================================
 
 
@@ -13078,8 +13120,6 @@ multi-connectors only ... with the incorrect mutiplicities.
 ??? Is this still an issue? 
 
 Bugs: using ListLink for the partial sums on csets... why???
-
-Bugs: the mst parse algo is O^5 and yuret gives a nice O^3 also
 
 Bugs: graphing takes too long.
 

--- a/opencog/nlp/learn/notes
+++ b/opencog/nlp/learn/notes
@@ -13228,9 +13228,11 @@ wtf:
  fatal flex scanner internal error--end of buffer missed
 en_pairs_rfive_mi
 
+Need lock.
+
 
 =========================================================================
-very good:
+OK-ish misses the mark:
 arxiv 1703.08314v1 coecke Interacting conceptual spaces
 
 
@@ -13259,3 +13261,11 @@ Bugs: while mst parsing, guile goes GC-crazy after a while, and
       never recovers.
 
 Items: create LG feederbacker
+
+Bugs; get rid of [!] in words
+
+Bugs: cleanup zen due to above
+Bugs: clean up zh due to above
+Bugs: cleanup embedded daashes in en 
+
+Bugs

--- a/opencog/nlp/learn/notes
+++ b/opencog/nlp/learn/notes
@@ -7081,6 +7081,43 @@ select count(*) from valuations; -- 18890832 == 18.9M valuations
 76e4bdce961b0bc760ad33329fee65e5  zen_pairs_three.sql.bz2
 
 ==================================================================
+zen_pairs_three_mi
+------------------
+Mandarin word-pairs. Segmentation into words done by Ruiting. 
+Contains the MI stats. See above for description.
+
+STATUS: good
+DATE: 13 August 2017
+REASON: No known defects.
+
+Summary Report for Correlation Matrix Link Grammar ANY link Word Pairs
+Left type: WordNode    Right Type: WordNode    Pair Type: ListLink
+
+Rows: 350889 Columns: 351293
+Size: 14579049 non-zero entries of 123264849477 possible
+Fraction non-zero: 1.1827E-4 Sparsity (-log_2): 13.046
+Total observations: 632143240.0  Avg obs per pair: 43.360
+Entropy Total: 19.346   Left: 11.460   Right: 11.252
+Total MI: 3.3656
+
+                 Left         Right     Avg-left     Avg-right
+                 ----         -----     --------     ---------
+Support (l_0)  2.8811E+4    2.7144E+4
+Count   (l_1)  6.8919E+6    5.5041E+6     239.2        202.8    
+Length  (l_2)  6.5943E+5    5.3804E+5     22.89        19.82    
+RMS Count      6.5889E+5    5.3761E+5     22.87        19.81    
+
+
+select count(*) from atoms;      -- 30913774 == 31M
+select count(*) from valuations; -- 47599360 == 47.6M
+
+4094403983 bytes uncompressed = 4.1GB
+ 706360370 bytes compressed   = 706 MB
+
+6991e8464e54492642881e005efb1de4  zen_pairs_three_mi.sql
+9f7a097611c2e0196e626038a26869ba  zen_pairs_three_mi.sql.bz2
+
+==================================================================
 ==================================================================
 ==================================================================
 ==================================================================
@@ -13108,6 +13145,16 @@ fstab!!!
 cd /home2/linas/lxc-local-containers/learn-zh
 cp -pr --parents rootfs/var/lib/postgresql /data/lxc-databases/learn-zh/
 
+
+=========================================================================
+very good:
+arxiv 1703.08314v1 coecke Interacting conceptual spaces
+
+
+crappier:
+Symbolic, Distributed and Distributional Representations for Natural
+Language Processing in the Era of Deep Learning: a Survey
+arxiv  1702.00764v1
 
 =========================================================================
 

--- a/opencog/nlp/learn/notes
+++ b/opencog/nlp/learn/notes
@@ -6817,7 +6817,7 @@ de95af1f2ddb7c696b19a4cc3a3e443e  en_pairs_rfive_mtwo.sql.bz2
 
 ==================================================================
 en_pairs_rfive_mthree
--------------------
+---------------------
 Random-planar-tree parsed books from tranche-1, 2, 3, 4 and 5. 
 MST-parsed tranche-1, 2 and 3. Contains pair-MI values; does NOT
 contain any disjunct marginals.
@@ -6873,6 +6873,35 @@ select count(*) from valuations; -- 123419676 = 123M =  7M more
 
 eff6127b82ab205502bc1f9e8b4e139d  en_pairs_rfive_mfour.sql
 763ffc8bf032127501692a5ee61538ec  en_pairs_rfive_mfour.sql.bz2
+
+==================================================================
+en_pairs_rfive_mfive
+--------------------
+Random-planar-tree parsed books from tranche-1, 2, 3, 4 and 5. 
+MST-parsed tranche-1, 2, 3, 4 and 5. Contains pair-MI values; does NOT
+contain any disjunct marginals.
+
+STATUS: good
+DATE: 14 August 2017
+REASON: Best so far, I think.  Same issues as en_pairs_rfive_mone
+
+                        List of relations
+ Schema |    Name    | Type  | Owner  |    Size    | Description 
+--------+------------+-------+--------+------------+-------------
+ public | atoms      | table | ubuntu | 11 GB      | 
+ public | spaces     | table | ubuntu | 40 kB      | 
+ public | typecodes  | table | ubuntu | 56 kB      | 
+ public | valuations | table | ubuntu | 13 GB      | 
+ public | values     | table | ubuntu | 8192 bytes | 
+
+select count(*) from atoms;      -- 124866072 = 125M = 19M more
+select count(*) from valuations; -- 133848790 = 134M = 11M more
+
+12210323166 bytes uncompressed = 12.2GBytes
+ 2104485691 byttes compressed  = 2.10 GBytes
+
+988be345ccaffc9312db6446693a3625  en_pairs_rfive_mfive.sql
+1bd09cb8c014ec2c8e33ee7d101f4357  en_pairs_rfive_mfive.sql.bz2
 
 ==================================================================
 zh_pairs_one
@@ -13144,6 +13173,10 @@ fstab!!!
 
 cd /home2/linas/lxc-local-containers/learn-zh
 cp -pr --parents rootfs/var/lib/postgresql /data/lxc-databases/learn-zh/
+
+wtf:
+ fatal flex scanner internal error--end of buffer missed
+en_pairs_rfive_mi
 
 
 =========================================================================

--- a/opencog/nlp/learn/notes
+++ b/opencog/nlp/learn/notes
@@ -7147,6 +7147,56 @@ select count(*) from valuations; -- 47599360 == 47.6M
 9f7a097611c2e0196e626038a26869ba  zen_pairs_three_mi.sql.bz2
 
 ==================================================================
+zen_pairs_three_mst
+-------------------
+Mandarin word-pairs. Segmentation into words done by Ruiting.
+This is the alpha-segmented-1 texts plus 100 texts from
+alpha-segmented-2 (aka alpha-segmented-2-part1). MST parsed,
+and include disjunct MI's and marginals.
+
+STATUS: good
+DATE: 15 August 2017
+REASON: No known defects.
+
+                        List of relations
+ Schema |    Name    | Type  | Owner  |    Size    | Description 
+--------+------------+-------+--------+------------+-------------
+ public | atoms      | table | ubuntu | 4300 MB    | 
+ public | spaces     | table | ubuntu | 40 kB      | 
+ public | typecodes  | table | ubuntu | 56 kB      | 
+ public | valuations | table | ubuntu | 9589 MB    | 
+ public | values     | table | ubuntu | 8192 bytes | 
+
+Summary Report for Correlation Matrix Word-Disjunct Pairs (Connector Sets)
+Left type: WordNode    Right Type: ConnectorSeq    Pair Type: Section
+Wildcard: (ListLink (ctv 0 0 17846845)
+   (AnyNode "cset-word")
+   (AnyNode "cset-disjunct")
+)
+Rows: 84656 Columns: 4889243
+Size: 7015959 non-zero entries of 413903755408 possible
+Fraction non-zero: 1.6951E-5 Sparsity (-log_2): 15.848
+Total observations: 17846845.0  Avg obs per pair: 2.5437
+Entropy Total: 20.476   Left: 17.060   Right: 9.5156
+Total MI: 6.0994
+
+                 Left         Right     Avg-left     Avg-right
+                 ----         -----     --------     ---------
+Support (l_0)  1.0066E+5    3158.    
+Count   (l_1)  3.4329E+5    4.6825E+4     3.410        14.83    
+Length  (l_2)  2.2804E+4    8751.         .2265        2.771    
+RMS Count      2.2762E+4    8671.         .2261        2.745    
+
+select count(*) from atoms;      -- 47962056 == 47.9M
+select count(*) from valuations; -- 93516734 == 93.5M
+
+7648907200 bytes uncompressed == 7.65GBytes
+1077724617 bytes compressed   == 1.08 GBytes
+
+2d23fd42209ac9c3fdf7c7d599262069  zen_pairs_three_mst.sql
+31543876d6b836f9d6a53e9cd0a75a25  zen_pairs_three_mst.sql.bz2
+
+==================================================================
 ==================================================================
 ==================================================================
 ==================================================================

--- a/opencog/nlp/learn/scm/batch-word-pair.scm
+++ b/opencog/nlp/learn/scm/batch-word-pair.scm
@@ -474,6 +474,7 @@
 	(display "Finished loading sparse matrix pairs\n")
 
 	(batch-all-pair-mi LLOBJ)
+	(print-matrix-summary-report LLOBJ)
 )
 
 (define-public (batch-any-pairs)

--- a/opencog/nlp/learn/scm/mst-parser.scm
+++ b/opencog/nlp/learn/scm/mst-parser.scm
@@ -211,8 +211,15 @@
 
 	(define scorer (make-score-fn mi-source 'pair-fmi))
 
+	; Assign a bad cost to links that are too long --
+	; longer than 16. This is a sharp cutoff.
+	; This causes parser to run at O(N^3) for LEN < 16 and
+	; a faster rate, O(N^2.3) for 16<LEN. This should help.
+	(define (trunc-scorer LW RW LEN)
+		(if (< 16 LEN) -2e25 (scorer LW RW LEN)))
+
 	; Process the list of words.
-	(mst-parse-atom-seq word-list scorer)
+	(mst-parse-atom-seq word-list trunc-scorer)
 )
 
 ; ---------------------------------------------------------------------

--- a/opencog/nlp/lg-dict/LGDictNode.cc
+++ b/opencog/nlp/lg-dict/LGDictNode.cc
@@ -20,6 +20,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <mutex>
+
 #include <link-grammar/link-includes.h>
 #include <opencog/util/Logger.h>
 #include <opencog/nlp/types/atom_types.h>
@@ -79,6 +81,14 @@ Dictionary LgDictNode::get_dictionary()
 
 	lg_error_set_handler(error_handler, nullptr);
 	const char * lang = getName().c_str();
+
+	// Link grammar dictionary creation is NOT thread-safe.
+	static std::mutex _global_mtx;
+	std::lock_guard<std::mutex> lck(_global_mtx);
+
+	// Check again, this time under the lock.
+	if (_dict) return _dict;
+
 	_dict = dictionary_create_lang(lang);
 	return _dict;
 }

--- a/opencog/nlp/lg-parse/LGParseLink.cc
+++ b/opencog/nlp/lg-parse/LGParseLink.cc
@@ -162,7 +162,8 @@ Handle LGParseLink::execute(AtomSpace* as) const
 			ldn->getName().c_str());
 
 	// Set up the sentence
-	Sentence sent = sentence_create(_outgoing[0]->getName().c_str(), dict);
+	const char* phrstr = _outgoing[0]->getName().c_str() ;
+	Sentence sent = sentence_create(phrstr, dict);
 	if (nullptr == sent) return Handle();
 
 	// Work with the default parse options (mostly).
@@ -219,7 +220,7 @@ Handle LGParseLink::execute(AtomSpace* as) const
 	for (int i=0; i<num_linkages; i++)
 	{
 		Linkage lkg = linkage_create(i, sent, opts);
-		Handle pnode = cvt_linkage(lkg, i, sentstr, minimal, as);
+		Handle pnode = cvt_linkage(lkg, i, sentstr, phrstr, minimal, as);
 		as->add_link(PARSE_LINK, pnode, snode);
 		linkage_delete(lkg);
 	}
@@ -234,6 +235,7 @@ Handle LGParseLink::execute(AtomSpace* as) const
 static std::atomic<unsigned long> wcnt;
 
 Handle LGParseLink::cvt_linkage(Linkage lkg, int i, const char* idstr,
+                                const char* phrstr,
                                 bool minimal, AtomSpace* as) const
 {
 	char parseid[80];
@@ -245,7 +247,21 @@ Handle LGParseLink::cvt_linkage(Linkage lkg, int i, const char* idstr,
 	int nwords = linkage_get_num_words(lkg);
 	for (int w=0; w<nwords; w++)
 	{
-		const char* wrd = linkage_get_word(lkg, w);
+		size_t sb = linkage_get_word_byte_start(lkg, w);
+		size_t eb = linkage_get_word_byte_end(lkg, w);
+
+		// Problem: the default LG API supplies the word together with
+		// the subscript, and with word regex and guess-marks. We really
+		// do NOT want that crud. So use the byte offsets to get the
+		// actual original string.  Since LEFT-WALL and RIGHT-WALL have
+		// no offsets, we need to handle those differently.
+		// strndupa allocates on stack, no need to free.
+		const char* wrd;
+		if (eb == sb)
+			wrd = linkage_get_word(lkg, w);
+		else
+			wrd = strndupa(phrstr + sb, eb-sb+1);
+
 		char buff[801] = "";
 		strncat(buff, wrd, 800);
 		strncat(buff, "@", 800);

--- a/opencog/nlp/lg-parse/LGParseLink.h
+++ b/opencog/nlp/lg-parse/LGParseLink.h
@@ -48,8 +48,8 @@ class LGParseLink : public FunctionLink
 {
 protected:
 	void init();
-	Handle cvt_linkage(Linkage, int, const char*, bool,
-	                   AtomSpace*) const;
+	Handle cvt_linkage(Linkage, int, const char*, const char*,
+	                   bool, AtomSpace*) const;
 
 public:
 	LGParseLink(const HandleSeq&, Type=LG_PARSE_LINK);


### PR DESCRIPTION
The brand new API unintentionally used the subscripted words, instead of the raw word strings. Fix this. 