### PR TITLE
Cause test_psi_related_goals_1 to segfault

### DIFF
--- a/tests/openpsi/OpenPsiUTest.cxxtest
+++ b/tests/openpsi/OpenPsiUTest.cxxtest
@@ -84,8 +84,7 @@ public:
         // core part of the other functions, that are tested, most tests fail
         // as a result. That is why main.scm is loaded here instead of running
         // (use-modules (opencog openpsi)).
-        _scm->eval("(load \"" PROJECT_SOURCE_DIR
-                   "/opencog/openpsi/main.scm\")");
+        _scm->eval("(use-modules (opencog openpsi))");
         CHKERR
         _scm->eval("(load \"" OPENPSI_TEST_PATH "/rules.scm\")");
         CHKERR


### PR DESCRIPTION
Running the test in guile shell works

The stack trace
```shell
(gdb) r
Starting program: /opencog/build/tests/openpsi/OpenPsiUTest 
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
[New Thread 0x7ffff13b7700 (LWP 31478)]
Running cxxtest tests (10 tests)[New Thread 0x7ffff0bb6700 (LWP 31479)]
[New Thread 0x7fffeaa82700 (LWP 31480)]
[2017-09-28 03:17:24:400] [INFO] BEGIN TEST: test_psi_satisfiable_and_satisfiable__predicate
[2017-09-28 03:17:24:402] [INFO] END TEST: test_psi_satisfiable_and_satisfiable__predicate
.[2017-09-28 03:17:24:409] [INFO] BEGIN TEST: test_psi_select_rules_per_demand
[2017-09-28 03:17:24:413] [INFO] END TEST: test_psi_select_rules_per_demand
.[2017-09-28 03:17:24:419] [INFO] BEGIN TEST: test_psi_related_goals

Program received signal SIGSEGV, Segmentation fault.
opencog::Atom::operator==(opencog::ProtoAtom const&) const [clone .local.498] (this=0x94a888, other=...)
    at /atomspace/opencog/atoms/base/Atom.h:398
398             if (_type != other.getType()) return false;
(gdb) bt
#0  opencog::Atom::operator==(opencog::ProtoAtom const&) const [clone .local.498] (this=0x94a888, other=...)
    at /atomspace/opencog/atoms/base/Atom.h:398
#1  0x00007ffff75396d2 in opencog::SchemeSmob::equalp_misc(scm_unused_struct*, scm_unused_struct*) (a=<optimized out>, 
    b=<optimized out>) at /atomspace/opencog/guile/SchemeSmob.cc:158
#2  0x00007ffff533ad84 in ?? () from /usr/lib/libguile-2.0.so.22
#3  0x00007ffff52b2747 in scm_call_1 () from /usr/lib/libguile-2.0.so.22
#4  0x00007ffff52d3af1 in scm_filter () from /usr/lib/libguile-2.0.so.22
#5  0x00007ffff533ac00 in ?? () from /usr/lib/libguile-2.0.so.22
#6  0x00007ffff52b2747 in scm_call_1 () from /usr/lib/libguile-2.0.so.22
#7  0x00007ffff52d3af1 in scm_filter () from /usr/lib/libguile-2.0.so.22
#8  0x00007ffff533ac00 in ?? () from /usr/lib/libguile-2.0.so.22
#9  0x00007ffff52b2747 in scm_call_1 () from /usr/lib/libguile-2.0.so.22
#10 0x00007ffff52d3af1 in scm_filter () from /usr/lib/libguile-2.0.so.22
#11 0x00007ffff533ac00 in ?? () from /usr/lib/libguile-2.0.so.22
#12 0x00007ffff52b2747 in scm_call_1 () from /usr/lib/libguile-2.0.so.22
#13 0x00007ffff533ac00 in ?? () from /usr/lib/libguile-2.0.so.22
#14 0x00007ffff52b281e in scm_call_3 () from /usr/lib/libguile-2.0.so.22
#15 0x00007ffff533ac00 in ?? () from /usr/lib/libguile-2.0.so.22
#16 0x00007ffff52b2863 in scm_call_4 () from /usr/lib/libguile-2.0.so.22
#17 0x00007ffff753f628 in opencog::SchemeEval::do_eval (this=0x93fdd0, expr=...) at /atomspace/opencog/guile/SchemeEval.cc:572
#18 0x00007ffff753f743 in opencog::SchemeEval::c_wrap_eval (p=0x93fdd0) at /atomspace/opencog/guile/SchemeEval.cc:501
#19 0x00007ffff52a92ca in ?? () from /usr/lib/libguile-2.0.so.22
#20 0x00007ffff533ac00 in ?? () from /usr/lib/libguile-2.0.so.22
#21 0x00007ffff52b2863 in scm_call_4 () from /usr/lib/libguile-2.0.so.22
#22 0x00007ffff52a99ff in ?? () from /usr/lib/libguile-2.0.so.22
#23 0x00007ffff52a9a95 in scm_c_with_continuation_barrier () from /usr/lib/libguile-2.0.so.22
#24 0x00007ffff43b4d30 in GC_call_with_gc_active () from /usr/lib/x86_64-linux-gnu/libgc.so.1
#25 0x00007ffff53227d1 in ?? () from /usr/lib/libguile-2.0.so.22
#26 0x00007ffff43af2c2 in GC_call_with_stack_base () from /usr/lib/x86_64-linux-gnu/libgc.so.1
#27 0x00007ffff5322b48 in scm_with_guile () from /usr/lib/libguile-2.0.so.22
#28 0x00007ffff753f6ee in opencog::SchemeEval::eval_expr (this=0x93fdd0, expr=...) at /atomspace/opencog/guile/SchemeEval.cc:473
#29 0x0000000000418a15 in eval (expr="(test_psi_related_goals_1)", this=0x93fdd0) at /usr/local/include/opencog/guile/SchemeEval.h:161
#30 OpenPsiUTest::test_psi_related_goals (this=0x6256b0 <suite_OpenPsiUTest>) at /opencog/tests/openpsi/OpenPsiUTest.cxxtest:241
#31 0x000000000040efa1 in CxxTest::RealTestDescription::run (
    this=0x6255e0 <testDescription_suite_OpenPsiUTest_test_psi_related_goals>) at /usr/include/cxxtest/RealDescriptions.cpp:121
#32 0x00000000004131d2 in runTest (td=..., this=<optimized out>) at /usr/include/cxxtest/TestRunner.h:103
#33 runSuite (sd=..., this=<optimized out>) at /usr/include/cxxtest/TestRunner.h:87
#34 runWorld (this=<optimized out>) at /usr/include/cxxtest/TestRunner.h:67
#35 CxxTest::TestRunner::runAllTests (listener=...) at /usr/include/cxxtest/TestRunner.h:40
#36 0x00000000004138ff in run (this=0x7fffffffd420) at /usr/include/cxxtest/ErrorFormatter.h:63
#37 CxxTest::Main<CxxTest::ErrorPrinter> (tmp=..., argc=argc@entry=1, argv=argv@entry=0x7fffffffd558)
    at /usr/include/cxxtest/TestMain.h:128
#38 0x000000000040c3bf in main (argc=1, argv=0x7fffffffd558) at /opencog/build/tests/openpsi/OpenPsiUTest.cpp:20
(gdb) info args
this = 0x94a888
other = @0x0: <error reading variable>
```