### PR TITLE
Build Python3 by default, if Python3 is found.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -385,18 +385,13 @@ IF (HAVE_PY_INTERP)
 		# differ on each operating system.
 		ADD_DEFINITIONS(-DHAVE_CYTHON)
 		SET(HAVE_CYTHON 1)
-		EXECUTE_PROCESS(
-			COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import *;print(get_python_lib())"
-			OUTPUT_VARIABLE PYTHON_DEST
-		)
 
-		# Replace new line at end.
-		STRING(REPLACE "\n" "" PYTHON_DEST "${PYTHON_DEST}")
-		IF ("${PYTHON_DEST}" STREQUAL "")
-			MESSAGE(FATAL_ERROR "Python destination dir not found")
-		ELSE ("${PYTHON_DEST}" STREQUAL "")
-			MESSAGE(STATUS "Python destination dir found: ${PYTHON_DEST}" )
-		ENDIF ("${PYTHON_DEST}" STREQUAL "")
+		# Hack together some reasonable install location.
+		SET(PYTHON_DEST
+			"lib${LIB_DIR_SUFFIX}/${PYTHON_VER}/dist-packages/opencog")
+		MESSAGE(STATUS
+			"Python install dir: ${CMAKE_INSTALL_PREFIX}/${PYTHON_DEST}" )
+
 	ELSE (CYTHON_FOUND AND HAVE_PY_LIBS)
 		IF(NOT CYTHON_FOUND)
 			MESSAGE(STATUS "Cython executable not found.")
@@ -404,9 +399,14 @@ IF (HAVE_PY_INTERP)
 	ENDIF (CYTHON_FOUND AND HAVE_PY_LIBS)
 
 	# Nosetests will find and automatically run python tests.
-	FIND_PROGRAM(NOSETESTS_EXECUTABLE nosetests)
+	IF (PYTHON3INTERP_FOUND)
+		FIND_PROGRAM(NOSETESTS_EXECUTABLE nosetests3)
+	ELSE ()
+		FIND_PROGRAM(NOSETESTS_EXECUTABLE nosetests)
+	ENDIF ()
 	IF (NOSETESTS_EXECUTABLE AND CYTHON_FOUND AND HAVE_PY_LIBS)
 		SET(HAVE_NOSETESTS 1)
+		MESSAGE(STATUS "Using nosetests executable " ${NOSETESTS_EXECUTABLE})
 	ENDIF (NOSETESTS_EXECUTABLE AND CYTHON_FOUND AND HAVE_PY_LIBS)
 ENDIF (HAVE_PY_INTERP)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -346,20 +346,30 @@ MESSAGE(STATUS "${PROTOBUF_DIR_MESSAGE}")
 # -----------------------------------------------------------------------------
 # Python and Cython
 #
-# NOTE: Python interpreter is needed for runing python unit tests, and for
-# running the FindCython and FindCxxtest cmake modules.
+# NOTE: Python interpreter is needed for runing python unit tests,
+# and for running the FindCython module.
 
-FIND_PACKAGE(PythonInterp 2.7)
-IF (2.7.0 VERSION_LESS ${PYTHON_VERSION_STRING} AND
-	3.0.0 VERSION_GREATER ${PYTHON_VERSION_STRING})
+FIND_PACKAGE(Python3Interp)
+IF (3.4.0 VERSION_LESS ${PYTHON3_VERSION_STRING})
 	SET (HAVE_PY_INTERP 1)
-	MESSAGE(STATUS "Python ${PYTHON_VERSION_STRING} interpreter found.")
+	SET (PYTHON_VER python3.5)
+	MESSAGE(STATUS "Python ${PYTHON3_VERSION_STRING} interpreter found.")
 ENDIF()
 
-FIND_PACKAGE(PythonLibs 2.7)
+IF (NOT HAVE_PY_INTERP)
+	FIND_PACKAGE(PythonInterp)
+	IF (2.7.0 VERSION_LESS ${PYTHON_VERSION_STRING})
+		SET (HAVE_PY_INTERP 1)
+		SET (PYTHON_VER python2.7)
+		MESSAGE(STATUS "Python ${PYTHON_VERSION_STRING} interpreter found.")
+	ENDIF()
+ENDIF()
+
+FIND_PACKAGE(PythonLibs)
 IF (PYTHONLIBS_FOUND AND
-	2.7.0 VERSION_LESS ${PYTHONLIBS_VERSION_STRING} AND
-	3.0.0 VERSION_GREATER ${PYTHONLIBS_VERSION_STRING})
+     ((PYTHON3INTERP_FOUND AND 3.4.0 VERSION_LESS ${PYTHONLIBS_VERSION_STRING})
+     OR
+     (2.7.0 VERSION_LESS ${PYTHONLIBS_VERSION_STRING})))
 	SET (HAVE_PY_LIBS 1)
 	MESSAGE(STATUS "Python ${PYTHONLIBS_VERSION_STRING} libraries found.")
 ELSE()
