### PR TITLE
Fix repeated words

### DIFF
--- a/opencog/nlp/learn/scm/link-pipeline.scm
+++ b/opencog/nlp/learn/scm/link-pipeline.scm
@@ -223,12 +223,11 @@
 
 	; Create and count a word-pair, and the distance.
 	(define (count-one-pair left-seq right-seq)
-		(define pare (ListLink (gar left-seq) (gar right-seq)))
 		(define dist (- (get-no right-seq) (get-no left-seq)))
 
 		; Only count if the distance is less than the cap.
 		(if (<= dist MAX-LEN)
-			(begin
+			(let ((pare (ListLink (gar left-seq) (gar right-seq))))
 				(count-one-atom (EvaluationLink pair-pred pare))
 				(if RECORD-LEN
 					(count-one-atom

--- a/opencog/nlp/lg-parse/LGParseLink.cc
+++ b/opencog/nlp/lg-parse/LGParseLink.cc
@@ -281,10 +281,14 @@ Handle LGParseLink::cvt_linkage(Linkage lkg, int i, const char* idstr,
 		if (0 == w and 0 == strcmp(wrd, "LEFT-WALL")) wrd = "###LEFT-WALL###";
 		if (nwords-1 == w and 0 == strcmp(wrd, "RIGHT-WALL")) wrd = "###RIGHT-WALL###";
 
+		uuid_t uu2;
+		uuid_generate(uu2);
+		char idstr2[37];
+		uuid_unparse(uu2, idstr2);
 		char buff[801] = "";
 		strncat(buff, wrd, 800);
 		strncat(buff, "@", 800);
-		strncat(buff, parseid, 800);
+		strncat(buff, idstr2, 800);
 		Handle winst(as->add_node(WORD_INSTANCE_NODE, buff));
 		wrds.push_back(winst);
 


### PR DESCRIPTION
Fixed bug that ignored repeated words in clique-pair counting, reported in https://github.com/opencog/opencog/issues/3033
Also, only create LinkPairs when the words are withing allowed distance. This had caused me problems before in some tests.