### PR TITLE
Optimize pattern miner

### DIFF
--- a/opencog/learning/PatternMiner/PatternMiner.cc
+++ b/opencog/learning/PatternMiner/PatternMiner.cc
@@ -2025,7 +2025,7 @@ unsigned int PatternMiner::getAllEntityCountWithSamePredicatesForAPattern(const 
             return eit->second;
         }
 
-        vector<HandleSet> allEntitiesForEachPredicate;
+        HandleSetSeq allEntitiesForEachPredicate;
 
         for (const Handle& predicate : allPredicateNodes)
         {

--- a/opencog/learning/scm/CMakeLists.txt
+++ b/opencog/learning/scm/CMakeLists.txt
@@ -1,4 +1,5 @@
 ADD_GUILE_MODULE (FILES
 	patternminer.scm
+	xpattern-miner.scm
 	MODULE_DESTINATION "${DATADIR}/scm/opencog/"
 )

--- a/opencog/learning/scm/xpattern-miner.scm
+++ b/opencog/learning/scm/xpattern-miner.scm
@@ -1,0 +1,10 @@
+;;
+;; OpenCog XPattern Miner module
+;;
+(define-module (opencog xpattern-miner))
+
+;; We need this to set the LTDL_LIBRARY_PATH
+(use-modules (opencog))
+
+;; This loads the xpattern-miner atom types.
+(load-extension "libguile-xpatternminer" "opencog_xpatternminer_init")

--- a/opencog/learning/xpattern-miner/c++-based/CMakeLists.txt
+++ b/opencog/learning/xpattern-miner/c++-based/CMakeLists.txt
@@ -1,4 +1,4 @@
-ADD_LIBRARY(xpatternminer
+ADD_LIBRARY(xpatternminer SHARED
   XPatternMiner
   HandleTree
   Valuations
@@ -17,3 +17,17 @@ INSTALL (FILES
     Valuations.h
 	DESTINATION "include/opencog/learning/xpattern-miner/c++-based"
 )
+
+IF (HAVE_GUILE)
+  ADD_LIBRARY(guile-xpatternminer SHARED
+    XPatternMinerSCM
+  )
+
+  TARGET_LINK_LIBRARIES(guile-xpatternminer
+    xpatternminer
+    ${GUILE_LIBRARIES}
+  )
+
+  INSTALL (TARGETS guile-xpatternminer DESTINATION "lib${LIB_DIR_SUFFIX}/opencog")
+
+ENDIF (HAVE_GUILE)

--- a/opencog/learning/xpattern-miner/c++-based/Valuations.h
+++ b/opencog/learning/xpattern-miner/c++-based/Valuations.h
@@ -51,6 +51,11 @@ public:
 	 */
 	Handle variable(unsigned i) const;
 
+	/**
+	 * Return the number of valuations
+	 */
+	unsigned size() const;
+
 	Variables variables;
 };
 
@@ -73,6 +78,9 @@ public:
 	/**
 	 * Erase the front variable with all its corresponding values on a
 	 * copy of this valuations.
+	 *
+	 * TODO: instead of erasing the front it would be better to move
+	 * some pointer to the next variable.
 	 */
 	SCValuations erase_front() const;
 
@@ -83,11 +91,24 @@ public:
 	SCValuations erase(const Handle& var) const;
 
 	/**
+	 * Compare if 2 SCValuations are equal, in fact only looking at
+	 * their variables, as it is enough it the context in which they
+	 * will be used.
+	 */
+	bool operator==(const SCValuations& other) const;
+
+	/**
 	 * Less than relationship according to Variables, because it's
 	 * cheap and no 2 SCValuations with same variables will be in the
 	 * same set at once.
 	 */
 	bool operator<(const SCValuations& other) const;
+
+	/**
+	 * Return the size of the SCValuations, that is its number of
+	 * values.
+	 */
+	unsigned size() const;
 
 	HandleSeqSeq values;
 };
@@ -122,7 +143,22 @@ public:
 	 */
 	const SCValuations& get_scvaluations(const Handle& var) const;
 
+	/**
+	 * Return the size of the Valuations, that is its totally number
+	 * of values accounting for the potential combinations of values
+	 * between the strongly connected valuations.
+	 */
+	unsigned size() const;
+
 	SCValuationsSet scvs;
+
+private:
+	/**
+	 * Calculate and set _size
+	 */
+	void setup_size();
+
+	unsigned _size;
 };
 
 typedef std::map<Handle, Valuations> HandleValuationsMap;

--- a/opencog/learning/xpattern-miner/c++-based/Valuations.h
+++ b/opencog/learning/xpattern-miner/c++-based/Valuations.h
@@ -52,6 +52,11 @@ public:
 	Handle variable(unsigned i) const;
 
 	/**
+	 * Return the index corresponding to var
+	 */
+	unsigned index(const Handle& var) const;
+
+	/**
 	 * Return the number of valuations
 	 */
 	unsigned size() const;
@@ -91,6 +96,12 @@ public:
 	SCValuations erase(const Handle& var) const;
 
 	/**
+	 * Return all counted values corresponding to var.
+	 */
+	HandleUCounter values(const Handle& var) const;
+	HandleUCounter values(unsigned var_idx) const;
+
+	/**
 	 * Compare if 2 SCValuations are equal, in fact only looking at
 	 * their variables, as it is enough it the context in which they
 	 * will be used.
@@ -110,7 +121,9 @@ public:
 	 */
 	unsigned size() const;
 
-	HandleSeqSeq values;
+	// Actual valuations, sequence of tuples of values associated to
+	// each variable.
+	HandleSeqSeq valuations;
 };
 
 typedef std::set<SCValuations> SCValuationsSet;

--- a/opencog/learning/xpattern-miner/c++-based/XPatternMiner.cc
+++ b/opencog/learning/xpattern-miner/c++-based/XPatternMiner.cc
@@ -644,11 +644,15 @@ const Variables& XPatternMiner::get_variables(const Handle& pattern)
 	return empty_variables;
 }
 
-const Handle& XPatternMiner::get_vardecl(const Handle& pattern)
+Handle XPatternMiner::get_vardecl(const Handle& pattern)
 {
 	RewriteLinkPtr sc = RewriteLinkCast(pattern);
-	if (sc)
-		return RewriteLinkCast(pattern)->get_vardecl();
+	if (sc) {
+		Handle vardecl = sc->get_vardecl();
+		if (not vardecl)
+			vardecl = sc->get_variables().get_vardecl();
+		return vardecl;
+	}
 	return Handle::UNDEFINED;
 }
 

