### PR TITLE
Start of refactoring of openpsi framework

### DIFF
--- a/opencog/eva/behavior/psi-behavior.scm
+++ b/opencog/eva/behavior/psi-behavior.scm
@@ -138,7 +138,8 @@
 (psi-set-controlled-rule
 	(psi-rule (list (True))
 		(DefinedPredicate "Salient:Curious")
-		salient-demand-satisfied (stv 1 1) salient-demand "saliency-tracking"))
+		salient-demand-satisfied (stv 1 1) salient-demand)
+	"saliency-tracking")
 
 (psi-rule (list (DefinedPredicate "Room bright?"))
 	(DefinedPredicate "Bright:happy")

--- a/opencog/nlp/chatbot-psi/pln-psi-rules.scm
+++ b/opencog/nlp/chatbot-psi/pln-psi-rules.scm
@@ -14,8 +14,8 @@
         (True)
         (stv .95 .9)
         sociality
-        "select_pln_answer"
     )
+    "select_pln_answer"
 )
 
 ; If it's in the PLN reasoning mode and the reasoner hasn't have an
@@ -39,8 +39,8 @@
         (True)
         (stv .95 .9)
         sociality
-        "select_pln_answer"
     )
+    "select_pln_answer"
 )
 
 (psi-set-controlled-rule
@@ -55,8 +55,8 @@
         (True)
         (stv .95 .9)
         sociality
-        "select_pln_answer"
     )
+    "select_pln_answer"
 )
 
 (psi-set-controlled-rule
@@ -70,6 +70,6 @@
         (True)
         (stv .95 .9)
         sociality
-        "select_pln_answer"
     )
+    "select_pln_answer"
 )

--- a/opencog/nlp/chatbot-psi/psi-rules.scm
+++ b/opencog/nlp/chatbot-psi/psi-rules.scm
@@ -22,8 +22,8 @@
         (True)
         (stv .9 .9)
         sociality
-        "fuzzy_matcher"
     )
+    "fuzzy_matcher"
 )
 
 (psi-set-controlled-rule
@@ -41,8 +41,8 @@
         (True)
         (stv .9 .9)
         sociality
-        "fuzzy_matcher"
     )
+    "fuzzy_matcher"
 )
 
 (psi-set-controlled-rule
@@ -59,8 +59,8 @@
         (True)
         (stv .7 .7)
         sociality
-        "fuzzy_matcher"
     )
+    "fuzzy_matcher"
 )
 
 (psi-set-controlled-rule
@@ -76,8 +76,8 @@
         (True)
         (stv 0 .9)
         sociality
-        "aiml"
     )
+    "aiml"
 )
 
 (psi-set-controlled-rule
@@ -94,8 +94,8 @@
         (True)
         (stv 0 .9)
         sociality
-        "aiml"
     )
+    "aiml"
 )
 
 (psi-set-controlled-rule
@@ -114,8 +114,8 @@
         (True)
         (stv 0 .9)
         sociality
-        "aiml"
     )
+    "aiml"
 )
 
 (psi-set-controlled-rule
@@ -132,8 +132,8 @@
         (True)
         (stv .9 .9)
         sociality
-        "chatscript"
     )
+    "chatscript"
 )
 
 (psi-set-controlled-rule
@@ -151,8 +151,8 @@
         (True)
         (stv .9 .9)
         sociality
-        "chatscript"
     )
+    "chatscript"
 )
 
 (psi-set-controlled-rule
@@ -170,8 +170,8 @@
         (True)
         (stv .9 .9)
         sociality
-        "chatscript"
     )
+    "chatscript"
 )
 
 (psi-set-controlled-rule
@@ -189,8 +189,8 @@
         (True)
         (stv .9 .9)
         sociality
-        "chatscript"
     )
+    "chatscript"
 )
 
 (psi-set-controlled-rule
@@ -208,8 +208,8 @@
         (True)
         (stv .9 .9)
         sociality
-        "chatscript"
     )
+    "chatscript"
 )
 
 (psi-set-controlled-rule
@@ -223,8 +223,8 @@
         (True)
         (stv .9 .9)
         sociality
-        "duckduckgo"
     )
+    "duckduckgo"
 )
 
 (psi-set-controlled-rule
@@ -239,8 +239,8 @@
         (True)
         (stv .9 .9)
         sociality
-        "duckduckgo"
     )
+    "duckduckgo"
 )
 
 (psi-set-controlled-rule
@@ -256,8 +256,8 @@
         (True)
         (stv .9 .9)
         sociality
-        "duckduckgo"
     )
+    "duckduckgo"
 )
 
 (psi-set-controlled-rule
@@ -272,8 +272,8 @@
         (True)
         (stv .9 .9)
         sociality
-        "wolframalpha"
     )
+    "wolframalpha"
 )
 
 (psi-set-controlled-rule
@@ -288,8 +288,8 @@
         (True)
         (stv .9 .9)
         sociality
-        "wolframalpha"
     )
+    "wolframalpha"
 )
 
 (psi-set-controlled-rule
@@ -305,8 +305,8 @@
         (True)
         (stv .9 .9)
         sociality
-        "wolframalpha"
     )
+    "wolframalpha"
 )
 
 (psi-set-controlled-rule
@@ -322,8 +322,8 @@
         (True)
         (stv .9 .9)
         sociality
-        "openweathermap"
     )
+    "openweathermap"
 )
 
 (psi-set-controlled-rule
@@ -337,8 +337,8 @@
         (True)
         (stv .9 .9)
         sociality
-        "openweathermap"
     )
+    "openweathermap"
 )
 
 (psi-set-controlled-rule
@@ -356,8 +356,8 @@
         (True)
         (stv .9 .9)
         sociality
-        "random_sentence_pkd"
     )
+    "random_sentence_pkd"
 )
 
 (psi-set-controlled-rule
@@ -375,8 +375,8 @@
         (True)
         (stv 0 .9)
         sociality
-        "random_sentence_blogs"
     )
+    "random_sentence_blogs"
 )
 
 (psi-set-controlled-rule
@@ -394,8 +394,8 @@
         (True)
         (stv .9 .9)
         sociality
-        "random_sentence_kurzweil"
     )
+    "random_sentence_kurzweil"
 )
 
 (psi-set-controlled-rule
@@ -408,8 +408,8 @@
         (True)
         (stv .9 .9)
         sociality
-        "random_sentence_pkd"
     )
+    "random_sentence_pkd"
 )
 
 (psi-set-controlled-rule
@@ -422,8 +422,8 @@
         (True)
         (stv 0 .9)
         sociality
-        "random_sentence_blogs"
     )
+    "random_sentence_blogs"
 )
 
 (psi-set-controlled-rule
@@ -436,8 +436,8 @@
         (True)
         (stv .9 .9)
         sociality
-        "random_sentence_kurzweil"
     )
+    "random_sentence_kurzweil"
 )
 
 (psi-set-controlled-rule
@@ -451,8 +451,8 @@
         (True)
         (stv .9 .9)
         sociality
-        "chatbot_eva"
     )
+    "chatbot_eva"
 )
 
 (psi-set-controlled-rule
@@ -465,8 +465,8 @@
         (True)
         (stv .9 .9)
         sociality
-        "chatbot_eva"
     )
+    "chatbot_eva"
 )
 
 ; Emotion state inquiry
@@ -483,8 +483,8 @@
         (True)
         (stv .9 .9)
         sociality
-        "emotion_state"
     )
+    "emotion_state"
 )
 
 (psi-set-controlled-rule
@@ -498,8 +498,8 @@
         (True)
         (stv .9 .9)
         sociality
-        "emotion-state"
     )
