### PR TITLE
Fixed AtomSpacePublisherModuleUTest failure

### DIFF
--- a/tests/persist/zmq/events/AtomSpacePublisherModuleUTest.cxxtest
+++ b/tests/persist/zmq/events/AtomSpacePublisherModuleUTest.cxxtest
@@ -326,6 +326,9 @@ public:
         subscriberAVChanged.close();
         subscriberAddAF.close();
         subscriberRemoveAF.close();
-        context.close();
+
+	// BUGFIX: context destructor doing same as close method
+	//         This causes rc to be -1 instead of 0
+        //context.close();
     }
 };


### PR DESCRIPTION
Both close and destructor of zmq::context_t call the same code, which causes the destructor to fail.
Not sure if this is a bug in zmq, but at least this commit should prevent the unit test from failing

from zmq.hpp:
```
        inline ~context_t () ZMQ_NOTHROW
        {
            int rc = zmq_ctx_destroy (ptr);
            ZMQ_ASSERT (rc == 0);
        }

        inline void close() ZMQ_NOTHROW
        {
            int rc = zmq_ctx_destroy (ptr);
            ZMQ_ASSERT (rc == 0);
        }
```