### PR TITLE
Use 'LEFT-WALL' consistently

### DIFF
--- a/opencog/nlp/learn/scm/mst-parser.scm
+++ b/opencog/nlp/learn/scm/mst-parser.scm
@@ -170,7 +170,7 @@
 
 	; The left-wall indicates the start of the sentence, and
 	; is used to link to the head-verb, head-noun of the sentence.
-	(define left-wall "###LEFT-WALL###")
+	(define left-wall "LEFT-WALL")
 
 	(let* ((pad-text (pad-dash plain-text infix-list))
 			(word-list (string-split pad-text #\ ))


### PR DESCRIPTION
`LEFT-WALL` is used when doing random-parse so all the MI calculation is based on `LEFT-WALL` (with another word), but `###LEFT-WALL###` is used during mst-parse, causing no `LEFT-WALL`-* link get generated.

@linas should I change it to `LEFT-WALL` just to make it consistent, or is there any reason it should be kept this way?