@@ -367,7 +377,7 @@ ELSE()
 ENDIF()
 
 # Cython is used to generate python bindings.
-IF(HAVE_PY_INTERP)
+IF (HAVE_PY_INTERP)
 	FIND_PACKAGE(Cython 0.19.0)
 
 	IF (CYTHON_FOUND AND HAVE_PY_LIBS)
@@ -398,7 +408,7 @@ IF(HAVE_PY_INTERP)
 	IF (NOSETESTS_EXECUTABLE AND CYTHON_FOUND AND HAVE_PY_LIBS)
 		SET(HAVE_NOSETESTS 1)
 	ENDIF (NOSETESTS_EXECUTABLE AND CYTHON_FOUND AND HAVE_PY_LIBS)
-ENDIF(HAVE_PY_INTERP)
+ENDIF (HAVE_PY_INTERP)
 
 # -----------------------------------------------------------------------------
 

--- a/lib/FindCxxtest.cmake
+++ b/lib/FindCxxtest.cmake
@@ -87,3 +87,6 @@ IF(NOT CXXTEST_FOUND)
 		ENDIF(Cxxtest_FIND_REQUIRED)
 	ENDIF(NOT Cxxtest_FIND_QUIETLY)
 ENDIF(NOT CXXTEST_FOUND)
+
+# Leaving this set interfers with the Python3 search.
+UNSET(PYTHONINTERP_FOUND)

--- a/lib/FindPython3Interp.cmake
+++ b/lib/FindPython3Interp.cmake
@@ -1,0 +1,45 @@
+# Find the Python3 interpreter.
+#
+# NB: Generally, :code:`FindPythonInterp.cmake` as shipped by cmake
+# is able to find a python3 interpreter by working with version numbers. This find module
+# does some gymnastics to be able to find BOTH python2 and python3
+# interpreters within the same project, which does not seem possible
+# with the modules provided from upstream.
+#
+#
+# When using this to look for Python3, you should use
+# FindPython2Interp.cmake to look for the Python2 interpreter.
+#
+# This module sets the following variables:
+#
+#  PYTHON3INTERP_FOUND         - Was the Python executable found
+#  PYTHON3_EXECUTABLE          - path to the Python interpreter
+#
+#  PYTHON3_VERSION_STRING      - Python version found e.g. 2.5.2
+#  PYTHON3_VERSION_MAJOR       - Python major version found e.g. 2
+#  PYTHON3_VERSION_MINOR       - Python minor version found e.g. 5
+#  PYTHON3_VERSION_PATCH       - Python patch version found e.g. 2
+#
+
+# Nuke the cache, somebody might have looked for Python 2...
+if(PYTHONINTERP_FOUND)
+  message(WARNING "Please look for Python3 before looking for Python2...")
+endif()
+unset(PYTHON_EXECUTABLE CACHE)
+set(PYTHONINTERP_FOUND FALSE)
+
+find_package(PythonInterp 3 QUIET)
+find_package_handle_standard_args(Python3Interp
+                                  REQUIRED_VARS PYTHON_EXECUTABLE)
+
+# Set all those variables that we promised
+set(PYTHON3_EXECUTABLE ${PYTHON_EXECUTABLE})
+set(PYTHON3_VERSION_STRING ${PYTHON_VERSION_STRING})
+set(PYTHON3_VERSION_MAJOR ${PYTHON_VERSION_MAJOR})
+set(PYTHON3_VERSION_MINOR ${PYTHON_VERSION_MINOR})
+set(PYTHON3_VERSION_PATCH ${PYTHON_VERSION_PATCH})
+
+# Now nuke the cache to allow later rerunning of find_package(PythonInterp)
+# with a different required version number.
+unset(PYTHON_EXECUTABLE CACHE)
+set(PYTHONINTERP_FOUND FALSE)

--- a/opencog/cogserver/modules/python/PythonModule.cc
+++ b/opencog/cogserver/modules/python/PythonModule.cc
@@ -134,9 +134,7 @@ void PythonModule::init()
 
     // Many python libraries (e.g. ROS) expect sys.argv to be set. So,
     // avoid the error print, and let them know who we are.
-    static const char *argv0 = "cogserver";
-    PySys_SetArgv(1, (char **) &argv0);
-
+    PyRun_SimpleString("import sys; sys.argv='cogserver'\n");
 
     // NOTE: Even though the Cython docs do not say that you need to call this
     // more than once, you need to call the import functions in each separate

--- a/opencog/cython/CMakeLists.txt
+++ b/opencog/cython/CMakeLists.txt
@@ -1,8 +1,6 @@
 #
 ADD_SUBDIRECTORY (opencog)
 
-# direct file and path creation for stuff that doesn't need to be compiled
-file(MAKE_DIRECTORY opencog)
 # module init
+file(MAKE_DIRECTORY opencog)
 file(COPY opencog/__init__.py DESTINATION opencog)
-##

