### PR TITLE
URE pattern miner progress

### DIFF
--- a/opencog/learning/xpattern-miner/ure-based/pm-config.scm
+++ b/opencog/learning/xpattern-miner/ure-based/pm-config.scm
@@ -28,8 +28,7 @@
 
 ;; Load the rules (use load for relative path w.r.t. to that file)
 (add-to-load-path ".")
-(define rule-files (list ;; "rules/top-abstraction.scm"
-                         "rules/shallow-abstraction.scm"
+(define rule-files (list "rules/shallow-abstraction.scm"
                          "rules/specialization.scm"))
 (for-each load-from-path rule-files)
 
@@ -38,8 +37,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; List the rules and their weights.
-(define rules (list ;; top-abstraction-rule-name
-                    unary-specialization-rule-name
+(define rules (list unary-specialization-rule-name
                     binary-first-arg-specialization-rule-name
                     binary-second-arg-specialization-rule-name
                     ternary-first-arg-specialization-rule-name

--- a/opencog/learning/xpattern-miner/ure-based/pm-config.scm
+++ b/opencog/learning/xpattern-miner/ure-based/pm-config.scm
@@ -28,7 +28,7 @@
 
 ;; Load the rules (use load for relative path w.r.t. to that file)
 (add-to-load-path ".")
-(define rule-files (list "rules/top-abstraction.scm"
+(define rule-files (list ;; "rules/top-abstraction.scm"
                          "rules/shallow-abstraction.scm"
                          "rules/specialization.scm"))
 (for-each load-from-path rule-files)

--- a/opencog/learning/xpattern-miner/ure-based/pm-config.scm
+++ b/opencog/learning/xpattern-miner/ure-based/pm-config.scm
@@ -38,10 +38,13 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; List the rules and their weights.
-(define rules (list top-abstraction-rule-name
+(define rules (list ;; top-abstraction-rule-name
                     unary-specialization-rule-name
                     binary-first-arg-specialization-rule-name
-                    binary-second-arg-specialization-rule-name))
+                    binary-second-arg-specialization-rule-name
+                    ternary-first-arg-specialization-rule-name
+                    ternary-second-arg-specialization-rule-name
+                    ternary-third-arg-specialization-rule-name))
 
 ; Associate rules to PLN
 (ure-add-rules pm-rbs rules)

--- a/opencog/learning/xpattern-miner/ure-based/rules/specialization.scm
+++ b/opencog/learning/xpattern-miner/ure-based/rules/specialization.scm
@@ -1,8 +1,9 @@
-;; Rule to specialize a pattern and relate its specialization to its
-;; minimum support.
+;; Rule to specialize a pattern by composing it with a shallow
+;; abstraction, a constant, or a variable, and checks that it has
+;; enough support.
 ;;
-;; Given 2 patterns, g with arity n and with support ms, and f,
-;; specialize g by composing it with f over one of its variables, xi.
+;; Given g with arity n and with support ms, and f, specialize g by
+;; composing it with f over one of its variables, xi.
 ;;
 ;; Evaluation <tv1>
 ;;   Predicate "minsup"
@@ -22,23 +23,26 @@
 ;;     Put
 ;;       Lambda
 ;;         VariableList
-;;           <x0>
+;;           <x1>
 ;;           ...
-;;           <xn-1>
+;;           <xn>
 ;;         <g-body>
 ;;       List
-;;         <x0>
+;;         <x1>
 ;;         ...
 ;;         <xi-1>
 ;;         <f>
 ;;         <xi+1>
 ;;         ...
-;;         <xm>
+;;         <xn>
 ;;     <ms>
 ;;
 ;; assuming that tv1 equals to (stv 1 1), then calculate the frequency
-;; of the composed pattern and set tv2 accordingly, (stv 1 1) is g
+;; of the composed pattern and set tv2 accordingly, (stv 1 1) if g
 ;; composed with f has support ms, (stv 0 1) otherwise.
+;;
+;; <f> may either a shallow pattern (a function), a constant or a
+;; variable amongst <x1> to <xn> different than <xi>.
 ;;
 ;; TODO: we might want to split such rule into 2,
 ;;
@@ -50,8 +54,8 @@
 
 (load "pattern-miner-utils.scm")
 
-;; Generate specialization rule for a given arity and argument index
-;; ranging from 0 to arity-1.
+;; Generate composition specialization rule for a given arity and
+;; argument index ranging from 0 to arity-1.
 ;;
 ;; For instance (gen-specialization-rule 2 1) generates the following rule
 ;;
@@ -89,19 +93,19 @@
          (ms (Variable "$ms"))
          (f (Variable "$f"))
          ;; Types
-         (VariableT (Type "VariableNode"))
          (NumberT (Type "NumberNode"))
          (LambdaT (Type "LambdaLink"))
          (ConceptT (Type "ConceptNode"))
+         (VariableT (Type "VariableNode"))
          (PutT (Type "PutLink"))
          ;; Vardecls
          (g-decl (TypedVariable g (TypeChoice LambdaT PutT)))
          (texts-decl (TypedVariable texts ConceptT))
          (ms-decl (TypedVariable ms NumberT))
-         ;; TODO: for now hardwire the type of f, then later only
-         ;; accept shallow abstractions according to the
-         ;; "shallow-abstraction-of" predicate
-         (f-decl (TypedVariable f (TypeChoice LambdaT PutT ConceptT)))
+         ;; TODO: for now hardwire the types of f, then later only
+         ;; accept shallow abstractions, constants from valuations, or
+         ;; variables from the variables of g.
+         (f-decl (TypedVariable f (TypeChoice LambdaT ConceptT VariableT)))
          (vardecl (VariableList g-decl texts-decl ms-decl f-decl))
          ;; Patterns
          (minsup-g (minsup g texts ms))

--- a/opencog/learning/xpattern-miner/ure-based/rules/specialization.scm
+++ b/opencog/learning/xpattern-miner/ure-based/rules/specialization.scm
@@ -62,7 +62,7 @@
 ;;       VariableList
 ;;         <x0>
 ;;         <x1>
-;;       <g>
+;;       <g-body>
 ;;     <texts>
 ;;     <ms>
 ;; <f>
@@ -101,7 +101,7 @@
          ;; TODO: for now hardwire the type of f, then later only
          ;; accept shallow abstractions according to the
          ;; "shallow-abstraction-of" predicate
-         (f-decl (TypedVariable f (TypeChoice LambdaT ConceptT)))
+         (f-decl (TypedVariable f (TypeChoice LambdaT PutT ConceptT)))
          (vardecl (VariableList g-decl texts-decl ms-decl f-decl))
          ;; Patterns
          (minsup-g (minsup g texts ms))

--- a/opencog/learning/xpattern-miner/ure-based/rules/specialization.scm
+++ b/opencog/learning/xpattern-miner/ure-based/rules/specialization.scm
@@ -143,7 +143,6 @@
       (let* ((pre-minsup-pred (car premises))
              (con-minsup-args (gdr conclusion))
              (pre-minsup-pred-tv (cog-tv pre-minsup-pred))
-             (f-lamb (car (cdr premises)))
              (gf (cog-outgoing-atom con-minsup-args 0))
              (texts (cog-outgoing-atom con-minsup-args 1))
              (ms-atom (cog-outgoing-atom con-minsup-args 2))
@@ -204,7 +203,7 @@
   ternary-second-arg-specialization-rule)
 
 (define ternary-third-arg-specialization-rule
-  (gen-specialization-rule 3 1))
+  (gen-specialization-rule 3 2))
 (define ternary-third-arg-specialization-rule-name
   (DefinedSchemaNode "ternary-third-arg-specialization-rule"))
 (DefineLink ternary-third-arg-specialization-rule-name

--- a/opencog/learning/xpattern-miner/ure-based/rules/specialization.scm
+++ b/opencog/learning/xpattern-miner/ure-based/rules/specialization.scm
@@ -183,3 +183,25 @@
   (DefinedSchemaNode "binary-second-arg-specialization-rule"))
 (DefineLink binary-second-arg-specialization-rule-name
   binary-second-arg-specialization-rule)
+
+;; Define ternary specialization
+(define ternary-first-arg-specialization-rule
+  (gen-specialization-rule 3 0))
+(define ternary-first-arg-specialization-rule-name
+  (DefinedSchemaNode "ternary-first-arg-specialization-rule"))
+(DefineLink ternary-first-arg-specialization-rule-name
+  ternary-first-arg-specialization-rule)
+
+(define ternary-second-arg-specialization-rule
+  (gen-specialization-rule 3 1))
+(define ternary-second-arg-specialization-rule-name
+  (DefinedSchemaNode "ternary-second-arg-specialization-rule"))
+(DefineLink ternary-second-arg-specialization-rule-name
+  ternary-second-arg-specialization-rule)
+
+(define ternary-third-arg-specialization-rule
+  (gen-specialization-rule 3 1))
+(define ternary-third-arg-specialization-rule-name
+  (DefinedSchemaNode "ternary-third-arg-specialization-rule"))
+(DefineLink ternary-third-arg-specialization-rule-name
+  ternary-third-arg-specialization-rule)

--- a/opencog/learning/xpattern-miner/ure-based/rules/specialization.scm
+++ b/opencog/learning/xpattern-miner/ure-based/rules/specialization.scm
@@ -148,7 +148,7 @@
                                 ;; g has enough support, let see if
                                 ;; g.f has enough support
                                 (let ((sup (support gf texts ms)))
-                                  (if (equal? ms sup)
+                                  (if (<= ms sup)
                                       (stv 1 1)
                                       #f)) ; It is ill-formed
                                 ;; g does not have enough support,

--- a/opencog/learning/xpattern-miner/ure-based/rules/top-abstraction.scm
+++ b/opencog/learning/xpattern-miner/ure-based/rules/top-abstraction.scm
@@ -26,10 +26,6 @@
 
 (load "pattern-miner-utils.scm")
 
-(define top
-  (let ((top-arg (Variable "$top-arg")))
-    (Lambda top-arg top-arg)))
-
 ;; Note that due to the texts-ge-ms precondition, it will not be able
 ;; to proof its contrary, i.e. <tv> will never be assigned (stv 0 1).
 ;; To remedy that we may move texts-gt-ms in the formula.

--- a/tests/learning/xpattern-miner/ure-based/UREPatternMinerUTest.cxxtest
+++ b/tests/learning/xpattern-miner/ure-based/UREPatternMinerUTest.cxxtest
@@ -197,13 +197,13 @@ bool UREPatternMinerUTest::enough_support(const Handle& pat, int minsup)
 UREPatternMinerUTest::UREPatternMinerUTest() : _scm(&_as)
 {
 	// Main logger
-	logger().set_level(Logger::DEBUG);
+	logger().set_level(Logger::INFO);
 	logger().set_timestamp_flag(false);
 	logger().set_sync_flag(true);
 	logger().set_print_to_stdout_flag(true);
 
 	// URE logger
-	ure_logger().set_level(Logger::DEBUG);
+	ure_logger().set_level(Logger::INFO);
 	ure_logger().set_timestamp_flag(false);
 	ure_logger().set_sync_flag(true);
 	ure_logger().set_print_to_stdout_flag(true);
@@ -253,6 +253,7 @@ void UREPatternMinerUTest::test_A()
 
 	Handle query = mk_query({A}, 2, 1);
 	BackwardChainer bc(_as, pm_rb, query);
+	bc.get_config().set_maximum_iterations(100);
 	bc.do_chain();
 
 	Handle results = bc.get_results(),
@@ -458,19 +459,24 @@ void UREPatternMinerUTest::test_ABAB()
 // 	Handle X = tmp_an(VARIABLE_NODE, "$X"),
 // 		Y = tmp_an(VARIABLE_NODE, "$Y"),
 // 		initpat = tmp_al(LAMBDA_LINK,
-// 		                 tmp_al(IMPLICATION_LINK, X, Y));
+// 		                 tmp_al(IMPLICATION_LINK, X, Y)),
+// 		query = mk_query({AAAA, BBBB}, 2, 4, initpat);
 
-// 	XPMParameters param(2, 1, initpat);
-// 	XPatternMiner pm(_as, param);
-// 	HandleTree results = pm();
+// 	BackwardChainer bc(_as, pm_rb, query);
+// 	bc.get_config().set_maximum_iterations(1000);
+// 	bc.do_chain();
 
-// 	Handle XX = tmp_al(INHERITANCE_LINK, X, X),
-// 		expected = tmp_al(LAMBDA_LINK, tmp_al(IMPLICATION_LINK, XX, XX));
+// 	Handle results = bc.get_results(),
+// 		InhXX = tmp_al(INHERITANCE_LINK, X, X),
+// 		expected = tmp_al(LAMBDA_LINK,
+// 		                  tmp_al(IMPLICATION_LINK,
+// 		                         InhXX,
+// 		                         InhXX));
 
 // 	logger().debug() << "results = " << oc_to_string(results);
 // 	logger().debug() << "expected = " << oc_to_string(expected);
 
-// 	TS_ASSERT(content_is_in(expected, results));
+// 	TS_ASSERT(is_in(expected, results->getOutgoingSet()));
 // }
 
 // void UREPatternMinerUTest::test_2conjuncts_1()

--- a/tests/learning/xpattern-miner/ure-based/UREPatternMinerUTest.cxxtest
+++ b/tests/learning/xpattern-miner/ure-based/UREPatternMinerUTest.cxxtest
@@ -98,7 +98,7 @@ public:
 	void test_AB_AC();
 	void test_AB_AC_BC();
 	void test_AB_ABC();
-	// void test_ABCD();
+	void test_ABCD();
 	// void test_ABAB();
 	// void test_AAAA();
 	// void test_2conjuncts_1();
@@ -314,53 +314,51 @@ void UREPatternMinerUTest::test_AB_ABC()
 	TS_ASSERT(content_eq(results, expected));
 }
 
-// void UREPatternMinerUTest::test_ABCD()
-// {
-// 	logger().info("BEGIN TEST: %s", __FUNCTION__);
+void UREPatternMinerUTest::test_ABCD()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-// 	Handle A = an(CONCEPT_NODE, "A"),
-// 		B = an(CONCEPT_NODE, "B"),
-// 		C = an(CONCEPT_NODE, "C"),
-// 		D = an(CONCEPT_NODE, "D"),
-// 		E = an(CONCEPT_NODE, "E"),
-// 		F = an(CONCEPT_NODE, "F"),
-// 		G = an(CONCEPT_NODE, "G"),
-// 		H = an(CONCEPT_NODE, "H"),
-// 		AB = al(INHERITANCE_LINK, A, B),
-// 		CD = al(INHERITANCE_LINK, C, D),
-// 		EF = al(INHERITANCE_LINK, E, F),
-// 		GH = al(INHERITANCE_LINK, G, H),
-// 		ABCD = al(IMPLICATION_LINK, AB, AB),
-// 		EFGH = al(IMPLICATION_LINK, EF, GH);
+	Handle A = an(CONCEPT_NODE, "A"),
+		B = an(CONCEPT_NODE, "B"),
+		C = an(CONCEPT_NODE, "C"),
+		D = an(CONCEPT_NODE, "D"),
+		E = an(CONCEPT_NODE, "E"),
+		F = an(CONCEPT_NODE, "F"),
+		G = an(CONCEPT_NODE, "G"),
+		H = an(CONCEPT_NODE, "H"),
+		InhAB = al(INHERITANCE_LINK, A, B),
+		InhCD = al(INHERITANCE_LINK, C, D),
+		InhEF = al(INHERITANCE_LINK, E, F),
+		InhGH = al(INHERITANCE_LINK, G, H),
+		ImpABCD = al(IMPLICATION_LINK, InhAB, InhAB),
+		ImpEFGH = al(IMPLICATION_LINK, InhEF, InhGH),
+		X = an(VARIABLE_NODE, "$X"),
+		Y = an(VARIABLE_NODE, "$Y"),
+		Z = an(VARIABLE_NODE, "$Z"),
+		W = an(VARIABLE_NODE, "$W"),
+		InhXY = al(INHERITANCE_LINK, X, Y),
+		InhZW = al(INHERITANCE_LINK, Z, W),
+		ImpXY = al(IMPLICATION_LINK, X, Y),
+		initpat = al(LAMBDA_LINK, ImpXY),
+		query = mk_query({InhAB, InhCD, InhEF, InhGH, ImpABCD, ImpEFGH}, 2, initpat);
 
-// 	Handle X = tmp_an(VARIABLE_NODE, "$X"),
-// 		Y = tmp_an(VARIABLE_NODE, "$Y"),
-// 		initpat = tmp_al(LAMBDA_LINK,
-// 		                 tmp_al(IMPLICATION_LINK, X, Y));
+	BackwardChainer bc(_as, pm_rb, query);
+	bc.get_config().set_maximum_iterations(50);
+	bc.do_chain();
 
-// 	XPMParameters param(2, 1, initpat);
-// 	XPatternMiner pm(_as, param);
-// 	HandleTree results = pm();
+	Handle results = bc.get_results(),
+		expected = mk_minsup_evals(2,
+		                           { top,
+				                     al(LAMBDA_LINK, al(IMPLICATION_LINK, Z, InhXY)),
+				                     al(LAMBDA_LINK, al(IMPLICATION_LINK, InhZW, InhXY)),
+				                     al(LAMBDA_LINK, al(IMPLICATION_LINK, InhXY, Z)),
+				                     al(LAMBDA_LINK, al(IMPLICATION_LINK, InhZW, InhXY)) });
 
-// 	Handle Z = tmp_an(VARIABLE_NODE, "$Z"),
-// 		W = tmp_an(VARIABLE_NODE, "$W"),
-// 		XY = tmp_al(INHERITANCE_LINK, X, Y),
-// 		ZW = tmp_al(INHERITANCE_LINK, Z, W);
-// 	HandleTree expected{ HandleTree(tmp_al(LAMBDA_LINK,
-// 	                                       tmp_al(IMPLICATION_LINK, Z, XY)),
-// 	                                { tmp_al(LAMBDA_LINK,
-// 	                                         tmp_al(IMPLICATION_LINK, ZW, XY)) }),
-// 			             HandleTree(tmp_al(LAMBDA_LINK,
-// 			                               tmp_al(IMPLICATION_LINK, XY, Z)),
-// 	                                { tmp_al(LAMBDA_LINK,
-// 	                                         tmp_al(IMPLICATION_LINK, ZW, XY)) })
-// 			            };
+	logger().debug() << "results = " << oc_to_string(results);
+	logger().debug() << "expected = " << oc_to_string(expected);
 
-// 	logger().debug() << "results = " << oc_to_string(results);
-// 	logger().debug() << "expected = " << oc_to_string(expected);
-
-// 	TS_ASSERT(content_eq(expected, results));
-// }
+	TS_ASSERT(content_eq(expected, results));
+}
 
 // void UREPatternMinerUTest::test_ABAB()
 // {

--- a/tests/learning/xpattern-miner/ure-based/UREPatternMinerUTest.cxxtest
+++ b/tests/learning/xpattern-miner/ure-based/UREPatternMinerUTest.cxxtest
@@ -26,11 +26,10 @@
 
 #include <opencog/util/Config.h>
 #include <opencog/util/algorithm.h>
+#include <opencog/truthvalue/SimpleTruthValue.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/rule-engine/backwardchainer/BackwardChainer.h>
 #include <opencog/rule-engine/URELogger.h>
-#include <opencog/learning/xpattern-miner/c++-based/HandleTree.h>
-#include <opencog/learning/xpattern-miner/c++-based/XPatternMiner.h>
 #include <opencog/guile/SchemeEval.h>
 
 #include <vector>
@@ -54,7 +53,7 @@ private:
 	Handle X, Y, Z, W;
 
 	// Constants
-	Handle A, B, C, D;
+	Handle A, B, C, D, E, F, G, H;
 
 	// Pattern miner rule base
 	Handle pm_rb;
@@ -75,15 +74,32 @@ private:
 	 *   (Predicate "minsup")
 	 *   (List pattern (Concept "texts") minsup))
 	 */
-	Handle mk_minsup_eval(int minsup, const Handle& pattern);
-	Handle mk_minsup_evals(int minsup, const HandleSeq& patterns);
+	Handle mk_minsup_eval(int minsup,
+	                      const Handle& pattern,
+	                      TruthValuePtr tv=TruthValue::DEFAULT_TV());
+	Handle mk_minsup_evals(int minsup,
+	                       const HandleSeq& patterns,
+	                       TruthValuePtr tv=TruthValue::DEFAULT_TV());
 
 	/**
 	 * Make a URE query to mine patterns over texts with a given
 	 * minsup and a maximum of URE iterations.
 	 */
 	Handle mk_query(const HandleSeq& texts, int minsup,
-	                const Handle& initpat=Handle::UNDEFINED);
+	                int depth, Handle initpat=Handle::UNDEFINED);
+
+	/**
+	 * Gen shallow pattern variables for the query, for instance if i
+	 * = 2, return
+	 *
+	 * (Variable "$shapat-2")
+	 */
+	Handle gen_shapat_var(int i);
+
+	/**
+	 * Return whether if a pattern has enough support.
+	 */
+	bool enough_support(const Handle& pat, int ms);
 
 public:
 	UREPatternMinerUTest();
@@ -110,50 +126,86 @@ public:
 	// void test_SodaDrinker();
 };
 
-Handle UREPatternMinerUTest::mk_minsup_eval(int minsup, const Handle& pattern)
+Handle UREPatternMinerUTest::mk_minsup_eval(int minsup,
+                                            const Handle& pattern,
+                                            TruthValuePtr tv)
 {
-	return al(EVALUATION_LINK,
-	          minsup_prd,
-	          al(LIST_LINK,
-	             pattern,
-	             texts_cpt,
-	             an(NUMBER_NODE, to_string(minsup))));
+	Handle minsup_eval_h = al(EVALUATION_LINK,
+	                          minsup_prd,
+	                          al(LIST_LINK,
+	                             pattern,
+	                             texts_cpt,
+	                             an(NUMBER_NODE, to_string(minsup))));
+	minsup_eval_h->setTruthValue(tv);
+	return minsup_eval_h;
 }
 
 Handle UREPatternMinerUTest::mk_minsup_evals(int minsup,
-                                             const HandleSeq& patterns)
+                                             const HandleSeq& patterns,
+                                             TruthValuePtr tv)
 {
 	HandleSeq minsup_evals;
 	for (const Handle& pat : patterns)
-		minsup_evals.push_back(mk_minsup_eval(2, pat));
+		minsup_evals.push_back(mk_minsup_eval(2, pat, tv));
 	return al(SET_LINK, minsup_evals);
 }
 
 Handle UREPatternMinerUTest::mk_query(const HandleSeq& texts, int minsup,
-                                      const Handle& initpat)
+                                      int depth, Handle initpat)
 {
 	// Make (Member text (Concept "texts)) links
 	for (const Handle& text : texts)
 		al(MEMBER_LINK, text, texts_cpt);
 
+	// If init is not defined then use top
+	if (not initpat)
+		initpat = top;
+
+	// Add the axiom that initpat has enough support
+	bool es = enough_support(initpat, minsup);
+	TruthValuePtr tv = SimpleTruthValue::createTV(es ? 1.0 : 0.0, 1.0);
+	mk_minsup_eval(minsup, initpat, tv);
+
 	// Make URE query
-	Handle spe_initpat = (bool)initpat ? al(PUT_LINK, initpat, X) : X,
-		query = mk_minsup_eval(minsup, spe_initpat);
+	Handle folded_pattern = initpat;
+	for (int i = 0; i < depth; i++)
+		folded_pattern = al(PUT_LINK,
+		                    folded_pattern,
+		                    al(UNQUOTE_LINK,
+		                       gen_shapat_var(i)));
+	Handle query = mk_minsup_eval(minsup, al(QUOTE_LINK, folded_pattern));
 	return query;
+}
+
+Handle UREPatternMinerUTest::gen_shapat_var(int i)
+{
+	std::string shapat("$shapat-");
+	return an(VARIABLE_NODE, shapat + std::to_string(i));
+}
+
+bool UREPatternMinerUTest::enough_support(const Handle& pat, int minsup)
+{
+	std::string support_query_str("(support\n");
+	support_query_str += pat->to_string();
+	support_query_str += texts_cpt->to_string();
+	support_query_str += std::to_string(minsup) + ")";
+	std::string rs = _scm.eval(support_query_str);
+	int freq = std::stoi(rs);
+	return minsup <= freq;
 }
 
 UREPatternMinerUTest::UREPatternMinerUTest() : _scm(&_as)
 {
 	// Main logger
-	logger().set_level(Logger::INFO);
+	logger().set_level(Logger::DEBUG);
 	logger().set_timestamp_flag(false);
-	// logger().set_sync_flag(true);
+	logger().set_sync_flag(true);
 	logger().set_print_to_stdout_flag(true);
 
 	// URE logger
-	ure_logger().set_level(Logger::INFO);
+	ure_logger().set_level(Logger::DEBUG);
 	ure_logger().set_timestamp_flag(false);
-	// ure_logger().set_sync_flag(true);
+	ure_logger().set_sync_flag(true);
 	ure_logger().set_print_to_stdout_flag(true);
 
 	// Configure scheme load-paths that are common for all tests.
@@ -170,6 +222,7 @@ void UREPatternMinerUTest::setUp()
 	// Load URE-based pattern miner
 	std::string rs = _scm.eval("(load-from-path \"pm-config.scm\")");
 	logger().debug() << "rs = " << rs;
+
 	X = an(VARIABLE_NODE, "$X");
 	Y = an(VARIABLE_NODE, "$Y");
 	Z = an(VARIABLE_NODE, "$Z");
@@ -178,6 +231,10 @@ void UREPatternMinerUTest::setUp()
 	B = an(CONCEPT_NODE, "B");
 	C = an(CONCEPT_NODE, "C");
 	D = an(CONCEPT_NODE, "D");
+	E = an(CONCEPT_NODE, "E");
+	F = an(CONCEPT_NODE, "F");
+	G = an(CONCEPT_NODE, "G");
+	H = an(CONCEPT_NODE, "H");
 	pm_rb = _scm.eval_h("pm-rbs");
 	texts_cpt = an(CONCEPT_NODE, "texts");
 	minsup_prd = an(PREDICATE_NODE, "minsup");
@@ -194,7 +251,7 @@ void UREPatternMinerUTest::test_A()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-	Handle query = mk_query({A}, 2);
+	Handle query = mk_query({A}, 2, 1);
 	BackwardChainer bc(_as, pm_rb, query);
 	bc.do_chain();
 
@@ -211,7 +268,7 @@ void UREPatternMinerUTest::test_AB()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-	Handle query = mk_query({A, B}, 2);
+	Handle query = mk_query({A, B}, 2, 1);
 	BackwardChainer bc(_as, pm_rb, query);
 	bc.do_chain();
 
@@ -230,7 +287,7 @@ void UREPatternMinerUTest::test_AB_AC()
 
 	Handle AB = al(INHERITANCE_LINK, A, B),
 		AC = al(INHERITANCE_LINK, A, C),
-		query = mk_query({AB, AC}, 2);
+		query = mk_query({AB, AC}, 2, 2);
 	BackwardChainer bc(_as, pm_rb, query);
 	bc.get_config().set_maximum_iterations(50);
 	bc.do_chain();
@@ -260,10 +317,10 @@ void UREPatternMinerUTest::test_AB_AC_BC()
 		InhAB = al(INHERITANCE_LINK, A, B),
 		InhAC = al(INHERITANCE_LINK, A, C),
 		InhBC = al(INHERITANCE_LINK, B, C),
-		query = mk_query({A, B, C, InhAB, InhAC, InhBC}, 2);
+		query = mk_query({A, B, C, InhAB, InhAC, InhBC}, 2, 2);
 
 	BackwardChainer bc(_as, pm_rb, query);
-	bc.get_config().set_maximum_iterations(50);
+	bc.get_config().set_maximum_iterations(100);
 	bc.do_chain();
 
 	Handle results = bc.get_results(),
@@ -292,10 +349,10 @@ void UREPatternMinerUTest::test_AB_ABC()
 		C = an(CONCEPT_NODE, "C"),
 		InhAB = al(INHERITANCE_LINK, A, B),
 		InhABC = al(INHERITANCE_LINK, A, al(AND_LINK, B, C)),
-		query = mk_query({A, B, C, InhAB, InhABC}, 2);
+		query = mk_query({A, B, C, InhAB, InhABC}, 2, 2);
 
 	BackwardChainer bc(_as, pm_rb, query);
-	bc.get_config().set_maximum_iterations(50);
+	bc.get_config().set_maximum_iterations(100);
 	bc.do_chain();
 
 	Handle results = bc.get_results(),
@@ -318,41 +375,32 @@ void UREPatternMinerUTest::test_ABCD()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-	Handle A = an(CONCEPT_NODE, "A"),
-		B = an(CONCEPT_NODE, "B"),
-		C = an(CONCEPT_NODE, "C"),
-		D = an(CONCEPT_NODE, "D"),
-		E = an(CONCEPT_NODE, "E"),
-		F = an(CONCEPT_NODE, "F"),
-		G = an(CONCEPT_NODE, "G"),
-		H = an(CONCEPT_NODE, "H"),
-		InhAB = al(INHERITANCE_LINK, A, B),
+	Handle InhAB = al(INHERITANCE_LINK, A, B),
 		InhCD = al(INHERITANCE_LINK, C, D),
 		InhEF = al(INHERITANCE_LINK, E, F),
 		InhGH = al(INHERITANCE_LINK, G, H),
-		ImpABCD = al(IMPLICATION_LINK, InhAB, InhAB),
+		ImpABCD = al(IMPLICATION_LINK, InhAB, InhCD),
 		ImpEFGH = al(IMPLICATION_LINK, InhEF, InhGH),
-		X = an(VARIABLE_NODE, "$X"),
-		Y = an(VARIABLE_NODE, "$Y"),
-		Z = an(VARIABLE_NODE, "$Z"),
-		W = an(VARIABLE_NODE, "$W"),
 		InhXY = al(INHERITANCE_LINK, X, Y),
 		InhZW = al(INHERITANCE_LINK, Z, W),
 		ImpXY = al(IMPLICATION_LINK, X, Y),
 		initpat = al(LAMBDA_LINK, ImpXY),
-		query = mk_query({InhAB, InhCD, InhEF, InhGH, ImpABCD, ImpEFGH}, 2, initpat);
+		query = mk_query({InhAB, InhCD, InhEF, InhGH, ImpABCD, ImpEFGH},
+		                 2, 2, initpat);
 
 	BackwardChainer bc(_as, pm_rb, query);
-	bc.get_config().set_maximum_iterations(50);
+	bc.get_config().set_maximum_iterations(100);
 	bc.do_chain();
 
 	Handle results = bc.get_results(),
 		expected = mk_minsup_evals(2,
-		                           { top,
-				                     al(LAMBDA_LINK, al(IMPLICATION_LINK, Z, InhXY)),
-				                     al(LAMBDA_LINK, al(IMPLICATION_LINK, InhZW, InhXY)),
-				                     al(LAMBDA_LINK, al(IMPLICATION_LINK, InhXY, Z)),
-				                     al(LAMBDA_LINK, al(IMPLICATION_LINK, InhZW, InhXY)) });
+		                           { al(LAMBDA_LINK, ImpXY),
+				                     al(LAMBDA_LINK,
+				                        al(IMPLICATION_LINK, Z, InhXY)),
+				                     al(LAMBDA_LINK,
+				                        al(IMPLICATION_LINK, InhXY, Z)),
+				                     al(LAMBDA_LINK,
+				                        al(IMPLICATION_LINK, InhZW, InhXY)) });
 
 	logger().debug() << "results = " << oc_to_string(results);
 	logger().debug() << "expected = " << oc_to_string(expected);

--- a/tests/learning/xpattern-miner/ure-based/UREPatternMinerUTest.cxxtest
+++ b/tests/learning/xpattern-miner/ure-based/UREPatternMinerUTest.cxxtest
@@ -115,7 +115,7 @@ public:
 	void test_AB_AC_BC();
 	void test_AB_ABC();
 	void test_ABCD();
-	// void test_ABAB();
+	void test_ABAB();
 	// void test_AAAA();
 	// void test_2conjuncts_1();
 	// void test_2conjuncts_2();
@@ -289,7 +289,7 @@ void UREPatternMinerUTest::test_AB_AC()
 		AC = al(INHERITANCE_LINK, A, C),
 		query = mk_query({AB, AC}, 2, 2);
 	BackwardChainer bc(_as, pm_rb, query);
-	bc.get_config().set_maximum_iterations(50);
+	bc.get_config().set_maximum_iterations(100);
 	bc.do_chain();
 
 	Handle results = bc.get_results(),
@@ -408,35 +408,41 @@ void UREPatternMinerUTest::test_ABCD()
 	TS_ASSERT(content_eq(expected, results));
 }
 
-// void UREPatternMinerUTest::test_ABAB()
-// {
-// 	logger().info("BEGIN TEST: %s", __FUNCTION__);
+void UREPatternMinerUTest::test_ABAB()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-// 	Handle A = an(CONCEPT_NODE, "A"),
-// 		B = an(CONCEPT_NODE, "B"),
-// 		C = an(CONCEPT_NODE, "C"),
-// 		AB = al(INHERITANCE_LINK, A, B),
-// 		BC = al(INHERITANCE_LINK, B, C),
-// 		ABAB = al(IMPLICATION_LINK, AB, AB),
-// 		BCBC = al(IMPLICATION_LINK, BC, BC);
+	Handle A = an(CONCEPT_NODE, "A"),
+		B = an(CONCEPT_NODE, "B"),
+		C = an(CONCEPT_NODE, "C"),
+		AB = al(INHERITANCE_LINK, A, B),
+		BC = al(INHERITANCE_LINK, B, C),
+		ABAB = al(IMPLICATION_LINK, AB, AB),
+		BCBC = al(IMPLICATION_LINK, BC, BC);
 	
-// 	Handle X = tmp_an(VARIABLE_NODE, "$X"),
-// 		Y = tmp_an(VARIABLE_NODE, "$Y"),
-// 		initpat = tmp_al(LAMBDA_LINK,
-// 		                 tmp_al(IMPLICATION_LINK, X, Y));
+	Handle X = tmp_an(VARIABLE_NODE, "$X"),
+		Y = tmp_an(VARIABLE_NODE, "$Y"),
+		initpat = tmp_al(LAMBDA_LINK,
+		                 tmp_al(IMPLICATION_LINK, X, Y)),
+		query = mk_query({ABAB, BCBC}, 2, 2, initpat);
 
-// 	XPMParameters param(2, 1, initpat);
-// 	XPatternMiner pm(_as, param);
-// 	HandleTree results = pm();
+	BackwardChainer bc(_as, pm_rb, query);
+	bc.get_config().set_maximum_iterations(100);
+	bc.do_chain();
 
-// 	Handle XY = tmp_al(INHERITANCE_LINK, X, Y),
-// 		expected = tmp_al(LAMBDA_LINK, tmp_al(IMPLICATION_LINK, XY, XY));
+	Handle results = bc.get_results(),
+		VarXY = tmp_al(VARIABLE_LIST, X, Y),
+		InhXY = tmp_al(INHERITANCE_LINK, X, Y),
+		expected = mk_minsup_eval(2,
+		                          tmp_al(LAMBDA_LINK,
+		                                 VarXY,
+		                                 tmp_al(IMPLICATION_LINK, InhXY, InhXY)));
 
-// 	logger().debug() << "results = " << oc_to_string(results);
-// 	logger().debug() << "expected = " << oc_to_string(expected);
+	logger().debug() << "results = " << oc_to_string(results);
+	logger().debug() << "expected = " << oc_to_string(expected);
 
-// 	TS_ASSERT(content_is_in(expected, results));
-// }
+	TS_ASSERT(is_in(expected, results->getOutgoingSet()));
+}
 
 // void UREPatternMinerUTest::test_AAAA()
 // {


### PR DESCRIPTION
First complete, though extremely inefficient, version of URE pattern miner.

The main inefficiency is due to the leniency of the abstraction and specialization rules, considering many more patterns than necessary. So a first step toward optimizing it would be to restrict those rules by only considering viable abtractions/specializations. The C++ code does that by using an intermediary C++ structures (see https://github.com/opencog/opencog/blob/master/opencog/learning/xpattern-miner/c%2B%2B-based/Valuations.h). Either the entire thing could be ported to atomese or wrapped in some grounded schema, TBD.