### PR TITLE
spacetime-types, attention-types issue #3197

### DIFF
--- a/opencog/attention/CMakeLists.txt
+++ b/opencog/attention/CMakeLists.txt
@@ -22,7 +22,9 @@ ADD_LIBRARY(attention-types SHARED
 ADD_DEPENDENCIES(attention-types attention_atom_types)
 
 TARGET_LINK_LIBRARIES(attention-types
+	${ATOMSPACE_atomcore_LIBRARY}
 	${ATOMSPACE_atombase_LIBRARY}
+	${ATOMSPACE_atomproto_LIBRARY}
 )
 
 # --------------------------------------------------

--- a/opencog/spacetime/atom-types/CMakeLists.txt
+++ b/opencog/spacetime/atom-types/CMakeLists.txt
@@ -11,7 +11,9 @@ ADD_LIBRARY (spacetime-types SHARED
 )
 
 TARGET_LINK_LIBRARIES(spacetime-types
+	${ATOMSPACE_atomcore_LIBRARY}
 	${ATOMSPACE_atombase_LIBRARY}
+	${ATOMSPACE_atomproto_LIBRARY}
 )
 
 ADD_DEPENDENCIES(spacetime-types spacetime_atom_types)


### PR DESCRIPTION
Attempted fix for issue #3197, where there are missing symbols in the
libraries.  Apparently, different linkers do different thigs, here.
Don't know why.