--- a/opencog/cython/opencog/CMakeLists.txt
+++ b/opencog/cython/opencog/CMakeLists.txt
@@ -55,7 +55,7 @@ IF (HAVE_ATOMSPACE)
 	ADD_DEPENDENCIES(cogserver_type_constructors nlp_atom_types)
 	ADD_DEPENDENCIES(cogserver_type_constructors attention_atom_types)
 	ADD_DEPENDENCIES(cogserver_type_constructors spacetime_atom_types)
-	ADD_DEPENDENCIES(cogserver_type_constructors patternminer_types)
+	ADD_DEPENDENCIES(cogserver_type_constructors patternminer_atom_types)
 
 	TARGET_LINK_LIBRARIES(cogserver_type_constructors
 		attention-types

--- a/opencog/cython/opencog/CMakeLists.txt
+++ b/opencog/cython/opencog/CMakeLists.txt
@@ -71,7 +71,7 @@ IF (HAVE_ATOMSPACE)
 		OUTPUT_NAME cogserver_type_constructors)
 
 	INSTALL (TARGETS cogserver_type_constructors
-		DESTINATION "lib${LIB_DIR_SUFFIX}/python2.7/dist-packages/opencog")
+		DESTINATION "${PYTHON_DEST}")
 
 ENDIF (HAVE_ATOMSPACE)
 
@@ -103,7 +103,7 @@ IF (HAVE_SERVER)
 		OUTPUT_NAME cogserver)
 
 	INSTALL (TARGETS cogserver_cython
-		DESTINATION "lib${LIB_DIR_SUFFIX}/python2.7/dist-packages/opencog")
+		DESTINATION "${PYTHON_DEST}")
 
 	####################### agent finder ########################
 	CYTHON_ADD_MODULE_PYX(agent_finder
@@ -132,7 +132,7 @@ IF (HAVE_SERVER)
 		OUTPUT_NAME agent_finder)
 
 	INSTALL (TARGETS agent_finder
-		DESTINATION "lib${LIB_DIR_SUFFIX}/python2.7/dist-packages/opencog")
+		DESTINATION "${PYTHON_DEST}")
 ENDIF(HAVE_SERVER)
 
 IF (HAVE_STATISTICS)
@@ -160,9 +160,9 @@ IF (HAVE_STATISTICS)
 		OUTPUT_NAME statistics)
 
 	INSTALL (TARGETS statistics_cython
-		DESTINATION "lib${LIB_DIR_SUFFIX}/python2.7/dist-packages/opencog")
+		DESTINATION "${PYTHON_DEST}")
 ENDIF (HAVE_STATISTICS)
 
 INSTALL (FILES
 	__init__.py
-	DESTINATION "lib${LIB_DIR_SUFFIX}/python2.7/dist-packages/opencog")
+	DESTINATION "${PYTHON_DEST}")

--- a/opencog/nlp/anaphora/agents/hobbs.py
+++ b/opencog/nlp/anaphora/agents/hobbs.py
@@ -7,7 +7,7 @@ from opencog.scheme_wrapper import load_scm, scheme_eval_h, scheme_eval, __init_
 from opencog.cogserver_type_constructors import *
 from opencog import logger
 
-import Queue
+import queue
 import time
 
 __author__ = 'Hujie Wang'
@@ -312,7 +312,7 @@ class HobbsAgent(MindAgent):
         if node==None:
             #print("found you bfs")
             return
-        q=Queue.Queue()
+        q=queue.Queue()
         q.put(node)
         while not q.empty():
             front=q.get()

--- a/opencog/python/CMakeLists.txt
+++ b/opencog/python/CMakeLists.txt
@@ -1,12 +1,7 @@
 
-#
-# TODO - these should be in their own opencog module.
-# XXX This is a really terrible naming convention, the web api
-# should not be pretending that its something generic, and not
-# merely opencog-specific. FIXME
 INSTALL (FILES
 	web/__init__.py
-	DESTINATION "lib${LIB_DIR_SUFFIX}/python2.7/dist-packages/web")
+	DESTINATION "${PYTHON_DEST}/web")
 
 INSTALL (FILES
 	web/api/apiatomcollection.py
@@ -18,9 +13,9 @@ INSTALL (FILES
 	web/api/mappers.py
 	web/api/restapi.py
 	web/api/utilities.py
-	DESTINATION "lib${LIB_DIR_SUFFIX}/python2.7/dist-packages/web/api")
+	DESTINATION "${PYTHON_DEST}/web/api")
 
 INSTALL (FILES
 	web/socketio/atomspace_publisher.py
 	web/socketio/__init__.py
-	DESTINATION "lib${LIB_DIR_SUFFIX}/python2.7/dist-packages/web/socketio")
+	DESTINATION "${PYTHON_DEST}/web/socketio")


### PR DESCRIPTION
This requires opencog/atomspace#1567 as a pre-requisite.

It is strongly suggested that, when pulling and building, that a `make clean` be done first, as well as removing the `build/CMakeCache.txt` file, as otherwise there is a strong risk of mixing python2 and python3 together in the libraries, which will cause some unit tests to fail.