### PR TITLE
Added missing dependency to unit tests (cmake)

### DIFF
--- a/tests/spacetime/CMakeLists.txt
+++ b/tests/spacetime/CMakeLists.txt
@@ -1,6 +1,7 @@
 LINK_LIBRARIES(
 	atom_octomap
 	${ATOMSPACE_LIBRARIES}
+	${COGUTIL_LIBRARY}
 )
 ADD_CXXTEST(AtomOcTreeUTest)
 ADD_CXXTEST(TimeSpaceAtomUTest)


### PR DESCRIPTION
Build failed because libcogutil.so could not be found when building the unit test