### PR TITLE
Support for filtering out certain types of atoms from receiving STI

### DIFF
--- a/opencog/attention/ImportanceDiffusionBase.cc
+++ b/opencog/attention/ImportanceDiffusionBase.cc
@@ -185,7 +185,7 @@ void ImportanceDiffusionBase::diffuseAtom(Handle source)
         Handle target = it->first;
         auto ij = std::find_if(hsFilterOut.begin(), hsFilterOut.end(),
                 [target](const Handle& h){
-                return (target->get_type() == h->get_type());
+                return (target->get_type() == classerver().getType(h->get_name()));
                 });
         if( hsFilterOut.end() != ij){
             totalRefund += (totalDiffusionAmount * it->second);

--- a/opencog/attention/ImportanceDiffusionBase.cc
+++ b/opencog/attention/ImportanceDiffusionBase.cc
@@ -561,8 +561,9 @@ void ImportanceDiffusionBase::processDiffusionStack()
  *
  */
 double ImportanceDiffusionBase::redistribute(const Handle& target, const double& sti,
-                                           std::vector<std::pair<Handle, double>>& refund){
-    static unsigned int NRECURSION = 1; // Prevent stack-overflowing. XXX how to determing maxdepth?
+                                           std::vector<std::pair<Handle, double>>& refund
+                                           ,unsigned int NRECURSION/*=0*/){
+    //static unsigned int NRECURSION = 1; // Prevent stack-overflowing. XXX how to determing maxdepth?
     auto ij = std::find_if(hsFilterOut.begin(), hsFilterOut.end(),
             [target](const Handle& h){
             return (target->get_type() == nameserver().getType(h->get_name()));
@@ -574,7 +575,7 @@ double ImportanceDiffusionBase::redistribute(const Handle& target, const double&
         // the valid atom type in refund vector or if the refund is empty,
         // return the STI itself.
         auto min_spreading_value = _bank->get_af_min_sti();
-        if(sti < min_spreading_value or NRECURSION > 100){
+        if(sti < min_spreading_value or NRECURSION > 20){
             if(not refund.empty()){
                 refund[refund.size()-1].second += sti;
                 return 0;
@@ -594,9 +595,9 @@ double ImportanceDiffusionBase::redistribute(const Handle& target, const double&
         double r = sti/(double)seq.size();
         for(const Handle& h : seq)
         {
-            ++NRECURSION;
+            //++NRECURSION;
             ++spreaded_to;
-            double rsti = redistribute(h, r, refund);
+            double rsti = redistribute(h, r, refund, NRECURSION+1);
             // Adjust sti per atom if sti isn't spread.
             if( rsti > 0){
                 // If the last one failed. return amount.

--- a/opencog/attention/ImportanceDiffusionBase.cc
+++ b/opencog/attention/ImportanceDiffusionBase.cc
@@ -56,10 +56,6 @@ ImportanceDiffusionBase::ImportanceDiffusionBase(CogServer& cs) : Agent(cs)
                          ,_atq(&cs.getAtomSpace())
 {
     _bank = &attentionbank(_as);
-    // Filter out atoms listed in SPREADING_FILTER param so that no
-    // STI would be propagated to them.
-    Handle memberlink = _atq.get_param_hvalue(AttentionParamQuery::spreading_filter);
-    hsFilterOut = memberlink->getOutgoingSet();
 
     // Provide a logger
     setLogger(new opencog::Logger("ImportanceDiffusionBase.log",
@@ -177,9 +173,17 @@ void ImportanceDiffusionBase::diffuseAtom(Handle source)
         return;
     }
 
+    static bool isFirstRun = true;
+    // Filter out atoms listed in SPREADING_FILTER param so that no
+    // STI would be propagated to them.
+    if(isFirstRun){
+        Handle memberlink = _atq.get_param_hvalue(AttentionParamQuery::spreading_filter);
+        hsFilterOut = memberlink->getOutgoingSet();
+        isFirstRun = false;
+    }
 
+    // Redistribute sti values that should not go to types in hsFilterOut.
     std::map<Handle, double> refund;
-    // Redistribute sti values that should not go to certain types of atoms.
     for(auto it = probabilityVector.begin() ; it !=probabilityVector.end() ; ++it){
         std::vector<std::pair<Handle, double>> tempRefund;
         redistribute(it->first, it->second, tempRefund);

--- a/opencog/attention/ImportanceDiffusionBase.cc
+++ b/opencog/attention/ImportanceDiffusionBase.cc
@@ -559,7 +559,7 @@ std::vector<std::pair<Handle, double>> ImportanceDiffusionBase::redistribute(con
         HandleSeq seq;
         if(target->is_node())
             target->getIncomingSet(std::back_inserter(seq));
-        else
+        else if(target->is_link())
             seq = target->getOutgoingSet();
 
         auto r = sti/seq.size();

--- a/opencog/attention/ImportanceDiffusionBase.cc
+++ b/opencog/attention/ImportanceDiffusionBase.cc
@@ -595,12 +595,13 @@ double ImportanceDiffusionBase::redistribute(const Handle& target, const double&
 
         auto r = sti/seq.size();
         for(const Handle& h : seq)
+        {      ++NRECURSION;
             redistribute(h, r, refund);
+        }
     }
     else{
         refund.push_back(std::make_pair(target, sti));
     }
 
-    ++NRECURSION;
     return 0;
 }

--- a/opencog/attention/ImportanceDiffusionBase.cc
+++ b/opencog/attention/ImportanceDiffusionBase.cc
@@ -534,9 +534,6 @@ void ImportanceDiffusionBase::processDiffusionStack()
 #endif
 
 }
-
-std::vector<std::pair<Handle, double>> ImportanceDiffusionBase::redistribute(const Handle& target,
-                         const double& sti, std::vector<std::pair<Handle, double>>& refund){
 /**
  * Redistributed amount of sti that should have gone to target atom if
  * the atom type is in the Fitler set. The sti will be equally distributed
@@ -552,6 +549,8 @@ std::vector<std::pair<Handle, double>> ImportanceDiffusionBase::redistribute(con
  * @return void.
  *
  */
+void ImportanceDiffusionBase::redistribute(const Handle& target, const double& sti,
+                                           std::vector<std::pair<Handle, double>>& refund){
     static unsigned int NRECURSION = 1; // Prevent stack-overflowing. XXX how to determing maxdepth?
     auto ij = std::find_if(hsFilterOut.begin(), hsFilterOut.end(),
             [target](const Handle& h){
@@ -570,7 +569,7 @@ std::vector<std::pair<Handle, double>> ImportanceDiffusionBase::redistribute(con
         auto min_spreading_value = _bank->get_af_min_sti();
         if(sti < min_spreading_value or NRECURSION > 100){
             refund.push_back(std::make_pair(target, sti));
-            return refund;
+            return;
         }
         HandleSeq seq;
         if(target->is_node())
@@ -587,5 +586,5 @@ std::vector<std::pair<Handle, double>> ImportanceDiffusionBase::redistribute(con
     }
 
     ++NRECURSION;
-    return refund;
+    return;
 }

--- a/opencog/attention/ImportanceDiffusionBase.cc
+++ b/opencog/attention/ImportanceDiffusionBase.cc
@@ -131,35 +131,6 @@ void ImportanceDiffusionBase::diffuseAtom(Handle source)
     AttentionValue::sti_t totalDiffusionAmount =
             calculateDiffusionAmount(source);
 
-#ifdef LOG_AV_STAT
-    // Log sti gain from spreading via  non-hebbian links
-    for(const auto& kv : probabilityVectorIncident){
-        if(atom_avstat.find(kv.first) == atom_avstat.end()){
-            AVStat avstat;
-            avstat.link_sti_gain = kv.second;
-            atom_avstat[kv.first] = avstat;
-        }
-        atom_avstat[kv.first].link_sti_gain += kv.second;
-    }
-
-    // Log sti gain from spreading via hebbian links
-    for(const auto& kv : probabilityVectorHebbianAdjacent){
-        if(atom_avstat.find(kv.first) == atom_avstat.end()){
-            AVStat avstat;
-            avstat.heblink_sti_gain = kv.second;
-            atom_avstat[kv.first] = avstat;
-        }
-        atom_avstat[kv.first].heblink_sti_gain += kv.second;
-    }
-
-    // Log amount of sti spread from
-    if(atom_avstat.find(source) == atom_avstat.end()){
-        AVStat avstat;
-        avstat.spreading = totalDiffusionAmount;
-        atom_avstat[source] = avstat;
-    }
-    atom_avstat[source].spreading += totalDiffusionAmount;
-#endif
 
 #ifdef DEBUG
     std::cout << "Total diffusion amount: " << totalDiffusionAmount << std::endl;
@@ -208,7 +179,37 @@ void ImportanceDiffusionBase::diffuseAtom(Handle source)
 
     // Finishe the redistribution by assigning new values to probabilityVector.
     probabilityVector = refund;
-    
+
+#ifdef LOG_AV_STAT
+    // Log sti gain from spreading via  non-hebbian links
+    for(const auto& kv : probabilityVectorIncident){
+        if(atom_avstat.find(kv.first) == atom_avstat.end()){
+            AVStat avstat;
+            avstat.link_sti_gain = kv.second;
+            atom_avstat[kv.first] = avstat;
+        }
+        atom_avstat[kv.first].link_sti_gain += kv.second;
+    }
+
+    // Log sti gain from spreading via hebbian links
+    for(const auto& kv : probabilityVectorHebbianAdjacent){
+        if(atom_avstat.find(kv.first) == atom_avstat.end()){
+            AVStat avstat;
+            avstat.heblink_sti_gain = kv.second;
+            atom_avstat[kv.first] = avstat;
+        }
+        atom_avstat[kv.first].heblink_sti_gain += kv.second;
+    }
+
+    // Log amount of sti spread from
+    if(atom_avstat.find(source) == atom_avstat.end()){
+        AVStat avstat;
+        avstat.spreading = totalDiffusionAmount;
+        atom_avstat[source] = avstat;
+    }
+    atom_avstat[source].spreading += totalDiffusionAmount;
+#endif
+
     // Perform diffusion from the source to each atom target
     for( const auto& p : probabilityVector)
     {

--- a/opencog/attention/ImportanceDiffusionBase.cc
+++ b/opencog/attention/ImportanceDiffusionBase.cc
@@ -59,7 +59,7 @@ ImportanceDiffusionBase::ImportanceDiffusionBase(CogServer& cs) : Agent(cs)
     // Filter out atoms listed in SPREADING_FILTER param so that no
     // STI would be propagated to them.
     Handle memberlink = _atq.get_param_hvalue(AttentionParamQuery::spreading_filter);
-    hsfilter_out = memberlink->getOutgoingSet();
+    hsFilterOut = memberlink->getOutgoingSet();
 
     // Provide a logger
     setLogger(new opencog::Logger("ImportanceDiffusionBase.log",
@@ -178,17 +178,17 @@ void ImportanceDiffusionBase::diffuseAtom(Handle source)
     }
 
     // Filter out atom types that we don't want STI to be spread to.
-    AttentionValue::sti_t total_refund = 0.0;
+    AttentionValue::sti_t totalRefund = 0.0;
 
     for(auto it = probabilityVector.begin() ; it != probabilityVector.end();)
     {
         Handle target = it->first;
-        auto ij = std::find_if(hsfilter_out.begin(), hsfilter_out.end(),
+        auto ij = std::find_if(hsFilterOut.begin(), hsFilterOut.end(),
                 [target](const Handle& h){
                 return (target->get_type() == h->get_type());
                 });
-        if( hsfilter_out.end() != ij){
-            total_refund += (totalDiffusionAmount * it->second);
+        if( hsFilterOut.end() != ij){
+            totalRefund += (totalDiffusionAmount * it->second);
             probabilityVector.erase(it);
         } else {
             ++it;
@@ -196,8 +196,8 @@ void ImportanceDiffusionBase::diffuseAtom(Handle source)
     }
 
     // Equally spread back the amount that was supposed to be spread to the
-    // atoms types in hsfilter_out.
-    auto refund = total_refund / probabilityVector.size();
+    // atoms types in hsFilterOut.
+    auto refund = totalRefund / probabilityVector.size();
 
     // Perform diffusion from the source to each atom target
     for( const auto& p : probabilityVector)

--- a/opencog/attention/ImportanceDiffusionBase.cc
+++ b/opencog/attention/ImportanceDiffusionBase.cc
@@ -571,11 +571,13 @@ void ImportanceDiffusionBase::redistribute(const Handle& target, const double& s
             refund.push_back(std::make_pair(target, sti));
             return;
         }
+
+        // Redistribute to all neighbors.
         HandleSeq seq;
-        if(target->is_node())
-            target->getIncomingSet(std::back_inserter(seq));
-        else if(target->is_link())
+        if(target->is_link())
             seq = target->getOutgoingSet();
+
+        target->getIncomingSet(std::back_inserter(seq));
 
         auto r = sti/seq.size();
         for(const Handle& h : seq)

--- a/opencog/attention/ImportanceDiffusionBase.cc
+++ b/opencog/attention/ImportanceDiffusionBase.cc
@@ -557,7 +557,7 @@ void ImportanceDiffusionBase::processDiffusionStack()
  *
  * @refund a list of pairs of atoms and redistributed sti.
  *
- * @return void.
+ * @return 0 on successfull redistribution or @param sti on failure to do so.
  *
  */
 double ImportanceDiffusionBase::redistribute(const Handle& target, const double& sti,
@@ -569,14 +569,10 @@ double ImportanceDiffusionBase::redistribute(const Handle& target, const double&
             });
 
     if(ij != hsFilterOut.end()){
-        // This is to prevent indefinite recursion which could
-        // happen incase of a cyclic graph.
-        // Assuming MIN_SPREADING_VALUE will be very small
-        // compared to the minimum STI in the AF and no direct stimulation,
-        // this  atoms should never get the chance to enter into the AF.
-        // the remaining value(sti) should in theory be collected back by rent collection
-        // agent.
-        // FIXME it could accumulate such small sti values over time and endup in the AF?
+        // If STI to be distributed is smaller that the af boundary or the
+        // recursion has reached maximum depth allowed, assign the sti to
+        // the valid atom type in refund vector or if the refund is empty,
+        // return the STI itself.
         auto min_spreading_value = _bank->get_af_min_sti();
         if(sti < min_spreading_value or NRECURSION > 100){
             if(not refund.empty()){

--- a/opencog/attention/ImportanceDiffusionBase.cc
+++ b/opencog/attention/ImportanceDiffusionBase.cc
@@ -537,6 +537,7 @@ void ImportanceDiffusionBase::processDiffusionStack()
 
 std::vector<std::pair<Handle, double>> ImportanceDiffusionBase::redistribute(const Handle& target,
                          const double& sti, std::vector<std::pair<Handle, double>>& refund){
+    static unsigned int NRECURSION = 1; // Prevent stack-overflowing. XXX how to determing maxdepth?
     auto ij = std::find_if(hsFilterOut.begin(), hsFilterOut.end(),
             [target](const Handle& h){
             return (target->get_type() == classserver().getType(h->get_name()));
@@ -552,7 +553,7 @@ std::vector<std::pair<Handle, double>> ImportanceDiffusionBase::redistribute(con
         // agent.
         // FIXME it could accumulate such small sti values over time and endup in the AF?
         auto min_spreading_value = _bank->get_af_min_sti();
-        if(sti < min_spreading_value){
+        if(sti < min_spreading_value or NRECURSION > 100){
             refund.push_back(std::make_pair(target, sti));
             return refund;
         }
@@ -570,5 +571,6 @@ std::vector<std::pair<Handle, double>> ImportanceDiffusionBase::redistribute(con
         refund.push_back(std::make_pair(target, sti));
     }
 
+    ++NRECURSION;
     return refund;
 }

--- a/opencog/attention/ImportanceDiffusionBase.cc
+++ b/opencog/attention/ImportanceDiffusionBase.cc
@@ -547,7 +547,8 @@ std::vector<std::pair<Handle, double>> ImportanceDiffusionBase::redistribute(con
         // the remaining value(sti) should in theory be collected back by rent collection
         // agent.
         // FIXME it could accumulate such small sti values over time and endup in the AF?
-        if(sti < MIN_SPREADING_VALUE){
+        auto min_spreading_value = _bank->get_af_min_sti();
+        if(sti < min_spreading_value){
             refund.push_back(std::make_pair(target, sti));
             return refund;
         }

--- a/opencog/attention/ImportanceDiffusionBase.cc
+++ b/opencog/attention/ImportanceDiffusionBase.cc
@@ -537,6 +537,21 @@ void ImportanceDiffusionBase::processDiffusionStack()
 
 std::vector<std::pair<Handle, double>> ImportanceDiffusionBase::redistribute(const Handle& target,
                          const double& sti, std::vector<std::pair<Handle, double>>& refund){
+/**
+ * Redistributed amount of sti that should have gone to target atom if
+ * the atom type is in the Fitler set. The sti will be equally distributed
+ * to the incoming or outgoing set of target atom.
+ *
+ * @param target the atom whose to type is to be checked against the filter set.
+ *
+ * @sti   the sti that should be redistribited if the target's type is in Filter
+ * set.
+ *
+ * @refund a list of pairs of atoms and redistributed sti.
+ *
+ * @return void.
+ *
+ */
     static unsigned int NRECURSION = 1; // Prevent stack-overflowing. XXX how to determing maxdepth?
     auto ij = std::find_if(hsFilterOut.begin(), hsFilterOut.end(),
             [target](const Handle& h){

--- a/opencog/attention/ImportanceDiffusionBase.cc
+++ b/opencog/attention/ImportanceDiffusionBase.cc
@@ -56,10 +56,14 @@ ImportanceDiffusionBase::ImportanceDiffusionBase(CogServer& cs) : Agent(cs)
                          ,_atq(&cs.getAtomSpace())
 {
     _bank = &attentionbank(_as);
+    // Filter out atoms listed in SPREADING_FILTER param so that no
+    // STI would be propagated to them.
+    Handle memberlink = _atq.get_param_hvalue(AttentionParamQuery::spreading_filter);
+    hsfilter_out = memberlink->getOutgoingSet();
 
     // Provide a logger
     setLogger(new opencog::Logger("ImportanceDiffusionBase.log",
-                                  Logger::FINE, true));
+                Logger::FINE, true));
 }
 
 /*
@@ -173,6 +177,28 @@ void ImportanceDiffusionBase::diffuseAtom(Handle source)
         return;
     }
 
+    // Filter out atom types that we don't want STI to be spread to.
+    AttentionValue::sti_t total_refund = 0.0;
+
+    for(auto it = probabilityVector.begin() ; it != probabilityVector.end();)
+    {
+        Handle target = it->first;
+        auto ij = std::find_if(hsfilter_out.begin(), hsfilter_out.end(),
+                [target](const Handle& h){
+                return (target->get_type() == h->get_type());
+                });
+        if( hsfilter_out.end() != ij){
+            total_refund += (totalDiffusionAmount * it->second);
+            probabilityVector.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
+    // Equally spread back the amount that was supposed to be spread to the
+    // atoms types in hsfilter_out.
+    auto refund = total_refund / probabilityVector.size();
+
     // Perform diffusion from the source to each atom target
     for( const auto& p : probabilityVector)
     {
@@ -181,7 +207,7 @@ void ImportanceDiffusionBase::diffuseAtom(Handle source)
         // Calculate the diffusion amount using the entry in the probability
         // vector for this particular target (stored in iterator->second)
         diffusionEvent.amount = (AttentionValue::sti_t)
-                (totalDiffusionAmount * p.second);
+            ((totalDiffusionAmount * p.second) + refund);
 
         diffusionEvent.source = source;
         diffusionEvent.target = p.first;

--- a/opencog/attention/ImportanceDiffusionBase.h
+++ b/opencog/attention/ImportanceDiffusionBase.h
@@ -91,6 +91,11 @@ protected:
     virtual void spreadImportance() = 0;
     virtual AttentionValue::sti_t calculateDiffusionAmount(Handle) = 0;
 
+    const double MIN_SPREADING_VALUE = 0.01;
+    // Recursively try to redistribute STI which was supposed to be delivered to
+    // certain atom types which should not receive STI.
+    std::vector<std::pair<Handle, double>> redistribute(const Handle& target, const double& sti,
+                                          std::vector<std::pair<Handle, double>>& refund);
 public:
     ImportanceDiffusionBase(CogServer&);
     virtual ~ImportanceDiffusionBase();

--- a/opencog/attention/ImportanceDiffusionBase.h
+++ b/opencog/attention/ImportanceDiffusionBase.h
@@ -93,7 +93,7 @@ protected:
 
     // Recursively try to redistribute STI which was supposed to be delivered to
     // certain atom types which should not receive STI.
-    void redistribute(const Handle& target, const double& sti, std::vector<std::pair<Handle,
+    double redistribute(const Handle& target, const double& sti, std::vector<std::pair<Handle,
                       double>>& refund);
 public:
     ImportanceDiffusionBase(CogServer&);

--- a/opencog/attention/ImportanceDiffusionBase.h
+++ b/opencog/attention/ImportanceDiffusionBase.h
@@ -94,7 +94,7 @@ protected:
     // Recursively try to redistribute STI which was supposed to be delivered to
     // certain atom types which should not receive STI.
     double redistribute(const Handle& target, const double& sti, std::vector<std::pair<Handle,
-                      double>>& refund);
+                      double>>& refund, unsigned int NRECURSION = 0);
 public:
     ImportanceDiffusionBase(CogServer&);
     virtual ~ImportanceDiffusionBase();

--- a/opencog/attention/ImportanceDiffusionBase.h
+++ b/opencog/attention/ImportanceDiffusionBase.h
@@ -93,8 +93,8 @@ protected:
 
     // Recursively try to redistribute STI which was supposed to be delivered to
     // certain atom types which should not receive STI.
-    std::vector<std::pair<Handle, double>> redistribute(const Handle& target, const double& sti,
-                                          std::vector<std::pair<Handle, double>>& refund);
+    void redistribute(const Handle& target, const double& sti, std::vector<std::pair<Handle,
+                      double>>& refund);
 public:
     ImportanceDiffusionBase(CogServer&);
     virtual ~ImportanceDiffusionBase();

--- a/opencog/attention/ImportanceDiffusionBase.h
+++ b/opencog/attention/ImportanceDiffusionBase.h
@@ -54,6 +54,11 @@ protected:
     double hebbianMaxAllocationPercentage;
     bool spreadHebbianOnly;
     AttentionParamQuery _atq;
+    // Set of atoms types spreading should not happen to.
+    // These types of atoms will not have STI value but
+    // atoms linked via them will receive STI via
+    // spreading.
+    HandleSeq hsfilter_out;
 
     typedef struct DiffusionEventType
     {

--- a/opencog/attention/ImportanceDiffusionBase.h
+++ b/opencog/attention/ImportanceDiffusionBase.h
@@ -58,7 +58,7 @@ protected:
     // These types of atoms will not have STI value but
     // atoms linked via them will receive STI via
     // spreading.
-    HandleSeq hsfilter_out;
+    HandleSeq hsFilterOut;
 
     typedef struct DiffusionEventType
     {

--- a/opencog/attention/ImportanceDiffusionBase.h
+++ b/opencog/attention/ImportanceDiffusionBase.h
@@ -94,7 +94,7 @@ protected:
     // Recursively try to redistribute STI which was supposed to be delivered to
     // certain atom types which should not receive STI.
     double redistribute(const Handle& target, const double& sti, std::vector<std::pair<Handle,
-                      double>>& refund, unsigned int NRECURSION = 0);
+                      double>>& refund, unsigned int depth = 0);
 public:
     ImportanceDiffusionBase(CogServer&);
     virtual ~ImportanceDiffusionBase();

--- a/opencog/attention/ImportanceDiffusionBase.h
+++ b/opencog/attention/ImportanceDiffusionBase.h
@@ -91,7 +91,6 @@ protected:
     virtual void spreadImportance() = 0;
     virtual AttentionValue::sti_t calculateDiffusionAmount(Handle) = 0;
 
-    const double MIN_SPREADING_VALUE = 0.01;
     // Recursively try to redistribute STI which was supposed to be delivered to
     // certain atom types which should not receive STI.
     std::vector<std::pair<Handle, double>> redistribute(const Handle& target, const double& sti,


### PR DESCRIPTION
This changes are introduced in response to issue #3107.  One can insert set of atom types that should not receive STI by specifying them [here](https://github.com/opencog/opencog/blob/master/opencog/attention/default-param-values.scm#L166).