### PR TITLE
Replace PredicateNode var_name by VariableNode var_name

### DIFF
--- a/opencog/nlp/relex2logic/rule-helpers.scm
+++ b/opencog/nlp/relex2logic/rule-helpers.scm
@@ -349,7 +349,7 @@
 					(Inheritance (Concept subj_instance) (Concept subj_concept))
 					(r2l-wordinst-concept subj_instance)
 					(EvaluationLink
-						(PredicateNode var_name)
+						(VariableNode var_name)
 						(ListLink (ConceptNode subj_instance)))
 				)
 		))


### PR DESCRIPTION
seems to make sense as it is a verb question.

Fix for #3083 