--- a/opencog/learning/xpattern-miner/c++-based/XPatternMiner.cc
+++ b/opencog/learning/xpattern-miner/c++-based/XPatternMiner.cc
@@ -152,12 +152,8 @@ HandleTree XPatternMiner::specialize_shabs(const Handle& pattern,
 	Handle var = valuations.front_variable();
 	for (const auto& shapat : shapats)
 	{
-		// Alpha convert to make sure it doesn't share variables with
-		// pattern
-		Handle subpat = alpha_conversion(shapat);
-
 		// Perform the composition (that is specialize)
-		Handle npat = compose(pattern, {{var, subpat}});
+		Handle npat = compose(pattern, {{var, shapat}});
 
 		// If the specialization has too few conjuncts, dismiss it.
 		if (conjuncts(npat) < param.initconjuncts)
@@ -413,27 +409,27 @@ Handle XPatternMiner::shallow_abstract(const Handle& value)
 Handle XPatternMiner::variable_list(const HandleSeq& vars)
 {
 	return vars.size() == 1 ? vars[0]
-		: pattern_as.add_link(VARIABLE_LIST, vars);
+		: createLink(vars, VARIABLE_LIST);
 }
 
 Handle XPatternMiner::lambda(const Handle& vardecl, const Handle& body)
 {
-	return pattern_as.add_link(LAMBDA_LINK, vardecl, body);
+	return createLink(LAMBDA_LINK, vardecl, body);
 }
 
 Handle XPatternMiner::quote(const Handle& h)
 {
-	return pattern_as.add_link(QUOTE_LINK, h);
+	return createLink(QUOTE_LINK, h);
 }
 
 Handle XPatternMiner::unquote(const Handle& h)
 {
-	return pattern_as.add_link(UNQUOTE_LINK, h);
+	return createLink(UNQUOTE_LINK, h);
 }
 
 Handle XPatternMiner::local_quote(const Handle& h)
 {
-	return pattern_as.add_link(LOCAL_QUOTE_LINK, h);
+	return createLink(LOCAL_QUOTE_LINK, h);
 }
 
 // TODO: take care of removing local quote in the composed

--- a/opencog/learning/xpattern-miner/c++-based/XPatternMiner.cc
+++ b/opencog/learning/xpattern-miner/c++-based/XPatternMiner.cc
@@ -136,12 +136,6 @@ HandleTree XPatternMiner::specialize_shabs(const Handle& pattern,
 	// that variable) to them.
 	HandleSet shapats = shallow_abstract(valuations);
 
-	// Generate variables for variable factorization (aka reduction)
-	HandleSet vs = variable_reduce(valuations);
-
-	// Include the variable factorization in the shallow patterns
-	shapats.insert(vs.begin(), vs.end());
-
 	// No shallow abstraction to use for specialization
 	if (shapats.empty())
 		return HandleTree();
@@ -176,24 +170,6 @@ HandleTree XPatternMiner::specialize_shabs(const Handle& pattern,
 		patterns = merge_patterns({patterns, npats});
 	}
 	return patterns;
-}
-
-HandleSet XPatternMiner::variable_reduce(const Valuations& valuations) const
-{
-	// No more variable to specialize from
-	if (valuations.novar())
-		return HandleSet();
-
-	// Variable to specialize
-	Handle var = valuations.front_variable();
-
-	// Variables not added to potential reduction yet
-	HandleSet remvars(std::next(valuations.variables.varseq.begin()),
-	                  valuations.variables.varseq.end());
-
-	// Let's not bother and consider all remaining variables as
-	// potentially reducible
-	return remvars;
 }
 
 bool XPatternMiner::terminate(const Handle& pattern,
@@ -319,6 +295,11 @@ HandleSet XPatternMiner::shallow_abstract(const Valuations& valuations)
 	HandleSet shapats;
 	for (const HandleSeq& valuation : var_scv.values)
 		shapats.insert(shallow_abstract(valuation[0]));
+
+	// Add all subsequent factorizable variables
+	shapats.insert(std::next(valuations.variables.varseq.begin()),
+	               valuations.variables.varseq.end());
+
 	return shapats;
 }
 

--- a/opencog/learning/xpattern-miner/c++-based/XPatternMiner.cc
+++ b/opencog/learning/xpattern-miner/c++-based/XPatternMiner.cc
@@ -176,8 +176,7 @@ bool XPatternMiner::terminate(const Handle& pattern,
                               const HandleSet& texts,
                               const Valuations& valuations,
                               int maxdepth) const
-{
-	
+{	
 	return
 		// We have reached the maximum depth
 		maxdepth == 0 or

--- a/opencog/learning/xpattern-miner/c++-based/XPatternMiner.cc
+++ b/opencog/learning/xpattern-miner/c++-based/XPatternMiner.cc
@@ -311,13 +311,12 @@ Handle XPatternMiner::shallow_abstract(const Handle& value)
 
 	Type tt = value->get_type();
 	HandleSeq rnd_vars = gen_rand_variables(value->get_arity());
+	Handle vardecl = variable_list(rnd_vars),
+		body = createLink(rnd_vars, tt);
 
 	// Links wrapped with LocalQuoteLink
 	if (tt == AND_LINK) {
-		Handle vardecl = variable_list(rnd_vars),
-			body = pattern_as.add_link(tt, rnd_vars),
-			pattern = lambda(vardecl, local_quote(body));
-		return pattern;
+		return lambda(vardecl, local_quote(body));
 	}
 	// Links wrapped with QuoteLink and UnquoteLinks
 	if (tt == BIND_LINK or
@@ -329,17 +328,11 @@ Handle XPatternMiner::shallow_abstract(const Handle& value)
 		for (Handle& var : rnd_vars)
 			uq_vars.push_back(unquote(var));
 
-		Handle vardecl = variable_list(rnd_vars),
-			body = pattern_as.add_link(tt, uq_vars),
-			pattern = lambda(vardecl, quote(body));
-		return pattern;
+		return lambda(vardecl, quote(body));
 	}
 
 	// Generic non empty link, let's abstract away all the arguments
-	Handle vardecl = variable_list(rnd_vars),
-		body = pattern_as.add_link(tt, rnd_vars),
-		pattern = lambda(vardecl, body);
-	return pattern;
+	return lambda(vardecl, body);
 }
 
 Handle XPatternMiner::variable_list(const HandleSeq& vars)

--- a/opencog/learning/xpattern-miner/c++-based/XPatternMiner.cc
+++ b/opencog/learning/xpattern-miner/c++-based/XPatternMiner.cc
@@ -101,6 +101,31 @@ HandleTree XPatternMiner::specialize(const Handle& pattern,
 	return specialize(pattern, texts, Valuations(pattern, texts), maxdepth);
 }
 
+HandleTree XPatternMiner::specialize_alt(const Handle& pattern,
+                                         const HandleSet& texts,
+                                         int maxdepth)
+{
+	HandleTree patterns;
+	Variables vars = get_variables(pattern);
+
+	// Calculate all shallow abstractions of pattern
+	HandleSetSeq shabs = shallow_abstract(pattern, texts);
+
+	// Generate all associated specializations
+	for (unsigned i = 0; i < shabs.size(); i++) {
+		for (const Handle& shapat : shabs[i]) {
+			// Compose pattern with shapat to obtain a specialization,
+			// and recursively specialize the result
+			HandleTree npats =
+				specialize_shapat(pattern, texts, vars.varseq[i], shapat, maxdepth);
+
+			// Insert specializations
+			patterns = merge_patterns({patterns, npats});
+		}
+	}
+	return patterns;
+}
+
 HandleTree XPatternMiner::specialize(const Handle& pattern,
                                      const HandleSet& texts,
                                      const Valuations& valuations,

--- a/opencog/learning/xpattern-miner/c++-based/XPatternMiner.cc
+++ b/opencog/learning/xpattern-miner/c++-based/XPatternMiner.cc
@@ -372,10 +372,10 @@ Handle XPatternMiner::shallow_abstract(const Handle& value)
 		return value;
 
 	Type tt = value->get_type();
+	HandleSeq rnd_vars = gen_rand_variables(value->get_arity());
 
 	// Links wrapped with LocalQuoteLink
 	if (tt == AND_LINK) {
-		HandleSeq rnd_vars = gen_rand_variables(value->get_arity());
 		Handle vardecl = variable_list(rnd_vars),
 			body = pattern_as.add_link(tt, rnd_vars),
 			pattern = lambda(vardecl, local_quote(body));
@@ -386,7 +386,6 @@ Handle XPatternMiner::shallow_abstract(const Handle& value)
 	    tt == EVALUATION_LINK or
 	    tt == EXECUTION_OUTPUT_LINK)
 	{
-		HandleSeq rnd_vars = gen_rand_variables(value->get_arity());
 		// Wrap variables in UnquoteLink
 		HandleSeq uq_vars;
 		for (Handle& var : rnd_vars)
@@ -399,7 +398,6 @@ Handle XPatternMiner::shallow_abstract(const Handle& value)
 	}
 
 	// Generic non empty link, let's abstract away all the arguments
-	HandleSeq rnd_vars = gen_rand_variables(value->get_arity());
 	Handle vardecl = variable_list(rnd_vars),
 		body = pattern_as.add_link(tt, rnd_vars),
 		pattern = lambda(vardecl, body);

--- a/opencog/learning/xpattern-miner/c++-based/XPatternMiner.h
+++ b/opencog/learning/xpattern-miner/c++-based/XPatternMiner.h
@@ -513,7 +513,7 @@ public:
 	 * respectively, and get_body returns the pattern itself.
 	 */
 	static const Variables& get_variables(const Handle& pattern);
-	static const Handle& get_vardecl(const Handle& pattern);
+	static Handle get_vardecl(const Handle& pattern);
 	static const Handle& get_body(const Handle& pattern);
 
 	/**

--- a/opencog/learning/xpattern-miner/c++-based/XPatternMiner.h
+++ b/opencog/learning/xpattern-miner/c++-based/XPatternMiner.h
@@ -130,6 +130,8 @@ public:
 	 */
 	HandleTree specialize(const Handle& pattern, const HandleSet& texts,
 	                      int maxdepth=-1);
+	HandleTree specialize_alt(const Handle& pattern, const HandleSet& texts,
+	                          int maxdepth=-1);
 
 	/**
 	 * Like above, where all valid texts have been converted into

--- a/opencog/learning/xpattern-miner/c++-based/XPatternMiner.h
+++ b/opencog/learning/xpattern-miner/c++-based/XPatternMiner.h
@@ -279,15 +279,6 @@ private:
 	Handle matched_results(const Handle& pattern, const Handle& text) const;
 
 	/**
-	 * Like shallow_abstract(const Valuations&) but takes a pattern
-	 * and a texts instead, and generate the valuations of the pattern
-	 * prior to calling shallow_abstract on its valuations.
-	 *
-	 * See comment below for more details.
-	 */
-	static HandleSetSeq shallow_abstract(const Handle& pattern, const HandleSet& texts);
-
-	/**
 	 * Given valuations produce all shallow abstractions over all
 	 * variables. It basically applies front_shallow_abstract
 	 * recursively. See the specification of front_shallow_abstract
@@ -449,6 +440,16 @@ private:
 	static Handle alpha_conversion(const Handle& pattern);
 
 public:
+	/**
+	 * Like shallow_abstract(const Valuations&) but takes a pattern
+	 * and a texts instead, and generate the valuations of the pattern
+	 * prior to calling shallow_abstract on its valuations.
+	 *
+	 * See comment below for more details.
+	 */
+	static HandleSetSeq shallow_abstract(const Handle& pattern,
+	                                     const HandleSet& texts);
+
 	/**
 	 * Given a vardecl and a body, filter the vardecl to contain only
 	 * variable of the body, and create a Lambda with them.

--- a/opencog/learning/xpattern-miner/c++-based/XPatternMiner.h
+++ b/opencog/learning/xpattern-miner/c++-based/XPatternMiner.h
@@ -299,7 +299,7 @@ private:
 	 *
 	 * TODO: we may want to support types in variable declaration.
 	 */
-	Handle shallow_abstract(const Handle& value);
+	static Handle shallow_abstract(const Handle& value);
 
 	/**
 	 * Given valuations produce all shallow abstractions based on the
@@ -330,28 +330,28 @@ private:
 	 *                                 (Concept "E")
 	 *                                 Y }
 	 */
-	HandleSet shallow_abstract(const Valuations& valuations);
-	
+	static HandleSet shallow_abstract(const Valuations& valuations);
+
 	/**
 	 * Wrap a VariableList around a variable list, if more than one
 	 * variable, otherwise return that one variable.
 	 */
-	Handle variable_list(const HandleSeq& vars);
+	static Handle variable_list(const HandleSeq& vars);
 
 	/**
 	 * Wrap a LambdaLink around a vardecl and body.
 	 */
-	Handle lambda(const Handle& vardecl, const Handle& body);
+	static Handle lambda(const Handle& vardecl, const Handle& body);
 
 	/**
 	 * Wrap a QuoteLink around h
 	 */
-	Handle quote(const Handle& h);
+	static Handle quote(const Handle& h);
 
 	/**
 	 * Wrap a UnquoteLink around h
 	 */
-	Handle unquote(const Handle& h);
+	static Handle unquote(const Handle& h);
 
 	/**
 	 * Wrap a LocalQuote link around h (typically used if it is a link
@@ -359,7 +359,7 @@ private:
 	 * multi-conjuncts patterns when in fact we want to match an
 	 * AndLink text.)
 	 */
-	Handle local_quote(const Handle& h);
+	static Handle local_quote(const Handle& h);
 
 	/**
 	 * TODO replace by RewriteLink::beta_reduce

--- a/opencog/learning/xpattern-miner/c++-based/XPatternMiner.h
+++ b/opencog/learning/xpattern-miner/c++-based/XPatternMiner.h
@@ -277,26 +277,6 @@ private:
 	Handle matched_results(const Handle& pattern, const Handle& text) const;
 
 	/**
-	 * Return all variables, except the front one, that could be
-	 * unified with the front one according to the given valuations.
-	 *
-	 * So for instance if valuations is
-	 *
-	 * { { X->Concept "A", Y->Concept "B", Z->Concept "C" },
-	 *   { X->Concept "B", Y->Concept "B", Z->Concept "C" },
-	 *   { X->Concept "C", Y->Concept "A", Z->Concept "B" } }
-	 *
-	 * then return {Y}. Indeed only Y is at least once equal to X.
-	 *
-	 * TODO: for now we return everything, and specializations that do
-	 * not have enough support are subsequently discarded. But it
-	 * could be faster to consider the minimum support in that
-	 * function and right away filter variables we know won't have
-	 * enough support based on valuations.
-	 */
-	HandleSet variable_reduce(const Valuations& valuations) const;
-
-	/**
 	 * Given an atom, return its corresponding shallow
 	 * abstraction. A shallow abstraction of an atom is
 	 *
@@ -322,14 +302,23 @@ private:
 	Handle shallow_abstract(const Handle& value);
 
 	/**
-	 * Given valuations, produce all shallow abstractions based on the
-	 * values associated to the front variable first variable.
+	 * Given valuations produce all shallow abstractions based on the
+	 * values associated to the front variable first variable. This
+	 * shallow abstractions include
+	 *
+	 * 1. Single operator patterns, like (Lambda X Y (Inheritance X Y))
+	 * 2. Constant nodes, like (Concept "A")
+	 * 3. Remain variable after the front one, x2, ..., xn
+	 *
+	 * Composing these 3 sorts of abstractions are enough to generate
+	 * all possible patterns.
 	 *
 	 * For instance
 	 *
-	 * valuations = { { X->(Inheritance (Concept "A") (Concept "B")), Y->(Concept "C") },
-	 *                { X->(Inheritance (Concept "B") (Concept "C")), Y->(Concept "D") },
-	 *                { X->(Concept "E"), Y->(Concept "D") } }
+	 * valuations =
+	 *   { { X->(Inheritance (Concept "A") (Concept "B")), Y->(Concept "C") },
+	 *     { X->(Inheritance (Concept "B") (Concept "C")), Y->(Concept "D") },
+	 *     { X->(Concept "E"), Y->(Concept "D") } }
 	 *
 	 * shallow_abstrac(valuations) = { (Lambda
 	 *                                   (VariableList
@@ -337,8 +326,9 @@ private:
 	 *                                     (Variable "$X2"))
 	 *                                   (Inheritance
 	 *                                     (Variable "$X1")
-	 *                                     (Variable "$X2")),
-	 *                                 (Concept "E") }
+	 *                                     (Variable "$X2"))),
+	 *                                 (Concept "E")
+	 *                                 Y }
 	 */
 	HandleSet shallow_abstract(const Valuations& valuations);
 	

--- a/opencog/learning/xpattern-miner/c++-based/XPatternMiner.h
+++ b/opencog/learning/xpattern-miner/c++-based/XPatternMiner.h
@@ -130,8 +130,6 @@ public:
 	 */
 	HandleTree specialize(const Handle& pattern, const HandleSet& texts,
 	                      int maxdepth=-1);
-	HandleTree specialize_alt(const Handle& pattern, const HandleSet& texts,
-	                          int maxdepth=-1);
 
 	/**
 	 * Like above, where all valid texts have been converted into
@@ -141,6 +139,10 @@ public:
 	                      const HandleSet& texts,
 	                      const Valuations& valuations,
 	                      int maxdepth);
+	HandleTree specialize_alt(const Handle& pattern,
+	                          const HandleSet& texts,
+	                          const Valuations& valuations,
+	                          int maxdepth);
 
 	// AtomSpace containing the text trees to mine.
 	AtomSpace& text_as;

--- a/opencog/learning/xpattern-miner/c++-based/XPatternMiner.h
+++ b/opencog/learning/xpattern-miner/c++-based/XPatternMiner.h
@@ -139,6 +139,10 @@ public:
 	                      const HandleSet& texts,
 	                      const Valuations& valuations,
 	                      int maxdepth);
+
+	/**
+	 * Alternate specialization that reflects how the URE would work.
+	 */
 	HandleTree specialize_alt(const Handle& pattern,
 	                          const HandleSet& texts,
 	                          const Valuations& valuations,
@@ -279,10 +283,10 @@ private:
 	Handle matched_results(const Handle& pattern, const Handle& text) const;
 
 	/**
-	 * Given valuations produce all shallow abstractions over all
-	 * variables. It basically applies front_shallow_abstract
-	 * recursively. See the specification of front_shallow_abstract
-	 * for more information.
+	 * Given valuations produce all shallow abstractions reachind
+	 * minimum support, over all variables. It basically applies
+	 * front_shallow_abstract recursively. See the specification of
+	 * front_shallow_abstract for more information.
 	 *
 	 * For instance, given
 	 *
@@ -290,6 +294,7 @@ private:
 	 *   { { X->(Inheritance (Concept "A") (Concept "B")), Y->(Concept "C") },
 	 *     { X->(Inheritance (Concept "B") (Concept "C")), Y->(Concept "D") },
 	 *     { X->(Concept "E"), Y->(Concept "D") } }
+	 * ms = 2
 	 *
 	 * shallow_abstract(valuations) =
 	 *  {
@@ -300,23 +305,17 @@ private:
 	 *          (Variable "$X2"))
 	 *        (Inheritance
 	 *          (Variable "$X1")
-	 *          (Variable "$X2"))),
-	 *      (Concept "E"),
-	 *      Y },
+	 *          (Variable "$X2"))) },
 	 *    ;; Shallow abstractions of Y
-	 *    { (Concept "C"),
-	 *      (Concept "D") }
+	 *    { (Concept "D") }
 	 *  }
-	 *
-	 * TODO: maybe we should count and dismiss shallow abstractions
-	 * that would not reach the minimum support.
 	 */
-	static HandleSetSeq shallow_abstract(const Valuations& valuations);
+	static HandleSetSeq shallow_abstract(const Valuations& valuations, unsigned ms);
 
 	/**
-	 * Given valuations produce all shallow abstractions based on the
-	 * values associated to the front variable first variable. This
-	 * shallow abstractions include
+	 * Given valuations produce all shallow abstractions reaching
+	 * minimum support based on the values associated to the front
+	 * variable first variable. This shallow abstractions include
 	 *
 	 * 1. Single operator patterns, like (Lambda X Y (Inheritance X Y))
 	 * 2. Constant nodes, like (Concept "A")
@@ -331,6 +330,7 @@ private:
 	 *   { { X->(Inheritance (Concept "A") (Concept "B")), Y->(Concept "C") },
 	 *     { X->(Inheritance (Concept "B") (Concept "C")), Y->(Concept "D") },
 	 *     { X->(Concept "E"), Y->(Concept "D") } }
+	 * ms = 2
 	 *
 	 * front_shallow_abstract(valuations) = { (Lambda
 	 *                                          (VariableList
@@ -338,11 +338,9 @@ private:
 	 *                                            (Variable "$X2"))
 	 *                                          (Inheritance
 	 *                                            (Variable "$X1")
-	 *                                            (Variable "$X2"))),
-	 *                                        (Concept "E"),
-	 *                                        Y }
+	 *                                            (Variable "$X2"))) }
 	 */
-	static HandleSet front_shallow_abstract(const Valuations& valuations);
+	static HandleSet front_shallow_abstract(const Valuations& valuations, unsigned ms);
 
 	/**
 	 * Given an atom, a value, return its corresponding shallow
@@ -441,14 +439,16 @@ private:
 
 public:
 	/**
-	 * Like shallow_abstract(const Valuations&) but takes a pattern
+	 * Like shallow_abstract(const Valuations&, unsigned) but takes a pattern
 	 * and a texts instead, and generate the valuations of the pattern
 	 * prior to calling shallow_abstract on its valuations.
 	 *
-	 * See comment below for more details.
+	 * See comment on shallow_abstract(const Valuations&, unsigned) for more
+	 * details.
 	 */
 	static HandleSetSeq shallow_abstract(const Handle& pattern,
-	                                     const HandleSet& texts);
+	                                     const HandleSet& texts,
+	                                     unsigned ms);
 
 	/**
 	 * Given a vardecl and a body, filter the vardecl to contain only

--- a/opencog/learning/xpattern-miner/c++-based/XPatternMinerSCM.cc
+++ b/opencog/learning/xpattern-miner/c++-based/XPatternMinerSCM.cc
@@ -1,0 +1,126 @@
+/*
+ * XPatternMinerSCM.cc
+ *
+ * Copyright (C) 2018 OpenCog Foundation
+ *
+ * Author: Nil Geisweiller <ngeiswei@gmail.com> 
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifdef HAVE_GUILE
+
+#include <opencog/guile/SchemeModule.h>
+
+namespace opencog {
+
+class XPatternMinerSCM : public ModuleWrap
+{
+protected:
+	virtual void init();
+
+	/**
+	 * Given a pattern and a texts concept, return all shallow
+	 * abstractions, pre-wrapped in Lists ready to be applied to the
+	 * pattern.
+	 *
+	 * For instance, given
+	 *
+	 * pattern = (Lambda X Y (Inheritance X Y))
+	 * texts  = { (Inheritance A B), (Inheritance A C) }
+	 *
+	 * returns
+	 *
+	 * Set
+	 *   List A Y
+	 *   List Y Y
+	 *   List X B
+	 *   List X C
+	 *
+	 * TODO: we really only want to return shallow abtractions that
+	 * would reach minimum support.
+	 */
+	Handle do_shallow_abstract(Handle pattern,
+	                           Handle texts);
+
+public:
+	XPatternMinerSCM();
+};
+
+} /*end of namespace opencog*/
+
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/guile/SchemePrimitive.h>
+
+#include <opencog/learning/xpattern-miner/c++-based/XPatternMiner.h>
+
+using namespace opencog;
+
+XPatternMinerSCM::XPatternMinerSCM() : ModuleWrap("opencog xpattern-miner") {}
+
+/// This is called while (opencog xpattern-miner) is the current
+/// module.  Thus, all the definitions below happen in that module.
+void XPatternMinerSCM::init(void)
+{
+	define_scheme_primitive("cog-shallow-abstract",
+		&XPatternMinerSCM::do_shallow_abstract, this, "xpattern-miner");
+}
+
+Handle XPatternMinerSCM::do_shallow_abstract(Handle pattern, Handle texts)
+{
+	AtomSpace *as = SchemeSmob::ss_get_env_as("cog-shallow-abstract");
+
+	// Fetch all texts
+	HandleSet texts_set;
+	IncomingSet member_links = texts->getIncomingSetByType(MEMBER_LINK);
+	for (const LinkPtr l : member_links) {
+		Handle member = l->getOutgoingAtom(0);
+		if (member != texts)
+			texts_set.insert(member);
+	}
+
+	// Generate all shallow abstractions
+	HandleSetSeq shabs_per_var =
+		XPatternMiner::shallow_abstract(pattern, texts_set);
+
+	// Turn that sequence of handle sets into a set of ready to be
+	// applied shallow abstractions
+	const Variables& vars = XPatternMiner::get_variables(pattern);
+	HandleSet sa_lists;
+	unsigned vari = 0;         // Index of the variable
+	for (const HandleSet& shabs : shabs_per_var) {
+		for (const Handle& sa : shabs) {
+			HandleSeq sa_list = vars.varseq;
+			sa_list[vari] = sa;
+			sa_lists.insert(as->add_link(LIST_LINK, sa_list));
+		}
+		vari++;
+	}
+
+	return as->add_link(SET_LINK, HandleSeq(sa_lists.begin(), sa_lists.end()));
+}
+
+extern "C" {
+void opencog_xpatternminer_init(void);
+};
+
+void opencog_xpatternminer_init(void)
+{
+    static XPatternMinerSCM xpattern_miner;
+    xpattern_miner.module_init();
+}
+
+#endif // HAVE_GUILE

--- a/opencog/learning/xpattern-miner/c++-based/XPatternMinerSCM.cc
+++ b/opencog/learning/xpattern-miner/c++-based/XPatternMinerSCM.cc
@@ -105,7 +105,10 @@ Handle XPatternMinerSCM::do_shallow_abstract(Handle pattern, Handle texts)
 		for (const Handle& sa : shabs) {
 			HandleSeq sa_list = vars.varseq;
 			sa_list[vari] = sa;
-			sa_lists.insert(as->add_link(LIST_LINK, sa_list));
+			sa_lists.insert(sa_list.size() == 1 ? sa_list[0]
+			                // Only Wrap in a list if arity is greater
+			                // than one
+			                : as->add_link(LIST_LINK, sa_list));
 		}
 		vari++;
 	}

--- a/opencog/learning/xpattern-miner/ure-based/pm-config.scm
+++ b/opencog/learning/xpattern-miner/ure-based/pm-config.scm
@@ -28,7 +28,8 @@
 
 ;; Load the rules (use load for relative path w.r.t. to that file)
 (add-to-load-path ".")
-(define rule-files (list "rules/shallow-abstraction.scm"
+(define rule-files (list "rules/top-abstraction.scm"
+                         "rules/shallow-abstraction.scm"
                          "rules/specialization.scm"))
 (for-each load-from-path rule-files)
 
@@ -37,12 +38,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; List the rules and their weights.
-(define rules (list unary-specialization-rule-name
-                    binary-first-arg-specialization-rule-name
-                    binary-second-arg-specialization-rule-name
-                    ternary-first-arg-specialization-rule-name
-                    ternary-second-arg-specialization-rule-name
-                    ternary-third-arg-specialization-rule-name))
+(define rules (list shallow-abstraction-rule-name
+                    specialization-rule-name))
 
 ; Associate rules to PLN
 (ure-add-rules pm-rbs rules)

--- a/opencog/learning/xpattern-miner/ure-based/pm-config.scm
+++ b/opencog/learning/xpattern-miner/ure-based/pm-config.scm
@@ -28,8 +28,7 @@
 
 ;; Load the rules (use load for relative path w.r.t. to that file)
 (add-to-load-path ".")
-(define rule-files (list "rules/top-abstraction.scm"
-                         "rules/shallow-abstraction.scm"
+(define rule-files (list "rules/shallow-abstraction.scm"
                          "rules/specialization.scm"))
 (for-each load-from-path rule-files)
 

--- a/opencog/learning/xpattern-miner/ure-based/rules/pattern-miner-utils.scm
+++ b/opencog/learning/xpattern-miner/ure-based/rules/pattern-miner-utils.scm
@@ -100,6 +100,10 @@
         texts
         ms)))
 
+;; Like minsup-eval and add (stv 1 1) on the EvaluationLink
+(define (minsup-eval-true pattern texts ms)
+  (cog-set-tv! (minsup-eval pattern texts ms) (stv 1 1)))
+
 ;; Given an atom created with minsup-eval, get the pattern, texts and
 ;; ms
 (define (get-pattern minsup-g)

--- a/opencog/learning/xpattern-miner/ure-based/rules/pattern-miner-utils.scm
+++ b/opencog/learning/xpattern-miner/ure-based/rules/pattern-miner-utils.scm
@@ -2,6 +2,7 @@
 (use-modules (opencog query))
 (use-modules (opencog logger))
 (use-modules (opencog rule-engine))
+(use-modules (opencog xpattern-miner))
 (use-modules (srfi srfi-1))
 
 ;; (cog-logger-set-level! "debug")
@@ -91,13 +92,41 @@
          (post-i (drop l (+ i 1))))
     (append pre-i (list v) post-i)))
 