+    "emotion-state"
 )
 
 (psi-rule

--- a/opencog/openpsi/CMakeLists.txt
+++ b/opencog/openpsi/CMakeLists.txt
@@ -13,6 +13,7 @@ ADD_SUBDIRECTORY (dynamics)
 
 ADD_LIBRARY (openpsi SHARED
 	OpenPsiImplicator.cc
+	OpenPsiRules.cc
 	OpenPsiSCM.cc
 )
 

--- a/opencog/openpsi/CMakeLists.txt
+++ b/opencog/openpsi/CMakeLists.txt
@@ -21,3 +21,7 @@ TARGET_LINK_LIBRARIES (openpsi
 )
 
 INSTALL (TARGETS openpsi DESTINATION "lib${LIB_DIR_SUFFIX}/opencog")
+
+INSTALL (FILES OpenPsiImplicator.h
+	DESTINATION "include/opencog/openpsi/"
+)

--- a/opencog/openpsi/CMakeLists.txt
+++ b/opencog/openpsi/CMakeLists.txt
@@ -10,3 +10,14 @@ ADD_GUILE_MODULE (FILES
 )
 
 ADD_SUBDIRECTORY (dynamics)
+
+ADD_LIBRARY (openpsi SHARED
+	OpenPsiImplicator.cc
+	OpenPsiSCM.cc
+)
+
+TARGET_LINK_LIBRARIES (openpsi
+	${ATOMSPACE_LIBRARIES}
+)
+
+INSTALL (TARGETS openpsi DESTINATION "lib${LIB_DIR_SUFFIX}/opencog")

--- a/opencog/openpsi/OpenPsiImplicator.cc
+++ b/opencog/openpsi/OpenPsiImplicator.cc
@@ -36,6 +36,9 @@ OpenPsiImplicator::OpenPsiImplicator(AtomSpace* as) :
 bool OpenPsiImplicator::grounding(const HandleMap &var_soln,
                                   const HandleMap &term_soln)
 {
+  // TODO: Saperated component patterns aren't handled by this function
+  // as PMCGroundings is used instead. Update to handle such cases.
+
   // The psi-rule weight calculations could be done here.
   _result = TruthValue::TRUE_TV();
 
@@ -56,7 +59,11 @@ TruthValuePtr OpenPsiImplicator::check_satisfiability(
   // (context + action ->goal)
   Handle context = himplication->getOutgoingAtom(0);
 
-  // TODO: How to prevent stale cache?
+  // TODO:
+  // 1. How to prevent stale cache?
+  // 2. Also remove entry if the context isn't grounding?
+  // 3. What happens if the atoms are removed for the atomspace for
+  // whatever reason? Is signal the only means?
   if (_update_cache) {
     PatternLinkPtr plp =  createPatternLink(context);
     plp->satisfy(*this);

--- a/opencog/openpsi/OpenPsiImplicator.cc
+++ b/opencog/openpsi/OpenPsiImplicator.cc
@@ -1,0 +1,45 @@
+/*
+ * OpenPsiImplicator.cc
+ *
+ * Copyright (C) 2017 MindCloud
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+
+#include "OpenPsiImplicator.h"
+
+using namespace opencog;
+
+OpenPsiImplicator::OpenPsiImplicator(AtomSpace* as) :
+  InitiateSearchCB(as),
+  DefaultPatternMatchCB(as),
+  Satisfier(as)
+{}
+
+bool OpenPsiImplicator::grounding(const HandleMap &var_soln,
+                                  const HandleMap &term_soln)
+{
+
+  // The psi-rule weight calculations could be done here
+  _result = TruthValue::TRUE_TV();
+
+  // NOTE: If a single grounding is found then why search for more? If there
+  // is an issue with instantiating the implicand then there is an issue with
+  // the implicand. Satisfier::grounding does exaustive search so this should
+  // theoretically speed psi-loop.
+  return true;
+}

--- a/opencog/openpsi/OpenPsiImplicator.cc
+++ b/opencog/openpsi/OpenPsiImplicator.cc
@@ -36,7 +36,6 @@ OpenPsiImplicator::OpenPsiImplicator(AtomSpace* as) :
 bool OpenPsiImplicator::grounding(const HandleMap &var_soln,
                                   const HandleMap &term_soln)
 {
-
   // The psi-rule weight calculations could be done here.
   _result = TruthValue::TRUE_TV();
 

--- a/opencog/openpsi/OpenPsiImplicator.cc
+++ b/opencog/openpsi/OpenPsiImplicator.cc
@@ -19,6 +19,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <opencog/atoms/execution/Instantiator.h>
 
 #include "OpenPsiImplicator.h"
 
@@ -49,10 +50,11 @@ bool OpenPsiImplicator::grounding(const HandleMap &var_soln,
   return true;
 }
 
-// TruthValuePtr OpenPsiImplicator::imply(
 TruthValuePtr OpenPsiImplicator::check_satisfiability(
   const Handle& himplication)
 {
+  // TODO: Replace this with the context, as psi-rule is
+  // (context + action ->goal)
   Handle context = himplication->getOutgoingAtom(0);
 
   // TODO: How to prevent stale cache?
@@ -65,5 +67,23 @@ TruthValuePtr OpenPsiImplicator::check_satisfiability(
     return TruthValue::TRUE_TV();
   } else {
     return TruthValue::FALSE_TV();
+  }
+}
+
+Handle OpenPsiImplicator::imply(const Handle& himplication)
+{
+  // TODO: Replace this with the action, as psi-rule is
+  // (context + action ->goal)
+  Handle context = himplication->getOutgoingAtom(0);
+  Instantiator inst(_as);
+
+  if (_satisfiability_cache.count(context)) {
+    return inst.instantiate(himplication->getOutgoingAtom(1),
+              _satisfiability_cache.at(context), true);
+  } else {
+    // NOTE: Trying to check for satisfiablity isn't done because it
+    // is the responsibility of the action-selector for determining
+    // what action is to be taken.
+    return Handle::UNDEFINED;
   }
 }

--- a/opencog/openpsi/OpenPsiImplicator.cc
+++ b/opencog/openpsi/OpenPsiImplicator.cc
@@ -34,7 +34,7 @@ bool OpenPsiImplicator::grounding(const HandleMap &var_soln,
                                   const HandleMap &term_soln)
 {
 
-  // The psi-rule weight calculations could be done here
+  // The psi-rule weight calculations could be done here.
   _result = TruthValue::TRUE_TV();
 
   // NOTE: If a single grounding is found then why search for more? If there
@@ -42,4 +42,13 @@ bool OpenPsiImplicator::grounding(const HandleMap &var_soln,
   // the implicand. Satisfier::grounding does exaustive search so this should
   // theoretically speed psi-loop.
   return true;
+}
+
+TruthValuePtr OpenPsiImplicator::check_satisfiability(
+  const Handle& himplication)
+{
+  PatternLinkPtr plp =  createPatternLink(himplication->getOutgoingAtom(0));
+  plp->satisfy(*this);
+
+  return _result;
 }

--- a/opencog/openpsi/OpenPsiImplicator.h
+++ b/opencog/openpsi/OpenPsiImplicator.h
@@ -28,11 +28,17 @@
 
 #include <opencog/query/Satisfier.h>
 
+class OpenPsiImplicatorUTest;
+
 namespace opencog
 {
 
 class OpenPsiImplicator: public virtual Satisfier
 {
+  // Needed for resetting private cache.
+  // TODO Why would one need to reset during psi-loop?
+  friend class ::OpenPsiImplicatorUTest;
+
 public:
   OpenPsiImplicator(AtomSpace* as);
 

--- a/opencog/openpsi/OpenPsiImplicator.h
+++ b/opencog/openpsi/OpenPsiImplicator.h
@@ -23,6 +23,7 @@
 #ifndef _OPENCOG_OPENPSI_IMPLICATOR_H
 #define _OPENCOG_OPENPSI_IMPLICATOR_H
 
+#include <opencog/atoms/pattern/PatternLink.h>
 #include <opencog/atomspace/AtomSpace.h>
 
 #include <opencog/query/Satisfier.h>
@@ -35,8 +36,16 @@ class OpenPsiImplicator: public virtual Satisfier
   public:
     OpenPsiImplicator(AtomSpace* as);
 
+    /**
+     * Return true if a single grounding has been found.
+     */
     bool grounding(const HandleMap &var_soln,
                    const HandleMap &term_soln);
+
+    /**
+     * Returns TRUE_TV if there is grounding else returns FALSE_TV.
+     */
+    TruthValuePtr check_satisfiability(const Handle& himplication);
 };
 
 }; // namespace opencog

--- a/opencog/openpsi/OpenPsiImplicator.h
+++ b/opencog/openpsi/OpenPsiImplicator.h
@@ -33,19 +33,19 @@ namespace opencog
 
 class OpenPsiImplicator: public virtual Satisfier
 {
-  public:
-    OpenPsiImplicator(AtomSpace* as);
+public:
+  OpenPsiImplicator(AtomSpace* as);
 
-    /**
-     * Return true if a single grounding has been found.
-     */
-    bool grounding(const HandleMap &var_soln,
-                   const HandleMap &term_soln);
+  /**
+   * Return true if a single grounding has been found.
+   */
+  bool grounding(const HandleMap &var_soln,
+                 const HandleMap &term_soln);
 
-    /**
-     * Returns TRUE_TV if there is grounding else returns FALSE_TV.
-     */
-    TruthValuePtr check_satisfiability(const Handle& himplication);
+  /**
+   * Returns TRUE_TV if there is grounding else returns FALSE_TV.
+   */
+  TruthValuePtr check_satisfiability(const Handle& himplication);
 };
 
 }; // namespace opencog

--- a/opencog/openpsi/OpenPsiImplicator.h
+++ b/opencog/openpsi/OpenPsiImplicator.h
@@ -48,6 +48,15 @@ public:
    */
   TruthValuePtr check_satisfiability(const Handle& himplication);
 
+  /**
+   * Instantiate the implicand of the given ImplicationLink.
+   *
+   * @param himplication Handle to the ImplicationLink.
+   * @param vars Map from variables to their groundings.
+   * @return The handle to the grounded atom.
+   */
+  Handle imply(const Handle& himplication);
+
 private:
   /**
    * Cache used to store context with the variable groundings.
@@ -60,6 +69,10 @@ private:
    * use the cache for a subset of contexts.
    */
   bool _update_cache = true;
+
+  // Because two of the ancestor classes that this class inherites
+  // from have _as variable.
+  using DefaultPatternMatchCB::_as;
 };
 
 }; // namespace opencog

