### PR TITLE
Make 'reuse' more usable in Ghost

### DIFF
--- a/opencog/ghost/ghost.scm
+++ b/opencog/ghost/ghost.scm
@@ -105,7 +105,7 @@
 ; A list of all the labels of the rules we have seen
 (define rule-label-list '())
 
-; An association list that contains all the atomese needed to create
+; An association list that contains all the terms needed to create
 ; the actual rules
 ; The key of this list is the labels of the rules
 (define rule-alist '())

--- a/opencog/ghost/ghost.scm
+++ b/opencog/ghost/ghost.scm
@@ -102,6 +102,14 @@
 ; during rule parsing & creation
 (define pat-vars '())
 
+; A list of all the labels of the rules we have seen
+(define rule-label-list '())
+
+; An association list that contains all the atomese needed to create
+; the actual rules
+; The key of this list is the labels of the rules
+(define rule-alist '())
+
 ; A list to keep track of what rules hierarchy
 ; Will be used when dealing with rejoinders
 (define rule-hierarchy '())
@@ -194,14 +202,18 @@
 "
   Parse the TXT, convert them into atomese.
 "
-  (test-parse TXT))
+  (test-parse TXT)
+  (process-rule-stack)
+)
 
 ; ----------
 (define-public (ghost-parse-file FILE)
 "
   Parse everything in the topic FILE, and convert them into atomese.
 "
-  (test-parse-file FILE))
+  (test-parse-file FILE)
+  (process-rule-stack)
+)
 
 ; ----------
 (define-public (ghost TXT)

--- a/opencog/ghost/translator.scm
+++ b/opencog/ghost/translator.scm
@@ -304,8 +304,8 @@
               ; A system function -- reuse
               ; First of all, try to see if the rule has been created in
               ; the AtomSpace, and get its action directly if so
-              ; Otherwise, see if the rule is defined in the same file being
-              ; parsed but just hasn't yet created, check the rule-alist if so
+              ; Otherwise, check the rule-alist to see if the rule is
+              ; defined in the same file being parsed
               ((and (equal? 'function (car n))
                     (equal? "reuse" (cadr n)))
                (let* ((label (cdaddr n))

--- a/opencog/ghost/translator.scm
+++ b/opencog/ghost/translator.scm
@@ -320,12 +320,13 @@
                            "Found the rule \"~a\" in the rule-alist" label)
                          (set! reuse #t)
                          (set! reused-rule-label label)
-                         ; The 2nd item in the list is the action
-                         (to-atomese (cdar (list-ref reused-rule-from-alist 1))))))
+                         (process-action
+                           ; The 2nd item in the list is the action
+                           (list-ref reused-rule-from-alist 1) label))))
                    (begin
                      (set! reuse #t)
                      (set! reused-rule-label label)
-                     (get-reused-action (list (psi-get-action reused-rule)))))))
+                     (psi-get-action reused-rule)))))
               ; Other functions
               ((equal? 'function (car n))
                (action-function (cadr n) (to-atomese (cddr n))))
@@ -370,7 +371,10 @@
     (list
       (ExecutionOutput
         gsn-action
-        (List action-atomese))
+        (List
+          (if reuse
+            (get-reused-action action-atomese)
+            action-atomese)))
       ; The expected behavior is that, when (the action of) a rule is reused,
       ; the rule will be considered as fired, so mark the last executed rule
       ; as the reused one instead of the one that calls the reuse function,

--- a/opencog/ghost/utils.scm
+++ b/opencog/ghost/utils.scm
@@ -271,5 +271,8 @@
       (Concept (string-append psi-prefix-str LABEL))))
 
   (if (null? rule)
-      (cog-logger-warn ghost-logger "Failed to find the GHOST rule \"~a\"" LABEL)
+      (begin
+        (cog-logger-debug ghost-logger
+          "Failed to find the GHOST rule \"~a\"" LABEL)
+        (list))
       (car rule)))


### PR DESCRIPTION
Should work fine as long as the rules being reused are defined in the same file