-(define (minsup pattern texts ms)
+(define (minsup-eval pattern texts ms)
   (Evaluation
      (Predicate "minsup")
      (List
         pattern
         texts
         ms)))
+
+;; Given an atom created with minsup-eval, get the pattern, texts and
+;; ms
+(define (get-pattern minsup-g)
+  (cog-outgoing-atom (gdr minsup-g) 0))
+(define (get-texts minsup-g)
+  (cog-outgoing-atom (gdr minsup-g) 1))
+(define (get-ms minsup-g)
+  (cog-outgoing-atom (gdr minsup-g) 2))
+
+(define (shallow-abstraction-eval shabs-list minsup-g)
+  (Evaluation
+    (Predicate "shallow-abstraction")
+    (List
+      shabs-list
+      minsup-g)))
+
+(define (absolutely-true-eval A)
+  (Evaluation
+    (GroundedPredicate "scm: absolutely-true")
+    A))
+
+(define (has-arity-eval g arity)
+  (Evaluation
+    (GroundedPredicate "scm: has-arity")
+    (List
+      g
+      (Number arity))))
 
 (define (pattern-arity pattern)
 "

--- a/opencog/learning/xpattern-miner/ure-based/rules/shallow-abstraction.scm
+++ b/opencog/learning/xpattern-miner/ure-based/rules/shallow-abstraction.scm
@@ -10,27 +10,29 @@
 ;;         ...
 ;;         <xn>
 ;;       <g-body>
+;;     <texts>
 ;;     <ms>
 ;; |-
 ;; Set
 ;;   Evaluation (stv 1 1)
-;;     Predicate "shabs"
+;;     Predicate "shallow-abstraction"
 ;;     List
 ;;       List
 ;;         <f1>
 ;;         <x2>
 ;;         ...
 ;;         <xn>
-;;     Evaluation
-;;       Predicate "minsup"
-;;       List
-;;         Lambda
-;;           VariableList
-;;             <x1>
-;;             ...
-;;             <xn>
-;;           <g-body>
-;;         <ms>
+;;       Evaluation
+;;         Predicate "minsup"
+;;         List
+;;           Lambda
+;;             VariableList
+;;               <x1>
+;;               ...
+;;               <xn>
+;;             <g-body>
+;;           <texts>
+;;           <ms>
 ;; ...
 ;;
 ;; where f1 to fn are a shallow abstractions (shabs stands for shallow
@@ -38,26 +40,64 @@
 ;; amongst x1 to xn.
 ;;
 ;; Note, it's weird that the second argument of shabs is the minsup
-;; evaluation, because it might be equivalent to it's TV, it's not
-;; clear though so we'll go with that for now.
+;; evaluation because it might be equivalent to it's TV, it's not
+;; clear though that it's much of a problem, so we'll go with that for
+;; now.
 
+(load "pattern-miner-utils.scm")
 
+(define shallow-abstraction-rule
+  (let* (;; Variables
+         (g (Variable "$g"))
+         (texts (Variable "$texts"))
+         (ms (Variable "$ms"))
+         ;; Types
+         (LambdaT (Type "LambdaLink"))
+         (PutT (Type "PutLink"))
+         (ConceptT (Type "ConceptNode"))
+         (NumberT (Type "NumberNode"))
+         ;; Vardecls
+         (g-decl (TypedVariable g (TypeChoice LambdaT PutT)))
+         (texts-decl (TypedVariable texts ConceptT))
+         (ms-decl (TypedVariable ms NumberT))
+         ;; Clauses
+         (minsup-g (minsup-eval g texts ms)))
+  (Bind
+    (VariableList
+      g-decl
+      texts-decl
+      ms-decl)
+    (And
+      minsup-g
+      (absolutely-true-eval minsup-g))
+    (ExecutionOutput
+      (GroundedSchema "scm: shallow-abstraction-formula")
+      (List
+        (Set)               ; Cannot know the structure of the rule
+                            ; conclusion in advance, because we don't
+                            ; know the number of shallow abstractions,
+                            ; thus we cannot build the Set. Need to
+                            ; support ConsLink, or ConsSetLink or
+                            ; such.
+        minsup-g)))))
 
-;; TODO
+;; Shallow abstraction formula
+(define (shallow-abstraction-formula conclusion . premises)
+  ;; (cog-logger-debug "shallow-abstraction-formula conclusion = ~a, premises = ~a" conclusion premises)
+  (if (= (length premises) 1)
+      (let* ((minsup-g (car premises))
+             (g (get-pattern minsup-g))
+             (texts (get-texts minsup-g))
+             (ms (get-ms minsup-g))
+             (shabs-lists (cog-shallow-abstract g texts))
+             (list->eval (lambda (x) (cog-set-tv!
+                                      (shallow-abstraction-eval x minsup-g)
+                                      (stv 1 1))))
+             (shabs-evals (map list->eval (cog-outgoing-set shabs-lists))))
+        (Set shabs-evals))))
 
-;; Function to generate shallow abstractions
-(define (gen-shallow-abstraction link-type arity)
-  (let* ((variables (gen-variables "$sha-arg" arity))
-         (vardecl (VariableList variables))
-         (body (link-type variables)))
-      (Lambda
-        vardecl
-        (if (equal? (cog-type body) 'AndLink)
-            (LocalQuote body)
-            body))))
-
-;; (define inheritance-shallow-abstraction
-;;   (gen-shallow-abstraction InheritanceLink 2))
-
-;; (define and-shallow-abstraction
-;;   (gen-shallow-abstraction AndLink 2))
+;; Define specialization
+(define shallow-abstraction-rule-name
+  (DefinedSchemaNode "shallow-abstraction-rule"))
+(DefineLink shallow-abstraction-rule-name
+  shallow-abstraction-rule)

--- a/opencog/learning/xpattern-miner/ure-based/rules/shallow-abstraction.scm
+++ b/opencog/learning/xpattern-miner/ure-based/rules/shallow-abstraction.scm
@@ -1,31 +1,51 @@
-;; Given a ground atom, abstract it
-;;
-;; L
-;;   A1
-;;   ...
-;;   An
-;; |-
-;; Lambda
-;;   V1
-;;   ...
-;;   Vn
-;;   L
-;;     V1
-;;     ...
-;;     Vn
-;;
-;; V1 to Vn are random generated variables.
-
-;; TODO: these are in fact, facts!
-
-;; TODO: rather build a rule to create some thing like
+;; Rule to generate shallow abstractions of a given pattern,
+;; specifically
 ;;
 ;; Evaluation
-;;   Predicate "shallow-abstraction-of"
+;;   Predicate "minsup"
 ;;   List
-;;     <shallow-pattern>
-;;     <valuations>
+;;     Lambda
+;;       VariableList
+;;         <x1>
+;;         ...
+;;         <xn>
+;;       <g-body>
+;;     <ms>
+;; |-
+;; Set
+;;   Evaluation (stv 1 1)
+;;     Predicate "shabs"
+;;     List
+;;       List
+;;         <f1>
+;;         <x2>
+;;         ...
+;;         <xn>
+;;     Evaluation
+;;       Predicate "minsup"
+;;       List
+;;         Lambda
+;;           VariableList
+;;             <x1>
+;;             ...
+;;             <xn>
+;;           <g-body>
+;;         <ms>
+;; ...
+;;
+;; where f1 to fn are a shallow abstractions (shabs stands for shallow
+;; abstraction) either functions, constant nodes, or a variable nodes
+;; amongst x1 to xn.
+;;
+;; Note, it's weird that the second argument of shabs is the minsup
+;; evaluation, because it might be equivalent to it's TV, it's not
+;; clear though so we'll go with that for now.
 
+
+
+;; TODO
+
+;; Function to generate shallow abstractions
 (define (gen-shallow-abstraction link-type arity)
   (let* ((variables (gen-variables "$sha-arg" arity))
          (vardecl (VariableList variables))
@@ -36,8 +56,8 @@
             (LocalQuote body)
             body))))
 
-(define inheritance-shallow-abstraction
-  (gen-shallow-abstraction InheritanceLink 2))
+;; (define inheritance-shallow-abstraction
+;;   (gen-shallow-abstraction InheritanceLink 2))
 
-(define and-shallow-abstraction
-  (gen-shallow-abstraction AndLink 2))
+;; (define and-shallow-abstraction
+;;   (gen-shallow-abstraction AndLink 2))

--- a/opencog/learning/xpattern-miner/ure-based/rules/shallow-abstraction.scm
+++ b/opencog/learning/xpattern-miner/ure-based/rules/shallow-abstraction.scm
@@ -89,7 +89,7 @@
              (g (get-pattern minsup-g))
              (texts (get-texts minsup-g))
              (ms (get-ms minsup-g))
-             (shabs-lists (cog-shallow-abstract g texts))
+             (shabs-lists (cog-shallow-abstract g texts ms))
              (list->eval (lambda (x) (cog-set-tv!
                                       (shallow-abstraction-eval x minsup-g)
                                       (stv 1 1))))

--- a/opencog/learning/xpattern-miner/ure-based/rules/specialization.scm
+++ b/opencog/learning/xpattern-miner/ure-based/rules/specialization.scm
@@ -1,6 +1,7 @@
 ;; Rule to specialize a pattern by composing it with a shallow
-;; abstraction, a constant, or a variable, and checks that it has
-;; enough support.
+;; abstraction, which can be pattern with just one link and all
+;; variables as outgoings, a constant, or a variable, and checks that
+;; it has enough support.
 ;;
 ;; Given g with arity n and with support ms, and f, specialize g by
 ;; composing it with f over one of its variables, xi.
@@ -14,10 +15,22 @@
 ;;         ...
 ;;         <xn>
 ;;       <g-body>
+;;     <texts>
 ;;     <ms>
-;; <f>
-;; |-
 ;; Evaluation <tv2>
+;;   Predicate "shallow-abstraction"
+;;   List
+;;     List
+;;       <x1>
+;;       ...
+;;       <xi-1>
+;;       <f>
+;;       <xi+1>
+;;       ...
+;;       <xn>
+;;     <minsup evaluation above>
+;; |-
+;; Evaluation <tv3>
 ;;   Predicate "minsup"
 ;;   List
 ;;     Put
@@ -35,14 +48,19 @@
 ;;         <xi+1>
 ;;         ...
 ;;         <xn>
+;;     <texts>
 ;;     <ms>
 ;;
-;; assuming that tv1 equals to (stv 1 1), then calculate the frequency
-;; of the composed pattern and set tv2 accordingly, (stv 1 1) if g
-;; composed with f has support ms, (stv 0 1) otherwise.
+;; assuming that tv1 and tv2 are equal to (stv 1 1), then calculate
+;; the frequency of the composed pattern and set tv3 accordingly, (stv
+;; 1 1) if g composed with f has support ms, (stv 0 1) otherwise.
 ;;
-;; <f> may either a shallow pattern (a function), a constant or a
-;; variable amongst <x1> to <xn> different than <xi>.
+;; <f> may either a pattern with one link all variables as outgoings,
+;; a constant or a variable amongst <x1> to <xn> different than <xi>.
+;;
+;; We don't need to care about the structure of (List <x1> ...)
+;; because, as presented implemented, only correct structures will be
+;; formed by the shallow-abstraction rule.
 ;;
 ;; TODO: we might want to split such rule into 2,
 ;;
@@ -54,94 +72,54 @@
 
 (load "pattern-miner-utils.scm")
 
-;; Generate composition specialization rule for a given arity and
-;; argument index ranging from 0 to arity-1.
-;;
-;; For instance (gen-specialization-rule 2 1) generates the following rule
-;;
-;; Evaluation <stv 1 1>
-;;   Predicate "minsup"
-;;   List
-;;     Lambda
-;;       VariableList
-;;         <x0>
-;;         <x1>
-;;       <g-body>
-;;     <texts>
-;;     <ms>
-;; <f>
-;; |-
-;; Evaluation <tv>
-;;   Predicate "minsup"
-;;   List
-;;     Put
-;;       Lambda
-;;         VariableList
-;;           <x0>
-;;           <x1>
-;;         <g-body>
-;;       List
-;;         <x0>
-;;         <f>
-;;     <texts>
-;;     <ms>
-(define (gen-specialization-rule arity index)
+(define specialization-rule
   (let* (;; Variables
-         (xs (gen-variables "$spe-arg" arity))
          (g (Variable "$g"))
          (texts (Variable "$texts"))
          (ms (Variable "$ms"))
-         (f (Variable "$f"))
+         (xs-f (Variable "$xs-f"))
          ;; Types
          (NumberT (Type "NumberNode"))
          (LambdaT (Type "LambdaLink"))
-         (ConceptT (Type "ConceptNode"))
-         (VariableT (Type "VariableNode"))
          (PutT (Type "PutLink"))
+         (ConceptT (Type "ConceptNode"))
          ;; Vardecls
          (g-decl (TypedVariable g (TypeChoice LambdaT PutT)))
          (texts-decl (TypedVariable texts ConceptT))
          (ms-decl (TypedVariable ms NumberT))
-         ;; TODO: for now hardwire the types of f, then later only
-         ;; accept shallow abstractions, constants from valuations, or
-         ;; variables from the variables of g.
-         (f-decl (TypedVariable f (TypeChoice LambdaT ConceptT VariableT)))
-         (vardecl (VariableList g-decl texts-decl ms-decl f-decl))
-         ;; Patterns
-         (minsup-g (minsup g texts ms))
+         (xs-f-decl xs-f)
+         (vardecl (VariableList g-decl texts-decl ms-decl xs-f-decl))
+         ;; Clauses
+         (minsup-g (minsup-eval g texts ms))
+         (shabs-eval (shallow-abstraction-eval xs-f minsup-g))
          ;; Make sure the pattern has the minimum support
-         (pre-cond-1 (Evaluation
-                       (GroundedPredicate "scm: absolutely-true")
-                       minsup-g))
-         (pre-cond-2 (Evaluation
-                       (GroundedPredicate "scm: has-arity")
-                       (List
-                         g
-                         (Number arity))))
+         (precond-1 (absolutely-true-eval minsup-g))
+         (precond-2 (absolutely-true-eval shabs-eval))
          ;; Rewrite
-         (xs-f (if (< 1 (length xs)) (List (replace-el xs index f)) f))
          (rewrite (ExecutionOutput
                     (GroundedSchema "scm: specialization-formula")
                     (List
-                      (minsup
+                      (minsup-eval
                         (Quote (Put
                           (Unquote g)
                           (Unquote xs-f)))
                         texts
                         ms)
-                      minsup-g
-                      f))))
+                      minsup-g))))      ; We ignore the f premise
+                                        ; since we're unable at this
+                                        ; moment to infer the shallow
+                                        ; abstraction backward.
     (Bind
       vardecl
-      (And minsup-g f pre-cond-1 pre-cond-2)
+      (And shabs-eval precond-1 precond-2)
       rewrite)))
 
 (define (specialization-formula conclusion . premises)
   ;; (cog-logger-debug "specialization-formula conclusion = ~a, premises = ~a"
   ;;                   conclusion premises)
-  (if (= (length premises) 2)
-      (let* ((pre-minsup-pred (car premises))
-             (con-minsup-args (gdr conclusion))
+  (if (= (length premises) 1)
+      (let* ((con-minsup-args (gdr conclusion))
+             (pre-minsup-pred (car premises))
              (pre-minsup-pred-tv (cog-tv pre-minsup-pred))
              (gf (cog-outgoing-atom con-minsup-args 0))
              (texts (cog-outgoing-atom con-minsup-args 1))
@@ -164,47 +142,8 @@
         (if conclusion-tv
             (cog-set-tv! reduced-conclusion conclusion-tv)))))
 
-;; Define unary specialization
-(define unary-specialization-rule
-  (gen-specialization-rule 1 0))
-(define unary-specialization-rule-name
-  (DefinedSchemaNode "unary-specialization-rule"))
-(DefineLink unary-specialization-rule-name
-  unary-specialization-rule)
-
-;; Define binary specialization
-(define binary-first-arg-specialization-rule
-  (gen-specialization-rule 2 0))
-(define binary-first-arg-specialization-rule-name
-  (DefinedSchemaNode "binary-first-arg-specialization-rule"))
-(DefineLink binary-first-arg-specialization-rule-name
-  binary-first-arg-specialization-rule)
-
-(define binary-second-arg-specialization-rule
-  (gen-specialization-rule 2 1))
-(define binary-second-arg-specialization-rule-name
-  (DefinedSchemaNode "binary-second-arg-specialization-rule"))
-(DefineLink binary-second-arg-specialization-rule-name
-  binary-second-arg-specialization-rule)
-
-;; Define ternary specialization
-(define ternary-first-arg-specialization-rule
-  (gen-specialization-rule 3 0))
-(define ternary-first-arg-specialization-rule-name
-  (DefinedSchemaNode "ternary-first-arg-specialization-rule"))
-(DefineLink ternary-first-arg-specialization-rule-name
-  ternary-first-arg-specialization-rule)
-
-(define ternary-second-arg-specialization-rule
-  (gen-specialization-rule 3 1))
-(define ternary-second-arg-specialization-rule-name
-  (DefinedSchemaNode "ternary-second-arg-specialization-rule"))
-(DefineLink ternary-second-arg-specialization-rule-name
-  ternary-second-arg-specialization-rule)
-
-(define ternary-third-arg-specialization-rule
-  (gen-specialization-rule 3 2))
-(define ternary-third-arg-specialization-rule-name
-  (DefinedSchemaNode "ternary-third-arg-specialization-rule"))
-(DefineLink ternary-third-arg-specialization-rule-name
-  ternary-third-arg-specialization-rule)
+;; Define specialization
+(define specialization-rule-name
+  (DefinedSchemaNode "specialization-rule"))
+(DefineLink specialization-rule-name
+  specialization-rule)

--- a/opencog/learning/xpattern-miner/ure-based/rules/specialization.scm
+++ b/opencog/learning/xpattern-miner/ure-based/rules/specialization.scm
@@ -105,10 +105,8 @@
                           (Unquote xs-f)))
                         texts
                         ms)
-                      minsup-g))))      ; We ignore the f premise
-                                        ; since we're unable at this
-                                        ; moment to infer the shallow
-                                        ; abstraction backward.
+                      minsup-g
+                      shabs-eval))))
     (Bind
       vardecl
       (And shabs-eval precond-1 precond-2)
@@ -117,7 +115,7 @@
 (define (specialization-formula conclusion . premises)
   ;; (cog-logger-debug "specialization-formula conclusion = ~a, premises = ~a"
   ;;                   conclusion premises)
-  (if (= (length premises) 1)
+  (if (= (length premises) 2)
       (let* ((con-minsup-args (gdr conclusion))
              (pre-minsup-pred (car premises))
              (pre-minsup-pred-tv (cog-tv pre-minsup-pred))

--- a/tests/learning/xpattern-miner/c++-based/XPatternMinerUTest.cxxtest
+++ b/tests/learning/xpattern-miner/c++-based/XPatternMinerUTest.cxxtest
@@ -258,8 +258,7 @@ void XPatternMinerUTest::test_AB_ABC()
 		AndXY = al(AND_LINK, X, Y),
 		InhXY = al(INHERITANCE_LINK, X, Y),
 		InhAY = al(INHERITANCE_LINK, A, Y);
-	HandleTree expected({ al(LAMBDA_LINK, VarXY, al(LOCAL_QUOTE_LINK, AndXY)),
-				          HandleTree(al(LAMBDA_LINK, VarXY, InhXY),
+	HandleTree expected({ HandleTree(al(LAMBDA_LINK, VarXY, InhXY),
 				                     { al(LAMBDA_LINK, Y, InhAY) }) });
 
 	logger().debug() << "results = " << oc_to_string(results);

--- a/tests/learning/xpattern-miner/c++-based/XPatternMinerUTest.cxxtest
+++ b/tests/learning/xpattern-miner/c++-based/XPatternMinerUTest.cxxtest
@@ -557,7 +557,7 @@ void XPatternMinerUTest::test_2conjuncts_5()
 	// connected components will be equal to the minimum frequency of
 	// each component. For that reason it should not be able to
 	// discover the desired pattern.
-	XPMParameters param(9/*minsup*/, 2/*nconjucts*/, initpat, -1/*maxdepth*/, 1/*info*/);
+	XPMParameters param(9/*minsup*/, 2/*nconjuncts*/, initpat, -1/*maxdepth*/, 1/*info*/);
 	XPatternMiner pm(_as, param);
 	HandleTree results = pm();
 	Handle non_expected_pattern = tmp_al(LAMBDA_LINK,
@@ -606,7 +606,7 @@ void XPatternMinerUTest::test_InferenceControl()
 		                        tmp_al(LIST_LINK, B, T))),
 		initpat = tmp_al(LAMBDA_LINK, vardecl, clauses);
 
-	XPMParameters param(2/*minsup*/, 3/*ngram*/, initpat, 2/*maxdepth*/, 1/*info*/);
+	XPMParameters param(2/*minsup*/, 3/*nconjuncts*/, initpat, 2/*maxdepth*/, 1/*info*/);
 	XPatternMiner pm(_as, param);
 	HandleTree results = pm();
 

--- a/tests/learning/xpattern-miner/c++-based/XPatternMinerUTest.cxxtest
+++ b/tests/learning/xpattern-miner/c++-based/XPatternMinerUTest.cxxtest
@@ -556,8 +556,8 @@ void XPatternMinerUTest::test_2conjuncts_5()
 	// Like test_2conjuncts_2 but setting the info heuristic to 1,
 	// meaning that the frequency of a conjunction of strongly
 	// connected components will be equal to the minimum frequency of
-	// each component. For that reason it should be able to discover
-	// the desired pattern.
+	// each component. For that reason it should not be able to
+	// discover the desired pattern.
 	XPMParameters param(9/*minsup*/, 2/*nconjucts*/, initpat, -1/*maxdepth*/, 1/*info*/);
 	XPatternMiner pm(_as, param);
 	HandleTree results = pm();

--- a/tests/learning/xpattern-miner/c++-based/XPatternMinerUTest.cxxtest
+++ b/tests/learning/xpattern-miner/c++-based/XPatternMinerUTest.cxxtest
@@ -81,6 +81,7 @@ XPatternMinerUTest::XPatternMinerUTest() : _scm(&_as)
 {
 	logger().set_level(Logger::INFO);
 	logger().set_timestamp_flag(false);
+	// logger().set_sync_flag(true);
 	logger().set_print_to_stdout_flag(true);
 
 	// Configure scheme load-paths that are common for all tests.

--- a/tests/learning/xpattern-miner/ure-based/UREPatternMinerUTest.cxxtest
+++ b/tests/learning/xpattern-miner/ure-based/UREPatternMinerUTest.cxxtest
@@ -50,6 +50,7 @@ private:
 	AtomSpace _as;
 	AtomSpace _tmp_as;
 	SchemeEval _scm;
+	SchemeEval _tmp_scm;
 
 	// Variables
 	Handle X, Y, Z, W;
@@ -93,6 +94,15 @@ private:
 	Handle mk_abs_true_eval(const Handle& h);
 
 	/**
+	 * Make
+	 *
+	 * (Lambda
+	 *   (VariableList X1 ... Xn)
+	 *   (And X1 ... Xn))
+	 */
+	Handle mk_nconjunct(unsigned n);
+	
+	/**
 	 * Make a URE query to mine patterns over texts with a given
 	 * minsup and a maximum of URE iterations.
 	 */
@@ -100,12 +110,14 @@ private:
 	                int depth, Handle initpat=Handle::UNDEFINED);
 
 	/**
-	 * Gen shallow pattern variables for the query, for instance if i
-	 * = 2, return
-	 *
-	 * (Variable "$shapat-2")
+	 * Generate a variable (VariableNode <prefix-i>)
 	 */
-	Handle gen_shapat_var(int i);
+	Handle gen_variable(const std::string& prefix, int i);
+
+	/**
+	 * Generate variables (VariableNode <prefix-0>) ... (VariableNode <prefix-n-1>)
+	 */
+	HandleSeq gen_variables(const std::string& prefix, int n);
 
 	/**
 	 * Return whether if a pattern has enough support.
@@ -133,15 +145,16 @@ public:
 	void test_AB_AC_BC();
 	void test_AB_ABC();
 	void test_ABCD();
-	// void test_ABAB();
-	// void test_AAAA();
-	// void test_2conjuncts_1();
-	// void test_2conjuncts_2();
-	// void test_2conjuncts_3();
-	// void test_2conjuncts_4();
+	void test_ABAB();
+	void test_AAAA();
+	void test_2conjuncts_1();
+	void test_2conjuncts_2();
+	void test_2conjuncts_3();
+	void test_2conjuncts_4();
+	// Disable for now as we do not have the corresponding heuristic
 	// void test_2conjuncts_5();
-	// void test_InferenceControl();
-	// void test_SodaDrinker();
+	void test_InferenceControl();
+	void test_SodaDrinker();
 };
 
 Handle UREPatternMinerUTest::mk_minsup_eval(int minsup,
@@ -176,37 +189,22 @@ Handle UREPatternMinerUTest::mk_abs_true_eval(const Handle& h)
 	          h);
 }
 
-Handle UREPatternMinerUTest::mk_query(const HandleSeq& texts, int minsup,
-                                      int depth, Handle initpat)
+Handle UREPatternMinerUTest::mk_nconjunct(unsigned n)
 {
-	// Make (Member text (Concept "texts)) links
-	for (const Handle& text : texts)
-		al(MEMBER_LINK, text, texts_cpt);
-
-	// If init is not defined then use top
-	if (not initpat)
-		initpat = top;
-
-	// Add the axiom that initpat has enough support
-	bool es = enough_support(initpat, minsup);
-	TruthValuePtr tv = SimpleTruthValue::createTV(es ? 1.0 : 0.0, 1.0);
-	mk_minsup_eval(minsup, initpat, tv);
-
-	// Make URE query
-	Handle folded_pattern = initpat;
-	for (int i = 0; i < depth; i++)
-		folded_pattern = al(PUT_LINK,
-		                    folded_pattern,
-		                    al(UNQUOTE_LINK,
-		                       gen_shapat_var(i)));
-	Handle query = mk_minsup_eval(minsup, al(QUOTE_LINK, folded_pattern));
-	return query;
+	return al(LAMBDA_LINK, al(AND_LINK, gen_variables("$X-", n)));
 }
 
-Handle UREPatternMinerUTest::gen_shapat_var(int i)
+Handle UREPatternMinerUTest::gen_variable(const std::string& prefix, int i)
 {
-	std::string shapat("$shapat-");
-	return an(VARIABLE_NODE, shapat + std::to_string(i));
+	return an(VARIABLE_NODE, prefix + std::to_string(i));
+}
+
+HandleSeq UREPatternMinerUTest::gen_variables(const std::string& prefix, int n)
+{
+	HandleSeq vars;
+	for (int i = 0; i < n; i++)
+		vars.push_back(gen_variable(prefix, i));
+	return vars;
 }
 
 bool UREPatternMinerUTest::enough_support(const Handle& pat, int minsup)
@@ -258,18 +256,18 @@ Handle UREPatternMinerUTest::run_pm(const HandleSeq& texts, int minsup,
 	return results;
 }
 
-UREPatternMinerUTest::UREPatternMinerUTest() : _scm(&_as)
+UREPatternMinerUTest::UREPatternMinerUTest() : _scm(&_as), _tmp_scm(&_tmp_as)
 {
 	// Main logger
-	logger().set_level(Logger::DEBUG);
+	logger().set_level(Logger::INFO);
 	logger().set_timestamp_flag(false);
-	logger().set_sync_flag(true);
+	// logger().set_sync_flag(true);
 	logger().set_print_to_stdout_flag(true);
 
 	// URE logger
-	ure_logger().set_level(Logger::DEBUG);
+	ure_logger().set_level(Logger::INFO);
 	ure_logger().set_timestamp_flag(false);
-	ure_logger().set_sync_flag(true);
+	// ure_logger().set_sync_flag(true);
 	ure_logger().set_print_to_stdout_flag(true);
 
 	// Configure scheme load-paths that are common for all tests.
@@ -367,10 +365,7 @@ void UREPatternMinerUTest::test_AB_AC_BC()
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
 	// Define texts
-	Handle A = an(CONCEPT_NODE, "A"),
-		B = an(CONCEPT_NODE, "B"),
-		C = an(CONCEPT_NODE, "C"),
-		InhAB = al(INHERITANCE_LINK, A, B),
+	Handle InhAB = al(INHERITANCE_LINK, A, B),
 		InhAC = al(INHERITANCE_LINK, A, C),
 		InhBC = al(INHERITANCE_LINK, B, C);
 	HandleSeq texts{A, B, C, InhAB, InhAC, InhBC};
@@ -398,10 +393,7 @@ void UREPatternMinerUTest::test_AB_ABC()
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
 	// Define texts
-	Handle A = an(CONCEPT_NODE, "A"),
-		B = an(CONCEPT_NODE, "B"),
-		C = an(CONCEPT_NODE, "C"),
-		InhAB = al(INHERITANCE_LINK, A, B),
+	Handle InhAB = al(INHERITANCE_LINK, A, B),
 		InhABC = al(INHERITANCE_LINK, A, al(AND_LINK, B, C));
 	HandleSeq texts{A, B, C, InhAB, InhABC};
 
@@ -458,220 +450,189 @@ void UREPatternMinerUTest::test_ABCD()
 	TS_ASSERT(content_eq(expected, results));
 }
 
-// void UREPatternMinerUTest::test_ABAB()
-// {
-// 	logger().info("BEGIN TEST: %s", __FUNCTION__);
+void UREPatternMinerUTest::test_ABAB()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-// 	Handle A = an(CONCEPT_NODE, "A"),
-// 		B = an(CONCEPT_NODE, "B"),
-// 		C = an(CONCEPT_NODE, "C"),
-// 		AB = al(INHERITANCE_LINK, A, B),
-// 		BC = al(INHERITANCE_LINK, B, C),
-// 		ABAB = al(IMPLICATION_LINK, AB, AB),
-// 		BCBC = al(IMPLICATION_LINK, BC, BC);
-	
-// 	Handle X = tmp_an(VARIABLE_NODE, "$X"),
-// 		Y = tmp_an(VARIABLE_NODE, "$Y"),
-// 		initpat = tmp_al(LAMBDA_LINK,
-// 		                 tmp_al(IMPLICATION_LINK, X, Y)),
-// 		query = mk_query({ABAB, BCBC}, 2, 2, initpat);
+	// Define texts
+	Handle AB = al(INHERITANCE_LINK, A, B),
+		BC = al(INHERITANCE_LINK, B, C),
+		ABAB = al(IMPLICATION_LINK, AB, AB),
+		BCBC = al(IMPLICATION_LINK, BC, BC);
+	HandleSeq texts{ABAB, BCBC};
 
-// 	BackwardChainer bc(_as, pm_rb, query);
-// 	bc.get_config().set_maximum_iterations(100);
-// 	bc.do_chain();
+	// Define initpat
+	Handle initpat = al(LAMBDA_LINK,
+	                    al(IMPLICATION_LINK, X, Y));
 
-// 	Handle results = bc.get_results(),
-// 		VarXY = tmp_al(VARIABLE_LIST, X, Y),
-// 		InhXY = tmp_al(INHERITANCE_LINK, X, Y),
-// 		expected = mk_minsup_eval(2,
-// 		                          tmp_al(LAMBDA_LINK,
-// 		                                 VarXY,
-// 		                                 tmp_al(IMPLICATION_LINK, InhXY, InhXY)));
+	// Run pattern miner
+	Handle results = run_pm(texts, 2, 100, initpat),
+		VarXY = al(VARIABLE_LIST, X, Y),
+		InhXY = al(INHERITANCE_LINK, X, Y),
+		expected = mk_minsup_eval(2,
+		                          al(LAMBDA_LINK,
+		                             VarXY,
+		                             al(IMPLICATION_LINK, InhXY, InhXY)));
 
-// 	logger().debug() << "results = " << oc_to_string(results);
-// 	logger().debug() << "expected = " << oc_to_string(expected);
+	logger().debug() << "results = " << oc_to_string(results);
+	logger().debug() << "expected = " << oc_to_string(expected);
 
-// 	TS_ASSERT(is_in(expected, results->getOutgoingSet()));
-// }
+	TS_ASSERT(is_in(expected, results->getOutgoingSet()));
+}
 
-// void UREPatternMinerUTest::test_AAAA()
-// {
-// 	logger().info("BEGIN TEST: %s", __FUNCTION__);
+void UREPatternMinerUTest::test_AAAA()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-// 	Handle A = an(CONCEPT_NODE, "A"),
-// 		B = an(CONCEPT_NODE, "B"),
-// 		AA = al(INHERITANCE_LINK, A, A),
-// 		BB = al(INHERITANCE_LINK, B, B),
-// 		AAAA = al(IMPLICATION_LINK, AA, AA),
-// 		BBBB = al(IMPLICATION_LINK, BB, BB);
-	
-// 	Handle X = tmp_an(VARIABLE_NODE, "$X"),
-// 		Y = tmp_an(VARIABLE_NODE, "$Y"),
-// 		initpat = tmp_al(LAMBDA_LINK,
-// 		                 tmp_al(IMPLICATION_LINK, X, Y)),
-// 		query = mk_query({AAAA, BBBB}, 2, 4, initpat);
+	// Define texts
+	Handle AA = al(INHERITANCE_LINK, A, A),
+		BB = al(INHERITANCE_LINK, B, B),
+		AAAA = al(IMPLICATION_LINK, AA, AA),
+		BBBB = al(IMPLICATION_LINK, BB, BB);
+	HandleSeq texts{AAAA, BBBB};
 
-// 	BackwardChainer bc(_as, pm_rb, query);
-// 	bc.get_config().set_maximum_iterations(1000);
-// 	bc.do_chain();
+	// Define initpat
+	Handle initpat = al(LAMBDA_LINK,
+	                    al(IMPLICATION_LINK, X, Y));
 
-// 	Handle results = bc.get_results(),
-// 		InhXX = tmp_al(INHERITANCE_LINK, X, X),
-// 		expected = tmp_al(LAMBDA_LINK,
-// 		                  tmp_al(IMPLICATION_LINK,
-// 		                         InhXX,
-// 		                         InhXX));
+	// Run pattern miner
+	Handle results = run_pm(texts, 2, 100, initpat),
+		InhXX = al(INHERITANCE_LINK, X, X),
+		expected = mk_minsup_eval(2,
+		                          al(LAMBDA_LINK,
+		                             al(IMPLICATION_LINK,
+		                                InhXX,
+		                                InhXX)));
 
-// 	logger().debug() << "results = " << oc_to_string(results);
-// 	logger().debug() << "expected = " << oc_to_string(expected);
+	logger().debug() << "results = " << oc_to_string(results);
+	logger().debug() << "expected = " << oc_to_string(expected);
 
-// 	TS_ASSERT(is_in(expected, results->getOutgoingSet()));
-// }
+	TS_ASSERT(is_in(expected, results->getOutgoingSet()));
+}
 
-// void UREPatternMinerUTest::test_2conjuncts_1()
-// {
-// 	logger().info("BEGIN TEST: %s", __FUNCTION__);
+void UREPatternMinerUTest::test_2conjuncts_1()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-// 	Handle
-// 		A = an(CONCEPT_NODE, "A"),
-// 		B = an(CONCEPT_NODE, "B"),
-// 		C1 = an(CONCEPT_NODE, "C1"),
-// 		C2 = an(CONCEPT_NODE, "C2"),
-// 		AB = al(INHERITANCE_LINK, A, B),
-// 		BC1 = al(INHERITANCE_LINK, B, C1),
-// 		BC2 = al(INHERITANCE_LINK, B, C2);
+	// Define texts
+	Handle C1 = an(CONCEPT_NODE, "C1"),
+		C2 = an(CONCEPT_NODE, "C2"),
+		AB = al(INHERITANCE_LINK, A, B),
+		BC1 = al(INHERITANCE_LINK, B, C1),
+		BC2 = al(INHERITANCE_LINK, B, C2);
+	HandleSeq texts{AB, BC1, BC2};
 
-// 	Handle
-// 		X = tmp_an(VARIABLE_NODE, "$X"),
-// 		Y = tmp_an(VARIABLE_NODE, "$Y"),
-// 		XY = tmp_al(VARIABLE_LIST, X, Y);
+	// Define initpat
+	Handle XY = al(VARIABLE_LIST, X, Y),
+		initpat = al(LAMBDA_LINK,
+		             XY,
+		             al(AND_LINK,
+		                al(INHERITANCE_LINK, X, A),
+		                al(INHERITANCE_LINK, A, Y)));
 
-// 	Handle initpat = tmp_al(LAMBDA_LINK,
-// 	                        XY,
-// 	                        tmp_al(AND_LINK,
-// 	                               tmp_al(INHERITANCE_LINK, X, A),
-// 	                               tmp_al(INHERITANCE_LINK, A, Y)));
+	// Run pattern miner
+	Handle results = run_pm(texts, 2, 10, initpat);
 
-// 	XPMParameters param(2, 2, initpat);
-// 	XPatternMiner pm(_as, param);
-// 	HandleTree results = pm();
+	logger().debug() << "results = " << oc_to_string(results);
 
-// 	logger().debug() << "results = " << oc_to_string(results);
+	TS_ASSERT(results->getOutgoingSet().empty());
+}
 
-// 	TS_ASSERT(results.empty());
-// }
+void UREPatternMinerUTest::test_2conjuncts_2()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-// void UREPatternMinerUTest::test_2conjuncts_2()
-// {
-// 	logger().info("BEGIN TEST: %s", __FUNCTION__);
+	// Define texts
+	Handle C1 = an(CONCEPT_NODE, "C1"),
+		C2 = an(CONCEPT_NODE, "C2"),
+		AB = al(INHERITANCE_LINK, A, B),
+		BC1 = al(INHERITANCE_LINK, B, C1),
+		BC2 = al(INHERITANCE_LINK, B, C2);
+	HandleSeq texts{AB, BC1, BC2};
 
-// 	Handle
-// 		A = an(CONCEPT_NODE, "A"),
-// 		B = an(CONCEPT_NODE, "B"),
-// 		C1 = an(CONCEPT_NODE, "C1"),
-// 		C2 = an(CONCEPT_NODE, "C2"),
-// 		AB = al(INHERITANCE_LINK, A, B),
-// 		BC1 = al(INHERITANCE_LINK, B, C1),
-// 		BC2 = al(INHERITANCE_LINK, B, C2);
+	// Define initpat
+	Handle XYZ = al(VARIABLE_LIST, X, Y, Z),
+		XYZW = al(VARIABLE_LIST, X, Y, Z, W),
+		initpat = al(LAMBDA_LINK,
+		             XYZW,
+		             al(AND_LINK,
+		                al(INHERITANCE_LINK, X, Y),
+		                al(INHERITANCE_LINK, Z, W)));
 
-// 	Handle
-// 		X = tmp_an(VARIABLE_NODE, "$X"),
-// 		Y = tmp_an(VARIABLE_NODE, "$Y"),
-// 		Z = tmp_an(VARIABLE_NODE, "$Z"),
-// 		W = tmp_an(VARIABLE_NODE, "$W"),
-// 		XYZ = tmp_al(VARIABLE_LIST, X, Y, Z),
-// 		XYZW = tmp_al(VARIABLE_LIST, X, Y, Z, W);
+	// Run pattern miner
+	Handle results = run_pm(texts, 2, 100, initpat);
+	Handle expected_pattern = mk_minsup_eval(2,
+	                                         al(LAMBDA_LINK,
+	                                            XYZ,
+	                                            al(AND_LINK,
+	                                               al(INHERITANCE_LINK, X, Y),
+	                                               al(INHERITANCE_LINK, Y, Z))));
 
-// 	Handle initpat = tmp_al(LAMBDA_LINK,
-// 	                        XYZW,
-// 	                        tmp_al(AND_LINK,
-// 	                               tmp_al(INHERITANCE_LINK, X, Y),
-// 	                               tmp_al(INHERITANCE_LINK, Z, W)));
-// 	XPMParameters param(2, 2, initpat);
-// 	XPatternMiner pm(_as, param);
-// 	HandleTree results = pm();
-// 	Handle expected_pattern = tmp_al(LAMBDA_LINK,
-// 	                                 XYZ,
-// 	                                 tmp_al(AND_LINK,
-// 	                                        tmp_al(INHERITANCE_LINK, X, Y),
-// 	                                        tmp_al(INHERITANCE_LINK, Y, Z)));
+	logger().debug() << "results = " << oc_to_string(results);
+	logger().debug() << "expected_pattern = " << oc_to_string(expected_pattern);
 
-// 	logger().debug() << "results = " << oc_to_string(results);
-// 	logger().debug() << "expected_pattern = " << oc_to_string(expected_pattern);
+	TS_ASSERT(is_in(expected_pattern, results->getOutgoingSet()));
+}
 
-// 	TS_ASSERT(content_is_in(expected_pattern, results));
-// }
+void UREPatternMinerUTest::test_2conjuncts_3()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-// void UREPatternMinerUTest::test_2conjuncts_3()
-// {
-// 	logger().info("BEGIN TEST: %s", __FUNCTION__);
+	// Define texts
+	Handle C1 = an(CONCEPT_NODE, "C1"),
+		C2 = an(CONCEPT_NODE, "C2"),
+		AB = al(INHERITANCE_LINK, A, B),
+		BC1 = al(INHERITANCE_LINK, B, C1),
+		BC2 = al(INHERITANCE_LINK, B, C2);
+	HandleSeq texts{AB, BC1, BC2};
 
-// 	Handle
-// 		A = an(CONCEPT_NODE, "A"),
-// 		B = an(CONCEPT_NODE, "B"),
-// 		C1 = an(CONCEPT_NODE, "C1"),
-// 		C2 = an(CONCEPT_NODE, "C2"),
-// 		AB = al(INHERITANCE_LINK, A, B),
-// 		BC1 = al(INHERITANCE_LINK, B, C1),
-// 		BC2 = al(INHERITANCE_LINK, B, C2);
+	// Run pattern miner
+	Handle results = run_pm(texts, 2, 500, mk_nconjunct(2)),
+		XYZ = al(VARIABLE_LIST, X, Y, Z),
+		expected_pattern = mk_minsup_eval(2,
+		                                  al(LAMBDA_LINK,
+		                                     XYZ,
+		                                     al(AND_LINK,
+		                                        al(INHERITANCE_LINK, X, Y),
+		                                        al(INHERITANCE_LINK, Y, Z))));
 
-// 	Handle
-// 		X = tmp_an(VARIABLE_NODE, "$X"),
-// 		Y = tmp_an(VARIABLE_NODE, "$Y"),
-// 		Z = tmp_an(VARIABLE_NODE, "$Z"),
-// 		XYZ = tmp_al(VARIABLE_LIST, X, Y, Z);
+	logger().debug() << "results = " << oc_to_string(results);
+	logger().debug() << "expected_pattern = " << oc_to_string(expected_pattern);
 
-// 	XPMParameters param(2, 2);
-// 	XPatternMiner pm(_as, param);
-// 	HandleTree results = pm();
-// 	Handle expected_pattern = tmp_al(LAMBDA_LINK,
-// 	                                 XYZ,
-// 	                                 tmp_al(AND_LINK,
-// 	                                        tmp_al(INHERITANCE_LINK, X, Y),
-// 	                                        tmp_al(INHERITANCE_LINK, Y, Z)));
+	TS_ASSERT(is_in(expected_pattern, results->getOutgoingSet()));
+}
 
-// 	logger().debug() << "results = " << oc_to_string(results);
-// 	logger().debug() << "expected_pattern = " << oc_to_string(expected_pattern);
+void UREPatternMinerUTest::test_2conjuncts_4()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-// 	TS_ASSERT(content_is_in(expected_pattern, results));
-// }
+	// Define texts
+	Handle A1 = an(CONCEPT_NODE, "A1"),
+		A2 = an(CONCEPT_NODE, "A2"),
+		B = an(CONCEPT_NODE, "B"),
+		C1 = an(CONCEPT_NODE, "C1"),
+		C2 = an(CONCEPT_NODE, "C2"),
+		A1B = al(INHERITANCE_LINK, A1, B),
+		A2B = al(INHERITANCE_LINK, A2, B),
+		BC1 = al(INHERITANCE_LINK, B, C1),
+		BC2 = al(INHERITANCE_LINK, B, C2);
+	HandleSeq texts{A1B, A2B, BC1, BC2};
 
-// void UREPatternMinerUTest::test_2conjuncts_4()
-// {
-// 	logger().info("BEGIN TEST: %s", __FUNCTION__);
+	// Run pattern miner
+	Handle results = run_pm(texts, 4, 100, mk_nconjunct(2)),
+		VarXYZ = al(VARIABLE_LIST, X, Y, Z),
+		expected_pattern = mk_minsup_eval(4,
+		                                  al(LAMBDA_LINK,
+		                                     VarXYZ,
+		                                     al(AND_LINK,
+		                                        al(INHERITANCE_LINK, X, Y),
+		                                        al(INHERITANCE_LINK, Y, Z))));
 
-// 	Handle
-// 		A1 = an(CONCEPT_NODE, "A1"),
-// 		A2 = an(CONCEPT_NODE, "A2"),
-// 		B = an(CONCEPT_NODE, "B"),
-// 		C1 = an(CONCEPT_NODE, "C1"),
-// 		C2 = an(CONCEPT_NODE, "C2"),
-// 		A1B = al(INHERITANCE_LINK, A1, B),
-// 		A2B = al(INHERITANCE_LINK, A2, B),
-// 		BC1 = al(INHERITANCE_LINK, B, C1),
-// 		BC2 = al(INHERITANCE_LINK, B, C2);
+	logger().debug() << "results = " << oc_to_string(results);
+	logger().debug() << "expected_pattern = " << oc_to_string(expected_pattern);
 
-// 	Handle
-// 		X = tmp_an(VARIABLE_NODE, "$X"),
-// 		Y = tmp_an(VARIABLE_NODE, "$Y"),
-// 		Z = tmp_an(VARIABLE_NODE, "$Z"),
-// 		VXY = tmp_al(VARIABLE_LIST, X, Y),
-// 		VXYZ = tmp_al(VARIABLE_LIST, X, Y, Z);
-
-// 	XPMParameters param(4, 2);
-// 	XPatternMiner pm(_as, param);
-// 	HandleTree results = pm();
-// 	Handle expected_pattern = tmp_al(LAMBDA_LINK,
-// 	                                 VXYZ,
-// 	                                 tmp_al(AND_LINK,
-// 	                                        tmp_al(INHERITANCE_LINK, X, Y),
-// 	                                        tmp_al(INHERITANCE_LINK, Y, Z)));
-
-// 	logger().debug() << "results = " << oc_to_string(results);
-// 	logger().debug() << "expected_pattern = " << oc_to_string(expected_pattern);
-
-// 	TS_ASSERT(content_is_in(expected_pattern, results));
-// }
+	TS_ASSERT(is_in(expected_pattern, results->getOutgoingSet()));
+}
 
 // void UREPatternMinerUTest::test_2conjuncts_5()
 // {
@@ -726,150 +687,152 @@ void UREPatternMinerUTest::test_ABCD()
 // 	TS_ASSERT(not content_is_in(non_expected_pattern, results));
 // }
 
-// void UREPatternMinerUTest::test_InferenceControl()
-// {
-// 	logger().info("BEGIN TEST: %s", __FUNCTION__);
+void UREPatternMinerUTest::test_InferenceControl()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-// 	// Load inference-control-corpus.scm
-// 	std::string rs =
-// 		_scm.eval("(load-from-path \"inference-control-corpus.scm\")");
+	// Define texts
+	// Load inference-control-corpus.scm to _tmp_as
+	std::string rs =
+		_tmp_scm.eval("(load-from-path \"inference-control-corpus.scm\")");
+	logger().debug() << "rs = " << rs;
+	HandleSeq texts;
+	_tmp_as.get_all_atoms(texts);
 
-// 	logger().debug() << "rs = " << rs;
+	// Define initpat
+	Handle expand = an(SCHEMA_NODE, "URE:BC:expand-and-BIT"),
+		preproof = an(PREDICATE_NODE, "URE:BC:preproof-of"),
+		rule = an(DEFINED_SCHEMA_NODE,
+		          "conditional-full-instantiation-implication-scope-meta-rule"),
+		de_rule = al(DONT_EXEC_LINK, rule),
+		VarT = an(VARIABLE_NODE, "$T"),
+		VarA = an(VARIABLE_NODE, "$A"),
+		VarL = an(VARIABLE_NODE, "$L"),
+		VarB = an(VARIABLE_NODE, "$B"),
+		vardecl = al(VARIABLE_LIST, VarT, VarA, VarL, VarB),
+		clauses = al(AND_LINK,
+		             al(EXECUTION_LINK,
+		                expand,
+		                al(LIST_LINK, VarA, VarL, de_rule),
+		                VarB),
+		             al(EVALUATION_LINK,
+		                preproof,
+		                al(LIST_LINK, VarA, VarT)),
+		             al(EVALUATION_LINK,
+		                preproof,
+		                al(LIST_LINK, VarB, VarT))),
+		initpat = al(LAMBDA_LINK, vardecl, clauses);
 
-// 	// Run the pattern miner
-// 	Handle expand = tmp_an(SCHEMA_NODE, "URE:BC:expand-and-BIT"),
-// 		preproof = tmp_an(PREDICATE_NODE, "URE:BC:preproof-of"),
-// 		rule = tmp_an(DEFINED_SCHEMA_NODE,
-// 		              "conditional-full-instantiation-implication-scope-meta-rule"),
-// 		de_rule = tmp_al(DONT_EXEC_LINK, rule),
-// 		T = tmp_an(VARIABLE_NODE, "$T"),
-// 		A = tmp_an(VARIABLE_NODE, "$A"),
-// 		L = tmp_an(VARIABLE_NODE, "$L"),
-// 		B = tmp_an(VARIABLE_NODE, "$B"),
-// 		vardecl = tmp_al(VARIABLE_LIST, T, A, L, B),
-// 		clauses = tmp_al(AND_LINK,
-// 		                 tmp_al(EXECUTION_LINK,
-// 		                        expand,
-// 		                        tmp_al(LIST_LINK, A, L, de_rule),
-// 		                        B),
-// 		                 tmp_al(EVALUATION_LINK,
-// 		                        preproof,
-// 		                        tmp_al(LIST_LINK, A, T)),
-// 		                 tmp_al(EVALUATION_LINK,
-// 		                        preproof,
-// 		                        tmp_al(LIST_LINK, B, T))),
-// 		initpat = tmp_al(LAMBDA_LINK, vardecl, clauses);
+	// Run pattern miner
+	Handle results = run_pm(texts, 2, 1000, initpat);
 
-// 	XPMParameters param(2/*minsup*/, 3/*ngram*/, initpat, 2/*maxdepth*/, 1/*info*/);
-// 	XPatternMiner pm(_as, param);
-// 	HandleTree results = pm();
+	// The pattern of interest looks like
+	//
+	// Lambda
+	//   T A X B
+	// And
+	//   Execution
+	//     Schema "expand"
+	//     List
+	//       A
+	//       Inheritance
+	//         ConceptNode "a"
+	//         X
+	//       GroundedSchemaNode "scm: conditional-full-instantiation-scope-formula"
+	//     B
+	//   Evaluation
+	//     Predicate "preproof-of"
+	//     List
+	//       A
+	//       T
+	//   Evaluation
+	//     Predicate "preproof-of"
+	//     List
+	//       B
+	//       T
+	Handle a = an(CONCEPT_NODE, "a"),
+		expected_vardecl = al(VARIABLE_LIST, VarT, VarA, X, VarB),
+		expected_clauses = al(AND_LINK,
+		                      al(EXECUTION_LINK,
+		                         expand,
+		                         al(LIST_LINK,
+		                            VarA,
+		                            al(INHERITANCE_LINK, a, X),
+		                            de_rule),
+		                         VarB),
+		                      al(EVALUATION_LINK,
+		                         preproof,
+		                         al(LIST_LINK, VarA, VarT)),
+		                      al(EVALUATION_LINK,
+		                         preproof,
+		                         al(LIST_LINK, VarB, VarT))),
+		expected_pattern = mk_minsup_eval(2,
+		                                  al(LAMBDA_LINK,
+		                                     expected_vardecl,
+		                                     expected_clauses));
 
-// 	// The pattern of interest looks like
-// 	//
-// 	// Lambda
-// 	//   T A X B
-// 	// And
-// 	//   Execution
-// 	//     Schema "expand"
-// 	//     List
-// 	//       A
-// 	//       Inheritance
-// 	//         ConceptNode "a"
-// 	//         X
-// 	//       GroundedSchemaNode "scm: conditional-full-instantiation-scope-formula"
-// 	//     B
-// 	//   Evaluation
-// 	//     Predicate "preproof"
-// 	//     A
-// 	//   Evaluation
-// 	//     Predicate "preproof"
-// 	//     B
-// 	Handle a = tmp_an(CONCEPT_NODE, "a"),
-// 		X = tmp_an(VARIABLE_NODE, "$X"),
-// 		expected_vardecl = tmp_al(VARIABLE_LIST, T, A, X, B),
-// 		expected_clauses = tmp_al(AND_LINK,
-// 		                          tmp_al(EXECUTION_LINK,
-// 		                                 expand,
-// 		                                 tmp_al(LIST_LINK,
-// 		                                        A,
-// 		                                        tmp_al(INHERITANCE_LINK, a, X),
-// 		                                        de_rule),
-// 		                                 B),
-// 		                          tmp_al(EVALUATION_LINK,
-// 		                                 preproof,
-// 		                                 tmp_al(LIST_LINK, A, T)),
-// 		                          tmp_al(EVALUATION_LINK,
-// 		                                 preproof,
-// 		                                 tmp_al(LIST_LINK, B, T))),
-// 		expected_pattern = tmp_al(LAMBDA_LINK,
-// 		                          expected_vardecl,
-// 		                          expected_clauses);
+	logger().debug() << "results = " << oc_to_string(results);
+	logger().debug() << "expected_pattern = " << oc_to_string(expected_pattern);
 
-// 	logger().debug() << "results = " << oc_to_string(results);
-// 	logger().debug() << "expected_pattern = " << oc_to_string(expected_pattern);
+	TS_ASSERT(is_in(expected_pattern, results->getOutgoingSet()));
+}
 
-// 	TS_ASSERT(content_is_in(expected_pattern, results));
-// }
+void UREPatternMinerUTest::test_SodaDrinker()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-// void UREPatternMinerUTest::test_SodaDrinker()
-// {
-// 	logger().info("BEGIN TEST: %s", __FUNCTION__);
+	// Define texts
+	// Load ugly-male-soda-drinker-corpus.scm
+	std::string rs =
+		_tmp_scm.eval("(load-from-path \"ugly-male-soda-drinker-corpus.scm\")");
+	logger().debug() << "rs = " << rs;
+	HandleSeq texts;
+	_tmp_as.get_all_atoms(texts);
 
-// 	// Load ugly-male-soda-drinker-corpus.scm
-// 	std::string rs =
-// 		_scm.eval("(load-from-path \"ugly-male-soda-drinker-corpus.scm\")");
+	// Define initial pattern (to speed up mining)
+	Handle XYZW = al(VARIABLE_LIST, X, Y, Z, W),
+		clauses = al(AND_LINK,
+		             al(INHERITANCE_LINK, X, Y),
+		             al(INHERITANCE_LINK, X, Z),
+		             al(INHERITANCE_LINK, X, W)),
+		initpat = al(LAMBDA_LINK, XYZW, clauses);
 
-// 	logger().debug() << "rs = " << rs;
+	// Run the pattern miner
+	Handle results = run_pm(texts, 5, 1000, initpat);
 
-// 	// Define initial pattern (to speed up mining)
-// 	Handle X = tmp_an(VARIABLE_NODE, "$X"),
-// 		Y = tmp_an(VARIABLE_NODE, "$Y"),
-// 		Z = tmp_an(VARIABLE_NODE, "$Z"),
-// 		W = tmp_an(VARIABLE_NODE, "$W"),
-// 		XYZW = tmp_al(VARIABLE_LIST, X, Y, Z, W),
-// 		clauses = tmp_al(AND_LINK,
-// 		                 tmp_al(INHERITANCE_LINK, X, Y),
-// 		                 tmp_al(INHERITANCE_LINK, X, Z),
-// 		                 tmp_al(INHERITANCE_LINK, X, W)),
-// 		initpat = tmp_al(LAMBDA_LINK, XYZW, clauses);
+	// The pattern of interest looks like
+	//
+	// Lambda
+	//   X
+	// And
+	//   Inheritance
+	//     X
+	//     Concept "man"
+	//   Inheritance
+	//     X
+	//     Concept "soda drinker"
+	//   Inheritance
+	//     X
+	//     Concept "ugly"
+	Handle man = an(CONCEPT_NODE, "man"),
+		soda_drinker = an(CONCEPT_NODE, "soda drinker"),
+		ugly = an(CONCEPT_NODE, "ugly"),
+		is_man = al(INHERITANCE_LINK, X, man),
+		is_soda_drinker = al(INHERITANCE_LINK, X, soda_drinker),
+		is_ugly = al(INHERITANCE_LINK, X, ugly),
+		expected_pattern = mk_minsup_eval(5,
+		                                  al(LAMBDA_LINK,
+		                                     X,
+		                                     al(AND_LINK,
+		                                        is_man,
+		                                        is_soda_drinker,
+		                                        is_ugly)));
 
-// 	// Run the pattern miner
-// 	XPMParameters param(5/*minsup*/, 3/*nconjuncts*/, initpat, 3/*maxdepth*/, 1/*info*/);
-// 	XPatternMiner pm(_as, param);
-// 	HandleTree results = pm();
+	logger().debug() << "results = " << oc_to_string(results);
+	logger().debug() << "expected_pattern = " << oc_to_string(expected_pattern);
 
-// 	// The pattern of interest looks like
-// 	//
-// 	// Lambda
-// 	//   X
-// 	// And
-// 	//   Inheritance
-// 	//     X
-// 	//     Concept "man"
-// 	//   Inheritance
-// 	//     X
-// 	//     Concept "soda drinker"
-// 	//   Inheritance
-// 	//     X
-// 	//     Concept "ugly"
-// 	Handle man = tmp_an(CONCEPT_NODE, "man"),
-// 		soda_drinker = tmp_an(CONCEPT_NODE, "soda drinker"),
-// 		ugly = tmp_an(CONCEPT_NODE, "ugly"),
-// 		is_man = tmp_al(INHERITANCE_LINK, X, man),
-// 		is_soda_drinker = tmp_al(INHERITANCE_LINK, X, soda_drinker),
-// 		is_ugly = tmp_al(INHERITANCE_LINK, X, ugly),
-// 		expected_pattern = tmp_al(LAMBDA_LINK,
-// 		                          X,
-// 		                          tmp_al(AND_LINK,
-// 		                                 is_man,
-// 		                                 is_soda_drinker,
-// 		                                 is_ugly));
-
-// 	logger().debug() << "results = " << oc_to_string(results);
-// 	logger().debug() << "expected_pattern = " << oc_to_string(expected_pattern);
-
-// 	TS_ASSERT(content_is_in(expected_pattern, results));
-// }
+	TS_ASSERT(is_in(expected_pattern, results->getOutgoingSet()));
+}
 
 #undef al
 #undef an

--- a/tests/learning/xpattern-miner/ure-based/UREPatternMinerUTest.cxxtest
+++ b/tests/learning/xpattern-miner/ure-based/UREPatternMinerUTest.cxxtest
@@ -28,6 +28,8 @@
 #include <opencog/util/algorithm.h>
 #include <opencog/truthvalue/SimpleTruthValue.h>
 #include <opencog/atomspace/AtomSpace.h>
+#include <opencog/query/BindLinkAPI.h>
+#include <opencog/rule-engine/forwardchainer/ForwardChainer.h>
 #include <opencog/rule-engine/backwardchainer/BackwardChainer.h>
 #include <opencog/rule-engine/URELogger.h>
 #include <opencog/guile/SchemeEval.h>
@@ -82,6 +84,15 @@ private:
 	                       TruthValuePtr tv=TruthValue::DEFAULT_TV());
 
 	/**
+	 * Make
+	 *
+	 * (Evaluation
+	 *   (GroundedPredicate "scm: absolutely-true")
+	 *   h)
+	 */
+	Handle mk_abs_true_eval(const Handle& h);
+
+	/**
 	 * Make a URE query to mine patterns over texts with a given
 	 * minsup and a maximum of URE iterations.
 	 */
@@ -101,6 +112,13 @@ private:
 	 */
 	bool enough_support(const Handle& pat, int ms);
 
+	/**
+	 * Generate a query, run the URE forward to generate patterns,
+	 * then backward to gather the results, and output them.
+	 */
+	Handle run_pm(const HandleSeq& texts, int minsup,
+	              int max_iter, Handle initpat=Handle::UNDEFINED);
+
 public:
 	UREPatternMinerUTest();
 	~UREPatternMinerUTest();
@@ -115,7 +133,7 @@ public:
 	void test_AB_AC_BC();
 	void test_AB_ABC();
 	void test_ABCD();
-	void test_ABAB();
+	// void test_ABAB();
 	// void test_AAAA();
 	// void test_2conjuncts_1();
 	// void test_2conjuncts_2();
@@ -136,6 +154,7 @@ Handle UREPatternMinerUTest::mk_minsup_eval(int minsup,
 	                             pattern,
 	                             texts_cpt,
 	                             an(NUMBER_NODE, to_string(minsup))));
+	// Warning: if minsup_eval_h existed, this may erase its TV
 	minsup_eval_h->setTruthValue(tv);
 	return minsup_eval_h;
 }
@@ -148,6 +167,13 @@ Handle UREPatternMinerUTest::mk_minsup_evals(int minsup,
 	for (const Handle& pat : patterns)
 		minsup_evals.push_back(mk_minsup_eval(2, pat, tv));
 	return al(SET_LINK, minsup_evals);
+}
+
+Handle UREPatternMinerUTest::mk_abs_true_eval(const Handle& h)
+{
+	return al(EVALUATION_LINK,
+	          an(GROUNDED_PREDICATE_NODE, "scm: absolutely-true"),
+	          h);
 }
 
 Handle UREPatternMinerUTest::mk_query(const HandleSeq& texts, int minsup,
@@ -194,16 +220,54 @@ bool UREPatternMinerUTest::enough_support(const Handle& pat, int minsup)
 	return minsup <= freq;
 }
 
+Handle UREPatternMinerUTest::run_pm(const HandleSeq& texts, int minsup,
+                                    int maxiter, Handle initpat)
+{
+	// Make (Member text (Concept "texts)) links
+	for (const Handle& text : texts)
+		al(MEMBER_LINK, text, texts_cpt);
+
+	// If init is not defined then use top
+	if (not initpat)
+		initpat = top;
+
+	// Add the axiom that initpat has enough support, and use it as
+	// source for the forward chainer
+	bool es = enough_support(initpat, minsup);
+	// If it doesn't have enough support return the empy solution
+	if (not es)
+		return al(SET_LINK);
+	TruthValuePtr tv = SimpleTruthValue::createTV(es ? 1.0 : 0.0, 1.0);
+	Handle source = mk_minsup_eval(minsup, initpat, tv);
+
+	// Run the foward chainer from the initial pattern
+	ForwardChainer fc(_as, pm_rb, source);
+	fc.get_config().set_maximum_iterations(maxiter);
+	fc.do_chain();
+
+	// Run the pattern matcher query to gather the knowledge of
+	// interest, i.e. patterns reaching the minimum support, and
+	// return the results.
+	Handle patvar = an(VARIABLE_NODE, "$patvar"),
+		target = mk_minsup_eval(minsup, patvar),
+		vardecl = al(TYPED_VARIABLE_LINK, patvar, an(TYPE_NODE, "LambdaLink")),
+		abs_true = mk_abs_true_eval(target),
+		bl = al(BIND_LINK, vardecl, al(AND_LINK, target, abs_true), target),
+		results = bindlink(&_as, bl);
+
+	return results;
+}
+
 UREPatternMinerUTest::UREPatternMinerUTest() : _scm(&_as)
 {
 	// Main logger
-	logger().set_level(Logger::INFO);
+	logger().set_level(Logger::DEBUG);
 	logger().set_timestamp_flag(false);
 	logger().set_sync_flag(true);
 	logger().set_print_to_stdout_flag(true);
 
 	// URE logger
-	ure_logger().set_level(Logger::INFO);
+	ure_logger().set_level(Logger::DEBUG);
 	ure_logger().set_timestamp_flag(false);
 	ure_logger().set_sync_flag(true);
 	ure_logger().set_print_to_stdout_flag(true);
@@ -251,12 +315,7 @@ void UREPatternMinerUTest::test_A()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-	Handle query = mk_query({A}, 2, 1);
-	BackwardChainer bc(_as, pm_rb, query);
-	bc.get_config().set_maximum_iterations(100);
-	bc.do_chain();
-
-	Handle results = bc.get_results(),
+	Handle results = run_pm({A}, 2, 10),
 		expected = al(SET_LINK);
 
 	logger().debug() << "results = " << oc_to_string(results);
@@ -269,11 +328,7 @@ void UREPatternMinerUTest::test_AB()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-	Handle query = mk_query({A, B}, 2, 1);
-	BackwardChainer bc(_as, pm_rb, query);
-	bc.do_chain();
-
-	Handle results = bc.get_results(),
+	Handle results = run_pm({A, B}, 2, 10),
 		expected = mk_minsup_evals(2, {top});
 
 	logger().debug() << "results = " << oc_to_string(results);
@@ -286,14 +341,13 @@ void UREPatternMinerUTest::test_AB_AC()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
+	// Define texts
 	Handle AB = al(INHERITANCE_LINK, A, B),
-		AC = al(INHERITANCE_LINK, A, C),
-		query = mk_query({AB, AC}, 2, 2);
-	BackwardChainer bc(_as, pm_rb, query);
-	bc.get_config().set_maximum_iterations(100);
-	bc.do_chain();
+		AC = al(INHERITANCE_LINK, A, C);
+	HandleSeq texts{AB, AC};
 
-	Handle results = bc.get_results(),
+	// Run pattern miner
+	Handle results = run_pm(texts, 2, 10),
 		VarXY = al(VARIABLE_LIST, X, Y),
 		InhXY = al(INHERITANCE_LINK, X, Y),
 		InhAY = al(INHERITANCE_LINK, A, Y),
@@ -312,19 +366,17 @@ void UREPatternMinerUTest::test_AB_AC_BC()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
+	// Define texts
 	Handle A = an(CONCEPT_NODE, "A"),
 		B = an(CONCEPT_NODE, "B"),
 		C = an(CONCEPT_NODE, "C"),
 		InhAB = al(INHERITANCE_LINK, A, B),
 		InhAC = al(INHERITANCE_LINK, A, C),
-		InhBC = al(INHERITANCE_LINK, B, C),
-		query = mk_query({A, B, C, InhAB, InhAC, InhBC}, 2, 2);
+		InhBC = al(INHERITANCE_LINK, B, C);
+	HandleSeq texts{A, B, C, InhAB, InhAC, InhBC};
 
-	BackwardChainer bc(_as, pm_rb, query);
-	bc.get_config().set_maximum_iterations(100);
-	bc.do_chain();
-
-	Handle results = bc.get_results(),
+	// Run pattern miner
+	Handle results = run_pm(texts, 2, 100),
 		VarXY = al(VARIABLE_LIST, X, Y),
 		InhXY = al(INHERITANCE_LINK, X, Y),
 		InhAY = al(INHERITANCE_LINK, A, Y),
@@ -345,18 +397,16 @@ void UREPatternMinerUTest::test_AB_ABC()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
+	// Define texts
 	Handle A = an(CONCEPT_NODE, "A"),
 		B = an(CONCEPT_NODE, "B"),
 		C = an(CONCEPT_NODE, "C"),
 		InhAB = al(INHERITANCE_LINK, A, B),
-		InhABC = al(INHERITANCE_LINK, A, al(AND_LINK, B, C)),
-		query = mk_query({A, B, C, InhAB, InhABC}, 2, 2);
+		InhABC = al(INHERITANCE_LINK, A, al(AND_LINK, B, C));
+	HandleSeq texts{A, B, C, InhAB, InhABC};
 
-	BackwardChainer bc(_as, pm_rb, query);
-	bc.get_config().set_maximum_iterations(100);
-	bc.do_chain();
-
-	Handle results = bc.get_results(),
+	// Run pattern miner
+	Handle results = run_pm(texts, 2, 100),
 		VarXY = al(VARIABLE_LIST, X, Y),
 		AndXY = al(AND_LINK, X, Y),
 		InhXY = al(INHERITANCE_LINK, X, Y),
@@ -376,6 +426,7 @@ void UREPatternMinerUTest::test_ABCD()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
+	// Define texts
 	Handle InhAB = al(INHERITANCE_LINK, A, B),
 		InhCD = al(INHERITANCE_LINK, C, D),
 		InhEF = al(INHERITANCE_LINK, E, F),
@@ -384,16 +435,14 @@ void UREPatternMinerUTest::test_ABCD()
 		ImpEFGH = al(IMPLICATION_LINK, InhEF, InhGH),
 		InhXY = al(INHERITANCE_LINK, X, Y),
 		InhZW = al(INHERITANCE_LINK, Z, W),
-		ImpXY = al(IMPLICATION_LINK, X, Y),
-		initpat = al(LAMBDA_LINK, ImpXY),
-		query = mk_query({InhAB, InhCD, InhEF, InhGH, ImpABCD, ImpEFGH},
-		                 2, 2, initpat);
+		ImpXY = al(IMPLICATION_LINK, X, Y);
+	HandleSeq texts{InhAB, InhCD, InhEF, InhGH, ImpABCD, ImpEFGH};
 
-	BackwardChainer bc(_as, pm_rb, query);
-	bc.get_config().set_maximum_iterations(100);
-	bc.do_chain();
+	// Define initpat
+	Handle initpat = al(LAMBDA_LINK, ImpXY);
 
-	Handle results = bc.get_results(),
+	// Run pattern miner
+	Handle results = run_pm(texts, 2, 100, initpat),
 		expected = mk_minsup_evals(2,
 		                           { al(LAMBDA_LINK, ImpXY),
 				                     al(LAMBDA_LINK,
@@ -409,41 +458,41 @@ void UREPatternMinerUTest::test_ABCD()
 	TS_ASSERT(content_eq(expected, results));
 }
 
-void UREPatternMinerUTest::test_ABAB()
-{
-	logger().info("BEGIN TEST: %s", __FUNCTION__);
+// void UREPatternMinerUTest::test_ABAB()
+// {
+// 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-	Handle A = an(CONCEPT_NODE, "A"),
-		B = an(CONCEPT_NODE, "B"),
-		C = an(CONCEPT_NODE, "C"),
-		AB = al(INHERITANCE_LINK, A, B),
-		BC = al(INHERITANCE_LINK, B, C),
-		ABAB = al(IMPLICATION_LINK, AB, AB),
-		BCBC = al(IMPLICATION_LINK, BC, BC);
+// 	Handle A = an(CONCEPT_NODE, "A"),
+// 		B = an(CONCEPT_NODE, "B"),
+// 		C = an(CONCEPT_NODE, "C"),
+// 		AB = al(INHERITANCE_LINK, A, B),
+// 		BC = al(INHERITANCE_LINK, B, C),
+// 		ABAB = al(IMPLICATION_LINK, AB, AB),
+// 		BCBC = al(IMPLICATION_LINK, BC, BC);
 	
-	Handle X = tmp_an(VARIABLE_NODE, "$X"),
-		Y = tmp_an(VARIABLE_NODE, "$Y"),
-		initpat = tmp_al(LAMBDA_LINK,
-		                 tmp_al(IMPLICATION_LINK, X, Y)),
-		query = mk_query({ABAB, BCBC}, 2, 2, initpat);
+// 	Handle X = tmp_an(VARIABLE_NODE, "$X"),
+// 		Y = tmp_an(VARIABLE_NODE, "$Y"),
+// 		initpat = tmp_al(LAMBDA_LINK,
+// 		                 tmp_al(IMPLICATION_LINK, X, Y)),
+// 		query = mk_query({ABAB, BCBC}, 2, 2, initpat);
 
-	BackwardChainer bc(_as, pm_rb, query);
-	bc.get_config().set_maximum_iterations(100);
-	bc.do_chain();
+// 	BackwardChainer bc(_as, pm_rb, query);
+// 	bc.get_config().set_maximum_iterations(100);
+// 	bc.do_chain();
 
-	Handle results = bc.get_results(),
-		VarXY = tmp_al(VARIABLE_LIST, X, Y),
-		InhXY = tmp_al(INHERITANCE_LINK, X, Y),
-		expected = mk_minsup_eval(2,
-		                          tmp_al(LAMBDA_LINK,
-		                                 VarXY,
-		                                 tmp_al(IMPLICATION_LINK, InhXY, InhXY)));
+// 	Handle results = bc.get_results(),
+// 		VarXY = tmp_al(VARIABLE_LIST, X, Y),
+// 		InhXY = tmp_al(INHERITANCE_LINK, X, Y),
+// 		expected = mk_minsup_eval(2,
+// 		                          tmp_al(LAMBDA_LINK,
+// 		                                 VarXY,
+// 		                                 tmp_al(IMPLICATION_LINK, InhXY, InhXY)));
 
-	logger().debug() << "results = " << oc_to_string(results);
-	logger().debug() << "expected = " << oc_to_string(expected);
+// 	logger().debug() << "results = " << oc_to_string(results);
+// 	logger().debug() << "expected = " << oc_to_string(expected);
 
-	TS_ASSERT(is_in(expected, results->getOutgoingSet()));
-}
+// 	TS_ASSERT(is_in(expected, results->getOutgoingSet()));
+// }
 
 // void UREPatternMinerUTest::test_AAAA()
 // {

--- a/tests/learning/xpattern-miner/ure-based/UREPatternMinerUTest.cxxtest
+++ b/tests/learning/xpattern-miner/ure-based/UREPatternMinerUTest.cxxtest
@@ -232,7 +232,7 @@ Handle UREPatternMinerUTest::run_pm(const HandleSeq& texts, int minsup,
 	// Add the axiom that initpat has enough support, and use it as
 	// source for the forward chainer
 	bool es = enough_support(initpat, minsup);
-	// If it doesn't have enough support return the empy solution
+	// If it doesn't have enough support return the empty solution
 	if (not es)
 		return al(SET_LINK);
 	TruthValuePtr tv = SimpleTruthValue::createTV(es ? 1.0 : 0.0, 1.0);
@@ -241,6 +241,7 @@ Handle UREPatternMinerUTest::run_pm(const HandleSeq& texts, int minsup,
 	// Run the foward chainer from the initial pattern
 	ForwardChainer fc(_as, pm_rb, source);
 	fc.get_config().set_maximum_iterations(maxiter);
+	fc.get_config().set_retry_sources(false);
 	fc.do_chain();
 
 	// Run the pattern matcher query to gather the knowledge of
@@ -619,7 +620,7 @@ void UREPatternMinerUTest::test_2conjuncts_4()
 	HandleSeq texts{A1B, A2B, BC1, BC2};
 
 	// Run pattern miner
-	Handle results = run_pm(texts, 4, 100, mk_nconjunct(2)),
+	Handle results = run_pm(texts, 4, 500, mk_nconjunct(2)),
 		VarXYZ = al(VARIABLE_LIST, X, Y, Z),
 		expected_pattern = mk_minsup_eval(4,
 		                                  al(LAMBDA_LINK,

--- a/tests/learning/xpattern-miner/ure-based/UREPatternMinerUTest.cxxtest
+++ b/tests/learning/xpattern-miner/ure-based/UREPatternMinerUTest.cxxtest
@@ -673,7 +673,7 @@ void UREPatternMinerUTest::test_2conjuncts_4()
 // 	// connected components will be equal to the minimum frequency of
 // 	// each component. For that reason it should be able to discover
 // 	// the desired pattern.
-// 	XPMParameters param(9/*minsup*/, 2/*nconjucts*/, initpat, -1/*maxdepth*/, 1/*info*/);
+// 	XPMParameters param(9/*minsup*/, 2/*nconjuncts*/, initpat, -1/*maxdepth*/, 1/*info*/);
 // 	XPatternMiner pm(_as, param);
 // 	HandleTree results = pm();
 // 	Handle non_expected_pattern = tmp_al(LAMBDA_LINK,


### PR DESCRIPTION
The URE pattern miner performances are now decent.

These optimizations are entirely based on reason, as opposed to experimental profiling using standard tools like valgrind, however the speed-up is tremendous (from +inf to 30s). It's still much slower than its C++ cousin that passes all unit tests in 4s (it has also been optimized), but it's decent and I believe usable. I do not know what accounts for the slow down, I think it could entirely be explained by the overhead of the URE itself.

What remains to be done:
1. Improve documentation (both README.md and wiki)
2. Experiment with heuristics, as well as surprisingness
3. Probably more optimization