--- a/opencog/openpsi/OpenPsiImplicator.h
+++ b/opencog/openpsi/OpenPsiImplicator.h
@@ -1,0 +1,44 @@
+/*
+ * OpenPsiImplicator.h
+ *
+ * Copyright (C) 2017 MindCloud
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+
+#ifndef _OPENCOG_OPENPSI_IMPLICATOR_H
+#define _OPENCOG_OPENPSI_IMPLICATOR_H
+
+#include <opencog/atomspace/AtomSpace.h>
+
+#include <opencog/query/Satisfier.h>
+
+namespace opencog
+{
+
+class OpenPsiImplicator: public virtual Satisfier
+{
+  public:
+    OpenPsiImplicator(AtomSpace* as);
+
+    bool grounding(const HandleMap &var_soln,
+                   const HandleMap &term_soln);
+};
+
+}; // namespace opencog
+
+#endif // _OPENCOG_OPENPSI_IMPLICATOR_H

--- a/opencog/openpsi/OpenPsiImplicator.h
+++ b/opencog/openpsi/OpenPsiImplicator.h
@@ -43,9 +43,23 @@ public:
                  const HandleMap &term_soln);
 
   /**
-   * Returns TRUE_TV if there is grounding else returns FALSE_TV.
+   * Returns TRUE_TV if there is grounding else returns FALSE_TV. If the
+   * cache has entry for the context then TRUE_TV is returned.
    */
   TruthValuePtr check_satisfiability(const Handle& himplication);
+
+private:
+  /**
+   * Cache used to store context with the variable groundings.
+   */
+  static std::map<Handle, HandleMap> _satisfiability_cache;
+
+  /**
+   * Used to signal whether cache should be updated or not. By default the
+   * cache is updated. It isn't static because one might only want to
+   * use the cache for a subset of contexts.
+   */
+  bool _update_cache = true;
 };
 
 }; // namespace opencog

--- a/opencog/openpsi/OpenPsiRules.cc
+++ b/opencog/openpsi/OpenPsiRules.cc
@@ -1,0 +1,53 @@
+/*
+ * OpenPsiRules.cc
+ *
+ * Copyright (C) 2017 MindCloud
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atoms/base/Node.h>
+
+#include "OpenPsiRules.h"
+
+using namespace opencog;
+
+std::map<Handle, OpenPsiRules::PsiTuple> OpenPsiRules::_psi_rules = {};
+Handle OpenPsiRules::_psi_action = \
+  Handle(createNode(CONCEPT_NODE, "OpenPsi: action"));
+
+OpenPsiRules::OpenPsiRules(AtomSpace* as): _as(as)
+{}
+
+Handle OpenPsiRules::add_rule(const HandleSeq& context, const Handle& action,
+  const Handle& goal, const TruthValuePtr stv, const Handle& demand)
+{
+  // Declare as an openpsi action if it hasn't already been declared.
+  _as->add_link(MEMBER_LINK, action, _psi_action);
+
+  // Add a SequentialAndLink of context and action which forms the
+  // implicant of the psi-rule.
+  HandleSeq temp_c =  context;
+  temp_c.push_back(action);
+  Handle hca = _as->add_link(SEQUENTIAL_AND_LINK, temp_c);
+
+  // Add the psi-rule, set the truthvalue and add to a demand.
+  Handle rule = _as->add_link(IMPLICATION_LINK, hca, goal);
+  rule->setTruthValue(stv);
+  _as->add_link(MEMBER_LINK, rule, demand);
+
+  return rule;
+}

--- a/opencog/openpsi/OpenPsiRules.h
+++ b/opencog/openpsi/OpenPsiRules.h
@@ -34,6 +34,13 @@ public:
 
   /**
    * Add a rule to the atomspace and the psi-rule index.
+   * @return An ImplicationLink that forms a psi-rule. The structure
+   *  of the rule is
+   *    (ImplicationLink TV
+   *      (SequentialAndLink
+   *        context
+   *        action)
+   *      goal)
    */
   Handle add_rule(const HandleSeq& context, const Handle& action,
     const Handle& goal, const TruthValuePtr stv, const Handle& demand);

