### PR TITLE
Support declaring user variable in Ghost

### DIFF
--- a/opencog/ghost/cs-parse.scm
+++ b/opencog/ghost/cs-parse.scm
@@ -275,6 +275,7 @@
         (create-topic $2 (string-split $3 #\sp) (list))
       (TOPIC ID names LSBRACKET RSBRACKET) :
         (create-topic $2 (string-split $3 #\sp) (list))
+      (UVAR EQUAL name) : (create-user-variable $1 $3)
     )
 
     (declaration-sequence

--- a/opencog/ghost/translator.scm
+++ b/opencog/ghost/translator.scm
@@ -511,3 +511,10 @@
   (for-each (lambda (kw) (Member kw rule-topic)) (terms-to-atomese KEYWORDS))
 
   rule-topic)
+
+(define (create-user-variable UVAR VAL)
+"
+  Define a new user variable.
+"
+  (ghost-set-user-variable (ghost-uvar UVAR) (List (Word VAL)))
+)


### PR DESCRIPTION
Can now declare variable in the rule file e.g. `$veryshort = 2000`