### PR TITLE
Make it possible to use guile modules even if (opencog attention-bank) isn't installed

### DIFF
--- a/opencog/ghost/ghost.scm
+++ b/opencog/ghost/ghost.scm
@@ -1,6 +1,5 @@
 (define-module (opencog ghost)
   #:use-module (opencog)
-  #:use-module (opencog attention-bank)
   #:use-module (opencog nlp)
   #:use-module (opencog nlp relex2logic)
   #:use-module (opencog nlp chatbot)
@@ -18,6 +17,11 @@
   #:use-module (ice-9 eval-string)
   #:use-module (ice-9 receive)
   #:use-module (system base lalr))
+
+; Temporarily used during transitioning. The aim is to make life easier for
+; developers who work with atomspace before opencog/atomspace/pull/1664 while
+; waiting for opencog/opencog/issues/3107 to resolve.
+(resolve-module '(opencog attention-bank) #:ensure #f)
 
 ;; --------------------
 ;; Shared things being used in the module

--- a/opencog/nlp/chatbot/chat-utils.scm
+++ b/opencog/nlp/chatbot/chat-utils.scm
@@ -11,13 +11,17 @@
 (use-modules (ice-9 threads)  ; needed for par-map
              (srfi srfi-1)
              (opencog)
-             (opencog attention-bank)
              (opencog rule-engine)
              (opencog nlp)
              (opencog nlp fuzzy)
              (opencog nlp microplanning)
              (opencog nlp relex2logic)
              (opencog exec))
+
+; Temporarily used during transitioning. The aim is to make life easier for
+; developers who work with atomspace before opencog/atomspace/pull/1664 while
+; waiting for opencog/opencog/issues/3107 to resolve.
+(resolve-module '(opencog attention-bank) #:ensure #f)
 
 ; -----------------------------------------------------------------------
 ; TODO: Replace these time related utilities with one from TimeMap, when it is

--- a/opencog/openpsi/action-selector.scm
+++ b/opencog/openpsi/action-selector.scm
@@ -6,7 +6,10 @@
 ; Copyright (C) 2016 OpenCog Foundation
 ; Copyright (C) 2017 MindCloud
 
-(use-modules (opencog attention-bank))
+; Temporarily used during transitioning. The aim is to make life easier for
+; developers who work with atomspace before opencog/atomspace/pull/1664 while
+; waiting for opencog/opencog/issues/3107 to resolve.
+(resolve-module '(opencog attention-bank) #:ensure #f)
 
 ; ----------------------------------------------------------------------
 (define (psi-set-action-selector! component exec-term)


### PR DESCRIPTION
(opencog attention-bank) module may not be installed if developers are using atomspace before
https://github.com/opencog/atomspace/pull/1664. 