--- a/opencog/openpsi/OpenPsiRules.h
+++ b/opencog/openpsi/OpenPsiRules.h
@@ -1,0 +1,76 @@
+/*
+ * OpenPsiRules.h
+ *
+ * Copyright (C) 2017 MindCloud
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OPENCOG_OPENPSI_RULES_H
+#define _OPENCOG_OPENPSI_RULES_H
+
+#include <opencog/atomspace/AtomSpace.h>
+
+namespace opencog
+{
+
+class OpenPsiRules
+{
+public:
+  OpenPsiRules(AtomSpace* as);
+
+  /**
+   * Add a rule to the atomspace and the psi-rule index.
+   */
+  Handle add_rule(const HandleSeq& context, const Handle& action,
+    const Handle& goal, const TruthValuePtr stv, const Handle& demand);
+
+private:
+  /**
+   * The structure of the tuple is (context, action, goal).
+   */
+  typedef std::tuple<HandleSeq, Handle, Handle> PsiTuple;
+
+  /**
+   * This is a index with the keys being the psi-rules and the corresponding
+   * value being a tuple of its three components. The intention is to minimize
+   * the computing required for getting the different component of a rule.
+   */
+  static std::map<Handle, PsiTuple> _psi_rules;
+
+  // TODO: Using names that are prefixed with "OpenPsi: " might be a bad idea,
+  // because it might hinder interoperability with other components that
+  // expect an explicit ontological representation. For historic reasons we
+  // continue using such convention but should be replaces with graph that
+  // represent the relationships. That way it would be possible to answer
+  // questions about the system the nlp pipeline.
+
+  /**
+   * Node used to declare an action.
+   */
+  static Handle _psi_action;
+
+  /**
+   * Node used to declare a goal.
+   */
+  // static Handle _psi_goal;
+
+  AtomSpace* _as;
+};
+
+} // namespace opencog
+
+#endif  // _OPENCOG_OPENPSI_RULES_H

--- a/opencog/openpsi/OpenPsiSCM.cc
+++ b/opencog/openpsi/OpenPsiSCM.cc
@@ -26,9 +26,6 @@
 
 using namespace opencog;
 
-/**
- * The constructor for OpenPsiSCM.
- */
 OpenPsiSCM::OpenPsiSCM()
 {
   static bool is_init = false;
@@ -37,9 +34,6 @@ OpenPsiSCM::OpenPsiSCM()
   scm_with_guile(init_in_guile, this);
 }
 
-/**
- * The main init function for the OpenPsiSCM object.
- */
 void OpenPsiSCM::init()
 {
   define_scheme_primitive("psi-satisfy", &OpenPsiSCM::satisfiable,
@@ -64,13 +58,6 @@ Handle OpenPsiSCM::psi_imply(const Handle& himplication)
   return implicator.imply(himplication);
 }
 
-/**
- * Init function for using with scm_with_guile.
- *
- * Creates the openpsi scheme module and uses it by default.
- *
- * @param self  pointer to the OpenPsiSCM object
- */
 void* OpenPsiSCM::init_in_guile(void* self)
 {
   scm_c_define_module("opencog openpsi", init_in_module, self);
@@ -78,11 +65,6 @@ void* OpenPsiSCM::init_in_guile(void* self)
   return NULL;
 }
 
-/**
- * The main function for defining stuff in the openpsi scheme module.
- *
- * @param data  pointer to the OpenPsiSCM object
- */
 void OpenPsiSCM::init_in_module(void* data)
 {
   OpenPsiSCM* self = (OpenPsiSCM*) data;

--- a/opencog/openpsi/OpenPsiSCM.cc
+++ b/opencog/openpsi/OpenPsiSCM.cc
@@ -1,0 +1,90 @@
+/*
+ * OpenPsiSCM.cc
+ *
+ * Copyright (C) 2017 MindCloud
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atoms/pattern/PatternLink.h>
+#include <opencog/guile/SchemePrimitive.h>
+
+#include "OpenPsiImplicator.h"
+#include "OpenPsiSCM.h"
+
+using namespace opencog;
+
+/**
+ * The constructor for OpenPsiSCM.
+ */
+OpenPsiSCM::OpenPsiSCM()
+{
+  static bool is_init = false;
+  if (is_init) return;
+  is_init = true;
+  scm_with_guile(init_in_guile, this);
+}
+
+/**
+ * The main init function for the OpenPsiSCM object.
+ */
+void OpenPsiSCM::init()
+{
+  define_scheme_primitive("psi-satisfy", &OpenPsiSCM::satisfiable,
+    this, "openpsi");
+}
+
+TruthValuePtr OpenPsiSCM::satisfiable(const Handle& himplication)
+{
+  // TODO: Rname to psi-satisfiable? once c++ cache is implemented.
+  AtomSpace *as = SchemeSmob::ss_get_env_as("psi-satisfy");
+  OpenPsiImplicator imply(as);
+
+  PatternLinkPtr plp =  createPatternLink(himplication->getOutgoingAtom(0));
+  plp->satisfy(imply);
+
+  return imply._result;
+}
+
+/**
+ * Init function for using with scm_with_guile.
+ *
+ * Creates the openpsi scheme module and uses it by default.
+ *
+ * @param self  pointer to the OpenPsiSCM object
+ */
+void* OpenPsiSCM::init_in_guile(void* self)
+{
+  scm_c_define_module("opencog openpsi", init_in_module, self);
+  scm_c_use_module("opencog openpsi");
+  return NULL;
+}
+
+/**
+ * The main function for defining stuff in the openpsi scheme module.
+ *
+ * @param data  pointer to the OpenPsiSCM object
+ */
+void OpenPsiSCM::init_in_module(void* data)
+{
+  OpenPsiSCM* self = (OpenPsiSCM*) data;
+  self->init();
+}
+
+void opencog_openpsi_init(void)
+{
+  static OpenPsiSCM openpsi;
+}

--- a/opencog/openpsi/OpenPsiSCM.cc
+++ b/opencog/openpsi/OpenPsiSCM.cc
@@ -19,7 +19,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/atoms/pattern/PatternLink.h>
 #include <opencog/guile/SchemePrimitive.h>
 
 #include "OpenPsiImplicator.h"
@@ -49,14 +48,10 @@ void OpenPsiSCM::init()
 
 TruthValuePtr OpenPsiSCM::satisfiable(const Handle& himplication)
 {
-  // TODO: Rname to psi-satisfiable? once c++ cache is implemented.
+  // TODO: Rename to psi-satisfiable? once c++ cache is implemented.
   AtomSpace *as = SchemeSmob::ss_get_env_as("psi-satisfy");
   OpenPsiImplicator imply(as);
-
-  PatternLinkPtr plp =  createPatternLink(himplication->getOutgoingAtom(0));
-  plp->satisfy(imply);
-
-  return imply._result;
+  return imply.check_satisfiability(himplication);
 }
 
 /**

--- a/opencog/openpsi/OpenPsiSCM.cc
+++ b/opencog/openpsi/OpenPsiSCM.cc
@@ -22,6 +22,8 @@
 #include <opencog/guile/SchemePrimitive.h>
 
 #include "OpenPsiImplicator.h"
+#include "OpenPsiRules.h"
+
 #include "OpenPsiSCM.h"
 
 using namespace opencog;
@@ -41,6 +43,9 @@ void OpenPsiSCM::init()
 
   define_scheme_primitive("psi-imply", &OpenPsiSCM::psi_imply,
     this, "openpsi");
+
+  define_scheme_primitive("psi-rule", &OpenPsiSCM::psi_rule,
+    this, "openpsi");
 }
 
 TruthValuePtr OpenPsiSCM::satisfiable(const Handle& himplication)
@@ -56,6 +61,16 @@ Handle OpenPsiSCM::psi_imply(const Handle& himplication)
   AtomSpace* as = SchemeSmob::ss_get_env_as("psi-imply");
   OpenPsiImplicator implicator(as);
   return implicator.imply(himplication);
+}
+
+Handle OpenPsiSCM::psi_rule(const HandleSeq& context, const Handle& action,
+  const Handle& goal, const TruthValuePtr stv, const Handle& demand)
+{
+  AtomSpace* as = SchemeSmob::ss_get_env_as("psi-rule");
+  // TODO: Should this be a singleton? What could be the issues that need
+  // to be handled?
+  OpenPsiRules rule_constructor(as);
+  return rule_constructor.add_rule(context, action, goal, stv, demand);
 }
 
 void* OpenPsiSCM::init_in_guile(void* self)

--- a/opencog/openpsi/OpenPsiSCM.cc
+++ b/opencog/openpsi/OpenPsiSCM.cc
@@ -44,14 +44,24 @@ void OpenPsiSCM::init()
 {
   define_scheme_primitive("psi-satisfy", &OpenPsiSCM::satisfiable,
     this, "openpsi");
+
+  define_scheme_primitive("psi-imply", &OpenPsiSCM::psi_imply,
+    this, "openpsi");
 }
 
 TruthValuePtr OpenPsiSCM::satisfiable(const Handle& himplication)
 {
   // TODO: Rename to psi-satisfiable? once c++ cache is implemented.
   AtomSpace *as = SchemeSmob::ss_get_env_as("psi-satisfy");
-  OpenPsiImplicator imply(as);
-  return imply.check_satisfiability(himplication);
+  OpenPsiImplicator implicator(as);
+  return implicator.check_satisfiability(himplication);
+}
+
+Handle OpenPsiSCM::psi_imply(const Handle& himplication)
+{
+  AtomSpace* as = SchemeSmob::ss_get_env_as("psi-imply");
+  OpenPsiImplicator implicator(as);
+  return implicator.imply(himplication);
 }
 
 /**

--- a/opencog/openpsi/OpenPsiSCM.h
+++ b/opencog/openpsi/OpenPsiSCM.h
@@ -34,7 +34,20 @@ public:
   OpenPsiSCM();
 
 private:
+  /**
+   * Returns TRUE_TV or FALSE_TV depending on whether the context of the
+   * given psi-rule is satisfiable or not.
+   *
+   * @param himplication A psi-rule.
+   */
   TruthValuePtr satisfiable(const Handle& himplication);
+
+  /**
+   * Instantiates the action of the psi-rule if their is an entry in
+   * the cache for the groundings of its context.
+   *
+   * @param himplication A psi-rule.
+   */
   Handle psi_imply(const Handle& himplication);
 
   /**

--- a/opencog/openpsi/OpenPsiSCM.h
+++ b/opencog/openpsi/OpenPsiSCM.h
@@ -30,16 +30,32 @@ namespace opencog
 
 class OpenPsiSCM
 {
-  public:
-    OpenPsiSCM();
+public:
+  OpenPsiSCM();
 
-  private:
-    static void* init_in_guile(void*);
-    static void init_in_module(void*);
-    void init(void);
+private:
+  TruthValuePtr satisfiable(const Handle& himplication);
+  Handle psi_imply(const Handle& himplication);
 
-    TruthValuePtr satisfiable(const Handle& himplication);
-    Handle psi_imply(const Handle& himplication);
+  /**
+   * Init function for using with scm_with_guile. It creates the
+   * openpsi scheme module and uses it by default.
+   *
+   * @param self pointer to the OpenPsiSCM object
+   */
+  static void* init_in_guile(void*);
+
+  /**
+   * The main function for defining stuff in the openpsi scheme module.
+   *
+   * @param data  pointer to the OpenPsiSCM object
+   */
+  static void init_in_module(void*);
+
+  /**
+   * The main init function for the OpenPsiSCM object.
+   */
+  void init(void);
 };
 
 } // namespace opencog

--- a/opencog/openpsi/OpenPsiSCM.h
+++ b/opencog/openpsi/OpenPsiSCM.h
@@ -1,0 +1,51 @@
+/*
+ * OpenPsiSCM.h
+ *
+ * Copyright (C) 2017 MindCloud
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef OPENPSI_H
+#define OPENPSI_H
+
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/truthvalue/TruthValue.h>
+
+namespace opencog
+{
+
+class OpenPsiSCM
+{
+  public:
+    OpenPsiSCM();
+
+  private:
+    static void* init_in_guile(void*);
+    static void init_in_module(void*);
+    void init(void);
+
+    TruthValuePtr satisfiable(const Handle& himplication);
+
+};
+
+} // namespace opencog
+
+extern "C" {
+void opencog_openpsi_init(void);
+};
+
+#endif  // OPENPSI_H

--- a/opencog/openpsi/OpenPsiSCM.h
+++ b/opencog/openpsi/OpenPsiSCM.h
@@ -39,7 +39,7 @@ class OpenPsiSCM
     void init(void);
 
     TruthValuePtr satisfiable(const Handle& himplication);
-
+    Handle psi_imply(const Handle& himplication);
 };
 
 } // namespace opencog

--- a/opencog/openpsi/OpenPsiSCM.h
+++ b/opencog/openpsi/OpenPsiSCM.h
@@ -51,6 +51,14 @@ private:
   Handle psi_imply(const Handle& himplication);
 
   /**
+   * Add psi-rule.
+   *
+   * @return An implication link which is a psi-rule.
+   */
+  Handle psi_rule(const HandleSeq& context, const Handle& action,
+    const Handle& goal, const TruthValuePtr stv, const Handle& demand);
+
+  /**
    * Init function for using with scm_with_guile. It creates the
    * openpsi scheme module and uses it by default.
    *

--- a/opencog/openpsi/OpenPsiSCM.h
+++ b/opencog/openpsi/OpenPsiSCM.h
@@ -19,8 +19,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef OPENPSI_H
-#define OPENPSI_H
+#ifndef _OPENCOG_OPENPSI_SCM_H
+#define _OPENCOG_OPENPSI_SCM_H
 
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/truthvalue/TruthValue.h>
@@ -64,4 +64,4 @@ extern "C" {
 void opencog_openpsi_init(void);
 };
 
-#endif  // OPENPSI_H
+#endif  // _OPENCOG_OPENPSI_SCM_H

--- a/opencog/openpsi/control.scm
+++ b/opencog/openpsi/control.scm
@@ -117,16 +117,18 @@
 )
 
 ; --------------------------------------------------------------
-(define (psi-set-controlled-rule psi-rule)
+(define (psi-set-controlled-rule psi-rule name)
 "
-  psi-set-controlled-rule RULE
+  psi-set-controlled-rule RULE NAME
 
-  Specify that RULE is to be controlled. Controlling means modifying the
-  weight of the rule, thus affecting the likelyhood of it being choosen.
+  Specify that RULE is to be controlled and give it a NAME. Controlling means
+  modifying the weight of the rule, thus affecting the likelyhood of it being choosen.
 "
     (MemberLink psi-rule psi-controller-demand)
 
     (psi-rule-set-atomese-weight psi-rule (tv-mean (cog-tv psi-rule)))
+
+    (psi-rule-set-alias psi-rule name)
 
     psi-rule
 )

--- a/opencog/openpsi/openpsi.scm
+++ b/opencog/openpsi/openpsi.scm
@@ -26,7 +26,6 @@
     psi-rule-set-atomese-weight psi-set-controlled-rule
     psi-get-controlled-rules psi-rule-atomese-weight
     psi-controller-update-weights psi-rule-disable psi-rule-enable
-    psi-rule
 
     ; From rule.scm
     psi-get-rules psi-get-all-rules psi-rule? psi-get-all-actions psi-action?
@@ -46,7 +45,7 @@
     psi-get-members
 
     ; C++ bindings from libopenpsi
-    psi-satisfy
+    psi-satisfy psi-imply psi-rule
     )
 )
 

--- a/opencog/openpsi/openpsi.scm
+++ b/opencog/openpsi/openpsi.scm
@@ -35,7 +35,7 @@
     psi-rule-satisfiability psi-get-satisfiable-rules
     psi-get-weighted-satisfiable-rules psi-get-all-satisfiable-rules
     psi-get-all-weighted-satisfiable-rules psi-context-weight psi-action-weight
-    psi-goal psi-goal?
+    psi-goal psi-goal? psi-rule-set-alias
 
     ; From main.scm
     psi-running? psi-get-loop-count psi-run-continue? psi-step psi-run psi-halt

--- a/opencog/openpsi/openpsi.scm
+++ b/opencog/openpsi/openpsi.scm
@@ -44,8 +44,13 @@
     ; From utilities.scm
     psi-prefix-str psi-suffix-str psi-get-exact-match psi-get-dual-match
     psi-get-members
+
+    ; C++ bindings from libopenpsi
+    psi-satisfy
     )
 )
+
+(load-extension "libopenpsi" "opencog_openpsi_init")
 
 (load-from-path "opencog/openpsi/action-selector.scm")
 (load-from-path "opencog/openpsi/demand.scm")

--- a/opencog/openpsi/rule.scm
+++ b/opencog/openpsi/rule.scm
@@ -59,7 +59,7 @@
 )
 
 ; --------------------------------------------------------------
-(define* (psi-rule context action goal a-stv demand)
+(define* (psi-rule-old context action goal a-stv demand)
 "
   psi-rule CONTEXT ACTION GOAL TV DEMAND - create a psi-rule.
 

--- a/opencog/openpsi/rule.scm
+++ b/opencog/openpsi/rule.scm
@@ -59,9 +59,9 @@
 )
 
 ; --------------------------------------------------------------
-(define* (psi-rule context action goal a-stv demand  #:optional name)
+(define* (psi-rule context action goal a-stv demand)
 "
-  psi-rule CONTEXT ACTION GOAL TV DEMAND [NAME] - create a psi-rule.
+  psi-rule CONTEXT ACTION GOAL TV DEMAND - create a psi-rule.
 
   Associate an action with a context such that, if the action is
   taken, then the goal will be satisfied. The structure of a rule
@@ -90,9 +90,6 @@
     be a SimpleTruthValue.
 
   DEMAND is a Node, representing the demand that this rule affects.
-
-  NAME is an optional argument; if it is provided, then it should be
-    a string that will be associated with the rule.
 "
     (let ((implication
             (Implication a-stv (SequentialAndLink context action) goal)))
@@ -102,17 +99,6 @@
         (MemberLink action psi-action)
 
         (MemberLink implication demand)
-
-        ; If a name is given, its used for control/feedback purposes.
-        ; TODO: This isn't necessary the hash (returned value by of cog-handle)
-        ; could be used as a hash is unique and reproducable.
-        (if name
-            (EvaluationLink
-                psi-rule-name-predicate-node
-                (ListLink
-                    implication
-                    (ConceptNode (string-append psi-prefix-str name))))
-        )
 
         implication
     )
@@ -228,6 +214,23 @@ actions are EvaluationLinks, not schemas or ExecutionOutputLinks.
     (cog-outgoing-atom rule 1)
 )
 
+; --------------------------------------------------------------
+(define (psi-rule-set-alias psi-rule name)
+"
+  psi-rule-set-alias PSI-RULE NAME
+
+  NAME is a string that will be associated with the rule and is used
+    as a repeatable means of referring to the rule. The hash of the
+    rule can't be used, because it is a function of the Type of atoms,
+    and there is no guarantee that the relationship between Types is
+    static as a result of which the hash-value could change.
+"
+    (EvaluationLink
+        psi-rule-name-predicate-node
+        (ListLink
+            psi-rule
+            (ConceptNode (string-append psi-prefix-str name))))
+)
 ; --------------------------------------------------------------
 (define (psi-rule-alias psi-rule)
 "

--- a/tests/openpsi/CMakeLists.txt
+++ b/tests/openpsi/CMakeLists.txt
@@ -1,7 +1,9 @@
 LINK_LIBRARIES(
   ${ATOMSPACE_LIBRARIES}
   ${COGUTIL_LIBRARY}
+  openpsi
 )
 
 ADD_CXXTEST(OpenPsiUTest)
+ADD_CXXTEST(OpenPsiImplicatorUTest)
 #ADD_CXXTEST(OpenPsiExampleTest)

--- a/tests/openpsi/OpenPsiImplicatorUTest.cxxtest
+++ b/tests/openpsi/OpenPsiImplicatorUTest.cxxtest
@@ -1,0 +1,112 @@
+/*
+ * OpenPsiImplicatorUTest.cxxtest
+ *
+ * Copyright (C) 2017 MindCloud
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <cxxtest/TestSuite.h>
+
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/guile/SchemeEval.h>
+// #include <opencog/util/Logger.h>
+#include <opencog/openpsi/OpenPsiImplicator.h>
+
+#define OPENPSI_TEST_PATH PROJECT_SOURCE_DIR "/tests/openpsi"
+#define CHKERR \
+    TSM_ASSERT("Caught scm error during eval", \
+        (false == _scm->eval_error()));
+
+using namespace opencog;
+
+class OpenPsiImplicatorUTest : public CxxTest::TestSuite
+{
+  private:
+    AtomSpace* _as;
+    SchemeEval* _scm;
+
+  public:
+    OpenPsiImplicatorUTest(): _as(nullptr), _scm(nullptr)
+    {
+        logger().set_level(Logger::DEBUG);
+        logger().set_print_level_flag(true);
+        logger().set_print_to_stdout_flag(true);
+    }
+
+    ~OpenPsiImplicatorUTest()
+    {
+        // Clean Up
+        delete _as;
+        _as = nullptr;
+        delete _scm;
+        _scm = nullptr;
+
+        // Erase the log file if no assertions failed
+        if(!CxxTest::TestTracker::tracker().suiteFailed())
+            std::remove(logger().get_filename().c_str());
+    }
+
+    void setUp()
+    {
+        // The scheme environment is reset between each test.
+        _as = new AtomSpace();
+        _scm = new SchemeEval(_as);
+
+        // Configure scheme load-paths that are common for all tests.
+        _scm->eval("(add-to-load-path \"/usr/local/share/opencog/scm\")");
+        CHKERR
+
+        // Load require modules to be tested and populate the atomspace
+        _scm->eval("(use-modules (opencog))");
+        CHKERR
+
+    }
+
+    void tearDown()
+    {
+        delete _as;
+        _as = nullptr;
+    }
+
+    void test_check_satisfiability()
+    {
+      logger().info("BEGIN TEST: %s", __FUNCTION__);
+      // Load test atomspace configuration file.
+      _scm->eval("(load \"" OPENPSI_TEST_PATH "/psi-implicator.scm\")");
+      CHKERR
+
+      // Common Setup
+      auto rule_1 = _scm->eval_h("(rule-1)");
+      CHKERR
+      OpenPsiImplicator imply(_as);
+      TruthValuePtr tv;
+
+      // Test 1:
+      // Test behaviour when there is no grounding.
+      tv = imply.check_satisfiability(rule_1);
+      TSM_ASSERT_EQUALS("Expected (stv 0 1)", TruthValue::FALSE_TV(), tv);
+
+      // Test 2:
+      // Test behaviour when there is a grounding.
+      _scm->eval("(groundable-content-1)");
+      CHKERR
+      tv = imply.check_satisfiability(rule_1);
+      TSM_ASSERT_EQUALS("Expected (stv 1 1)", TruthValue::TRUE_TV(), tv);
+
+      logger().info("END TEST: %s", __FUNCTION__);
+    }
+};

--- a/tests/openpsi/OpenPsiImplicatorUTest.cxxtest
+++ b/tests/openpsi/OpenPsiImplicatorUTest.cxxtest
@@ -41,44 +41,43 @@ private:
 public:
   OpenPsiImplicatorUTest(): _as(nullptr), _scm(nullptr)
   {
-      logger().set_level(Logger::DEBUG);
-      logger().set_print_level_flag(true);
-      logger().set_print_to_stdout_flag(true);
+    logger().set_level(Logger::DEBUG);
+    logger().set_print_level_flag(true);
+    logger().set_print_to_stdout_flag(true);
   }
 
   ~OpenPsiImplicatorUTest()
   {
-      // Clean Up
-      delete _as;
-      _as = nullptr;
-      delete _scm;
-      _scm = nullptr;
+    // Clean Up
+    delete _as;
+    _as = nullptr;
+    delete _scm;
+    _scm = nullptr;
 
-      // Erase the log file if no assertions failed
-      if(!CxxTest::TestTracker::tracker().suiteFailed())
-          std::remove(logger().get_filename().c_str());
+    // Erase the log file if no assertions failed
+    if(!CxxTest::TestTracker::tracker().suiteFailed())
+        std::remove(logger().get_filename().c_str());
   }
 
   void setUp()
   {
-      // The scheme environment is reset between each test.
-      _as = new AtomSpace();
-      _scm = new SchemeEval(_as);
+    // The scheme environment is reset between each test.
+    _as = new AtomSpace();
+    _scm = new SchemeEval(_as);
 
-      // Configure scheme load-paths that are common for all tests.
-      _scm->eval("(add-to-load-path \"/usr/local/share/opencog/scm\")");
-      CHKERR
+    // Configure scheme load-paths that are common for all tests.
+    _scm->eval("(add-to-load-path \"/usr/local/share/opencog/scm\")");
+    CHKERR
 
-      // Load require modules to be tested and populate the atomspace
-      _scm->eval("(use-modules (opencog))");
-      CHKERR
-
+    // Load require modules to be tested and populate the atomspace
+    _scm->eval("(use-modules (opencog))");
+    CHKERR
   }
 
   void tearDown()
   {
-      delete _as;
-      _as = nullptr;
+    delete _as;
+    _as = nullptr;
   }
 
   void test_check_satisfiability()

--- a/tests/openpsi/OpenPsiImplicatorUTest.cxxtest
+++ b/tests/openpsi/OpenPsiImplicatorUTest.cxxtest
@@ -23,7 +23,6 @@
 
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/guile/SchemeEval.h>
-// #include <opencog/util/Logger.h>
 #include <opencog/openpsi/OpenPsiImplicator.h>
 
 #define OPENPSI_TEST_PATH PROJECT_SOURCE_DIR "/tests/openpsi"
@@ -35,78 +34,78 @@ using namespace opencog;
 
 class OpenPsiImplicatorUTest : public CxxTest::TestSuite
 {
-  private:
-    AtomSpace* _as;
-    SchemeEval* _scm;
+private:
+  AtomSpace* _as;
+  SchemeEval* _scm;
 
-  public:
-    OpenPsiImplicatorUTest(): _as(nullptr), _scm(nullptr)
-    {
-        logger().set_level(Logger::DEBUG);
-        logger().set_print_level_flag(true);
-        logger().set_print_to_stdout_flag(true);
-    }
+public:
+  OpenPsiImplicatorUTest(): _as(nullptr), _scm(nullptr)
+  {
+      logger().set_level(Logger::DEBUG);
+      logger().set_print_level_flag(true);
+      logger().set_print_to_stdout_flag(true);
+  }
 
-    ~OpenPsiImplicatorUTest()
-    {
-        // Clean Up
-        delete _as;
-        _as = nullptr;
-        delete _scm;
-        _scm = nullptr;
+  ~OpenPsiImplicatorUTest()
+  {
+      // Clean Up
+      delete _as;
+      _as = nullptr;
+      delete _scm;
+      _scm = nullptr;
 
-        // Erase the log file if no assertions failed
-        if(!CxxTest::TestTracker::tracker().suiteFailed())
-            std::remove(logger().get_filename().c_str());
-    }
+      // Erase the log file if no assertions failed
+      if(!CxxTest::TestTracker::tracker().suiteFailed())
+          std::remove(logger().get_filename().c_str());
+  }
 
-    void setUp()
-    {
-        // The scheme environment is reset between each test.
-        _as = new AtomSpace();
-        _scm = new SchemeEval(_as);
+  void setUp()
+  {
+      // The scheme environment is reset between each test.
+      _as = new AtomSpace();
+      _scm = new SchemeEval(_as);
 
-        // Configure scheme load-paths that are common for all tests.
-        _scm->eval("(add-to-load-path \"/usr/local/share/opencog/scm\")");
-        CHKERR
-
-        // Load require modules to be tested and populate the atomspace
-        _scm->eval("(use-modules (opencog))");
-        CHKERR
-
-    }
-
-    void tearDown()
-    {
-        delete _as;
-        _as = nullptr;
-    }
-
-    void test_check_satisfiability()
-    {
-      logger().info("BEGIN TEST: %s", __FUNCTION__);
-      // Load test atomspace configuration file.
-      _scm->eval("(load \"" OPENPSI_TEST_PATH "/psi-implicator.scm\")");
+      // Configure scheme load-paths that are common for all tests.
+      _scm->eval("(add-to-load-path \"/usr/local/share/opencog/scm\")");
       CHKERR
 
-      // Common Setup
-      auto rule_1 = _scm->eval_h("(rule-1)");
+      // Load require modules to be tested and populate the atomspace
+      _scm->eval("(use-modules (opencog))");
       CHKERR
-      OpenPsiImplicator imply(_as);
-      TruthValuePtr tv;
 
-      // Test 1:
-      // Test behaviour when there is no grounding.
-      tv = imply.check_satisfiability(rule_1);
-      TSM_ASSERT_EQUALS("Expected (stv 0 1)", TruthValue::FALSE_TV(), tv);
+  }
 
-      // Test 2:
-      // Test behaviour when there is a grounding.
-      _scm->eval("(groundable-content-1)");
-      CHKERR
-      tv = imply.check_satisfiability(rule_1);
-      TSM_ASSERT_EQUALS("Expected (stv 1 1)", TruthValue::TRUE_TV(), tv);
+  void tearDown()
+  {
+      delete _as;
+      _as = nullptr;
+  }
 
-      logger().info("END TEST: %s", __FUNCTION__);
-    }
+  void test_check_satisfiability()
+  {
+    logger().info("BEGIN TEST: %s", __FUNCTION__);
+    // Load test atomspace configuration file.
+    _scm->eval("(load \"" OPENPSI_TEST_PATH "/psi-implicator.scm\")");
+    CHKERR
+
+    // Common Setup
+    auto rule_1 = _scm->eval_h("(rule-1)");
+    CHKERR
+    OpenPsiImplicator imply(_as);
+    TruthValuePtr tv;
+
+    // Test 1:
+    // Test behaviour when there is no grounding.
+    tv = imply.check_satisfiability(rule_1);
+    TSM_ASSERT_EQUALS("Expected (stv 0 1)", TruthValue::FALSE_TV(), tv);
+
+    // Test 2:
+    // Test behaviour when there is a grounding.
+    _scm->eval("(groundable-content-1)");
+    CHKERR
+    tv = imply.check_satisfiability(rule_1);
+    TSM_ASSERT_EQUALS("Expected (stv 1 1)", TruthValue::TRUE_TV(), tv);
+
+    logger().info("END TEST: %s", __FUNCTION__);
+  }
 };

--- a/tests/openpsi/OpenPsiImplicatorUTest.cxxtest
+++ b/tests/openpsi/OpenPsiImplicatorUTest.cxxtest
@@ -37,9 +37,10 @@ class OpenPsiImplicatorUTest : public CxxTest::TestSuite
 private:
   AtomSpace* _as;
   SchemeEval* _scm;
+  OpenPsiImplicator* _opi;
 
 public:
-  OpenPsiImplicatorUTest(): _as(nullptr), _scm(nullptr)
+  OpenPsiImplicatorUTest(): _as(nullptr), _scm(nullptr), _opi(nullptr)
   {
     logger().set_level(Logger::DEBUG);
     logger().set_print_level_flag(true);
@@ -49,10 +50,7 @@ public:
   ~OpenPsiImplicatorUTest()
   {
     // Clean Up
-    delete _as;
-    _as = nullptr;
-    delete _scm;
-    _scm = nullptr;
+    tearDown();
 
     // Erase the log file if no assertions failed
     if(!CxxTest::TestTracker::tracker().suiteFailed())
@@ -64,6 +62,7 @@ public:
     // The scheme environment is reset between each test.
     _as = new AtomSpace();
     _scm = new SchemeEval(_as);
+    _opi = new OpenPsiImplicator(_as);
 
     // Configure scheme load-paths that are common for all tests.
     _scm->eval("(add-to-load-path \"/usr/local/share/opencog/scm\")");
@@ -72,12 +71,21 @@ public:
     // Load require modules to be tested and populate the atomspace
     _scm->eval("(use-modules (opencog))");
     CHKERR
+    logger().info("##### Finished setting up to run a test #####");
   }
 
   void tearDown()
   {
     delete _as;
     _as = nullptr;
+    delete _scm;
+    _scm = nullptr;
+
+    // Reset the cache between each test.
+    _opi->_satisfiability_cache = {};
+    // OpenPsiImplicator::_satisfiability_cache = {};
+    delete _opi;
+    _opi = nullptr;
   }
 
   void test_check_satisfiability()
@@ -90,20 +98,47 @@ public:
     // Common Setup
     auto rule_1 = _scm->eval_h("(rule-1)");
     CHKERR
-    OpenPsiImplicator imply(_as);
     TruthValuePtr tv;
 
     // Test 1:
-    // Test behaviour when there is no grounding.
-    tv = imply.check_satisfiability(rule_1);
+    // Test when there is no grounding.
+    tv = _opi->check_satisfiability(rule_1);
     TSM_ASSERT_EQUALS("Expected (stv 0 1)", TruthValue::FALSE_TV(), tv);
 
     // Test 2:
-    // Test behaviour when there is a grounding.
+    // Test when there is a grounding.
     _scm->eval("(groundable-content-1)");
     CHKERR
-    tv = imply.check_satisfiability(rule_1);
+    tv = _opi->check_satisfiability(rule_1);
     TSM_ASSERT_EQUALS("Expected (stv 1 1)", TruthValue::TRUE_TV(), tv);
+
+    logger().info("END TEST: %s", __FUNCTION__);
+  }
+
+  void test_imply()
+  {
+    logger().info("BEGIN TEST: %s", __FUNCTION__);
+    // Load test atomspace configuration file.
+    _scm->eval("(load \"" OPENPSI_TEST_PATH "/psi-implicator.scm\")");
+    CHKERR
+
+    // Common Setup
+    auto rule_1 = _scm->eval_h("(groundable-content-1) (rule-1)");
+    CHKERR
+
+    // Test 1:
+    // Test when satisfiablity hasn't been checked.
+    Handle result_1 = _opi->imply(rule_1);
+    TSM_ASSERT_EQUALS("Expected null", nullptr, result_1);
+
+    // Test 2:
+    // Test when satisfiablity has been checked.
+    _opi->check_satisfiability(rule_1);
+    Handle result_2 = _opi->imply(rule_1);
+    auto expected_result = _scm->eval_h("(test_imply_solution)");
+    CHKERR
+    TSM_ASSERT_EQUALS("Expected grounded InheritanceLink",
+      expected_result, result_2);
 
     logger().info("END TEST: %s", __FUNCTION__);
   }

--- a/tests/openpsi/OpenPsiUTest.cxxtest
+++ b/tests/openpsi/OpenPsiUTest.cxxtest
@@ -133,8 +133,7 @@ public:
         // execution.
         auto result_2_2 = _scm->eval_tv("(satisfiable? (rule-1))");
         CHKERR
-            TSM_ASSERT_EQUALS("Expected (stv 1 1)", TruthValue::TRUE_TV(), result_2_2);
-
+        TSM_ASSERT_EQUALS("Expected (stv 1 1)", TruthValue::TRUE_TV(), result_2_2);
 
         logger().info("END TEST: %s", __FUNCTION__);
     }

--- a/tests/openpsi/psi-implicator.scm
+++ b/tests/openpsi/psi-implicator.scm
@@ -1,0 +1,34 @@
+(define (rule-1)
+  (Implication
+      (And
+        (InheritanceLink
+          (VariableNode "$H")
+          (ConceptNode "human"))
+        (EvaluationLink
+          (Predicate "eat")
+          (List
+            (VariableNode "$H")
+            (ConceptNode "Beso"))))
+     (InheritanceLink
+        (VariableNode "$H")
+        (ConceptNode "animal"))))
+
+(define (groundable-content-1)
+; Some data to populate the atomspace for grounding (rule-1)
+  (InheritanceLink
+    (ConceptNode "Abeba")
+    (ConceptNode "human"))
+  (EvaluationLink
+    (Predicate "eat")
+    (List
+      (ConceptNode "Abeba")
+      (ConceptNode "Beso")))
+  (InheritanceLink
+    (ConceptNode "Chala")
+    (ConceptNode "human"))
+  (EvaluationLink
+    (Predicate "eat")
+    (List
+      (ConceptNode "Chala")
+      (ConceptNode "Beso")))
+)

--- a/tests/openpsi/psi-implicator.scm
+++ b/tests/openpsi/psi-implicator.scm
@@ -23,12 +23,18 @@
     (List
       (ConceptNode "Abeba")
       (ConceptNode "Beso")))
+  ;(InheritanceLink
+  ;  (ConceptNode "Chala")
+  ;  (ConceptNode "human"))
+  ;(EvaluationLink
+  ;  (Predicate "eat")
+  ;  (List
+  ;    (ConceptNode "Chala")
+  ;    (ConceptNode "Beso")))
+)
+
+(define (test_imply_solution)
   (InheritanceLink
-    (ConceptNode "Chala")
-    (ConceptNode "human"))
-  (EvaluationLink
-    (Predicate "eat")
-    (List
-      (ConceptNode "Chala")
-      (ConceptNode "Beso")))
+    (ConceptNode "Abeba")
+    (ConceptNode "animal"))
 )


### PR DESCRIPTION
Main functionality added is the ability to instantiate actions using groundings from context.

This break OpenPsiUTest. Need to resolve https://github.com/opencog/opencog/pull/2898 before fixing the unit test failure, or might not be needed as refactoring continues.