### PR TITLE
Export mst

### DIFF
--- a/opencog/nlp/ull-parser/scm/mst-parser.scm
+++ b/opencog/nlp/ull-parser/scm/mst-parser.scm
@@ -258,154 +258,224 @@
 
 (define-public (observe-mst-extra plain-text CNT-MODE DIST-MODE)
 "
-  observe-mst-extra -- update pseduo-disjunct counts by observing raw
-  text.
-
-  See also 'observe-mst'.
+  observe-mst -- update pseduo-disjunct counts by observing raw text.
 
   This is the second part of the learning algo: simply count how
-  often pseudo-disjuncts show up. In addition to what 'observe-mst'
-  does, extra atoms will be generated to preserve the MST parse
-  for each of the inputs.
+  often pseudo-disjuncts show up.
 "
-	; Tokenize the text, create WordNodes as well as WordInstanceNodes
-	; for each of the words
-	(define word-strs (tokenize-text plain-text))
-	(define word-list (map WordNode word-strs))
-	(define word-insts (map (lambda (w) (WordInstanceNode
-		(random-node-name 'WordInstanceNode 36 (string-append w "@"))))
-			word-strs))
-
-	; Create a ParseNode, link each of the WordInstanceNodes with it
-	; by using WordInstanceLinks
-	; ReferenceLinks will also be created to link the WordInstanceNodes
-	; with their corresponding WordNodes
-	(define parse-node
-		(ParseNode (random-node-name 'ParseNode 36 "mst_parse@")))
-	(define word-inst-lks
-		(map (lambda (wi) (WordInstanceLink wi parse-node)) word-insts))
-	(define reference-lks
-		(map (lambda (wi w) (ReferenceLink wi w)) word-insts word-list))
-
-	; Create WordSequenceLink to record the word order
-	(define num-nodes '())
-	(define word-seq-lks (map
-		(lambda (wi)
-			(define n (NumberNode (length num-nodes)))
-			(set! num-nodes (append num-nodes (list n)))
-			(WordSequenceLink wi n))
-		word-insts))
-
-	; Do the MST parse
-	(define mstparse (mst-parse-text plain-text CNT-MODE DIST-MODE))
-	(define sections (make-sections mstparse))
-
-	; Take the parse from above, replace the WordNodes with WordInstanceNodes
-	; and create sections for those instances also
-	(define mstparse-insts
-		(map (lambda (w)
-			(define l-idx (overt-get-index (wedge-get-left-overt w)))
-			(define r-idx (overt-get-index (wedge-get-right-overt w)))
-			(cons ; Pair this connection with the score
-				(cons ; Pair the left and right word instances with their indexes
-					(cons l-idx (list-ref word-insts (- l-idx 1)))
-					(cons r-idx (list-ref word-insts (- r-idx 1)))
-				)
-				(wedge-get-score w)
-			))
-			mstparse))
-
-	; Make sections using the instances
-	(define section-insts (make-sections mstparse-insts))
-
+	(define parse (mst-parse-text plain-text CNT-MODE DIST-MODE))
+	(export-mst-parse plain-text parse "mst-parses.txt")
 	; The count-one-atom function fetches from the SQL database,
-	; increments the count by one, and stores the result back
+	; increments the count by 1, and stores the result back
 	(for-each
 		(lambda (dj) (if (not (is-oversize? dj)) (count-one-atom dj 1)))
-		sections
+		(make-sections parse)
 	)
-
-	; And store the whole parse
-	(for-each
-		(lambda (x)
-			(if (equal? (cog-type x) 'Section)
-				(if (not (is-oversize? x)) (store-atom x))
-				(store-atom x)))
-		(append section-insts word-seq-lks word-inst-lks reference-lks)
-	)
-
-	; Export the parse to a file
-	(export-mst-parses "mst-parses.txt")
-
-	; Remove the instances and the links containing them
-	(for-each cog-extract-recursive word-insts)
-
-	; Also remove those newly generated nodes
-	(for-each cog-extract num-nodes)
-	(cog-extract parse-node)
 )
 
-(define-public (export-mst-parses filename)
+(define-public (export-mst-parse plain-text mstparse filename)
 "
-  Export all the MST-parses that can be found in the
-  atomspace to a text file named \"filename\", so that
-  it would be easier for people to examine the parses.
+  Export an MST-parse to a text file named filename, 
+  so that parses can be examined.
 
   The format is:
   [sentence]
   [word1#] [word1] [word2#] [word2]
+  [word2#] [word2] [word4#] [word4]
+  ...
 "
 	(define file-port (open-file filename "a"))
 
-	; Given a WordInstanceNode, return its word sequence number
-	(define (get-index w)
-		(inexact->exact (string->number
-			(cog-name (word-inst-get-number w)))))
+	(define (get-mi link) (cdr link))
+	(define (get-lindex link)
+		(- (car (car (car link))) 1))
+	(define (get-rindex link)
+		(- (car (cdr (car link))) 1))
 
-	; Given a WordInstanceNode, return its corresponding word
-	(define (get-word w)
-		(cog-name (word-inst-get-word w)))
+	(define (get-lword link)
+		(cog-name (cdr (car (car link)))))
+	(define (get-rword link)
+		(cog-name (cdr (cdr (car link)))))
 
-	; Export a single parse
-	(define (export-parse word-insts)
-		; Print the sentence first
-		(if (not (null? word-insts))
-			(display
-				(format #f "~a\n"
-					(string-join (map get-word (cdr word-insts)) " "))
-				file-port))
+	; Print the sentence first
+	(if (not (null? plain-text))
+		(display
+			(format #f "~a\n"
+				plain-text)
+			file-port))
 
-		(for-each
-			(lambda (w) ; WordInstanceNodes
-				(for-each
-					(lambda (cs) ; ConnectorSeq
-						(for-each
-							(lambda (c) ; Connector
-								(if (equal? (cog-name (gdr c)) "+")
-									(display
-										(format #f "~a ~a ~a ~a\n"
-											(get-index w)
-											(get-word w)
-											(get-index (gar c))
-											(get-word (gar c)))
-										file-port)))
-							(cog-outgoing-set cs)))
-					(cog-chase-link 'Section 'ConnectorSeq w)))
-			word-insts
-		)
-
-		; Add a new line at the end
-		(display "\n" file-port)
+	; Print the links if they are not bad-pair
+	(for-each
+		(lambda (l) ; links
+			(if (> (get-mi l) -1.0e10) ; bad-MI
+				(display
+					(format #f "~a ~a ~a ~a\n"
+						(get-lindex l)
+						(get-lword l)
+						(get-rindex l)
+						(get-rword l))
+				file-port)))
+		mstparse
 	)
 
-	; Export the MST-parses
-	(for-each
-		(lambda (p)
-			(export-parse (parse-get-words-in-order p)))
-		(cog-get-atoms 'ParseNode))
+	; Add a new line at the end
+	(display "\n" file-port)
 
 	(close-port file-port)
 )
+
+; ---------------------------------------------------------------------
+;(define-public (observe-mst-extra-manhin plain-text CNT-MODE DIST-MODE)
+;"
+  ;observe-mst-extra -- update pseduo-disjunct counts by observing raw
+  ;text.
+
+  ;See also 'observe-mst'.
+
+  ;This is the second part of the learning algo: simply count how
+  ;often pseudo-disjuncts show up. In addition to what 'observe-mst'
+  ;does, extra atoms will be generated to preserve the MST parse
+  ;for each of the inputs.
+;"
+	;; Tokenize the text, create WordNodes as well as WordInstanceNodes
+	;; for each of the words
+	;(define word-strs (tokenize-text plain-text))
+	;(define word-list (map WordNode word-strs))
+	;(define word-insts (map (lambda (w) (WordInstanceNode
+		;(random-node-name 'WordInstanceNode 36 (string-append w "@"))))
+			;word-strs))
+
+	;; Create a ParseNode, link each of the WordInstanceNodes with it
+	;; by using WordInstanceLinks
+	;; ReferenceLinks will also be created to link the WordInstanceNodes
+	;; with their corresponding WordNodes
+	;(define parse-node
+		;(ParseNode (random-node-name 'ParseNode 36 "mst_parse@")))
+	;(define word-inst-lks
+		;(map (lambda (wi) (WordInstanceLink wi parse-node)) word-insts))
+	;(define reference-lks
+		;(map (lambda (wi w) (ReferenceLink wi w)) word-insts word-list))
+
+	;; Create WordSequenceLink to record the word order
+	;(define num-nodes '())
+	;(define word-seq-lks (map
+		;(lambda (wi)
+			;(define n (NumberNode (length num-nodes)))
+			;(set! num-nodes (append num-nodes (list n)))
+			;(WordSequenceLink wi n))
+		;word-insts))
+
+	;; Do the MST parse
+	;(define mstparse (mst-parse-text plain-text CNT-MODE DIST-MODE))
+	;(define sections (make-sections mstparse))
+
+	;; Take the parse from above, replace the WordNodes with WordInstanceNodes
+	;; and create sections for those instances also
+	;(define mstparse-insts
+		;(map (lambda (w)
+			;(define l-idx (overt-get-index (wedge-get-left-overt w)))
+			;(define r-idx (overt-get-index (wedge-get-right-overt w)))
+			;
+			;(cons ; Pair this connection with the score
+				;(cons ; Pair the left and right word instances with their indexes
+					;(cons l-idx (list-ref word-insts (- l-idx 1)))
+					;(cons r-idx (list-ref word-insts (- r-idx 1)))
+				;)
+				;(wedge-get-score w)
+			;))
+			;mstparse))
+
+	;; Make sections using the instances
+	;(define section-insts (make-sections mstparse-insts))
+
+	;; The count-one-atom function fetches from the SQL database,
+	;; increments the count by one, and stores the result back
+	;(for-each
+		;(lambda (dj) (if (not (is-oversize? dj)) (count-one-atom dj 1)))
+		;sections
+	;)
+
+	;; And store the whole parse
+	;(for-each
+		;(lambda (x)
+			;(if (equal? (cog-type x) 'Section)
+				;(if (not (is-oversize? x)) (store-atom x))
+				;(store-atom x)))
+		;(append section-insts word-seq-lks word-inst-lks reference-lks)
+	;)
+
+	;; Export the parse to a file
+	;(export-mst-parses "mst-parses.txt")
+
+	;; Remove the instances and the links containing them
+	;(for-each cog-extract-recursive word-insts)
+
+	;; Also remove those newly generated nodes
+	;(for-each cog-extract num-nodes)
+	;(cog-extract parse-node)
+;)
+
+;(define-public (export-mst-parses filename)
+;"
+  ;Export all the MST-parses that can be found in the
+  ;atomspace to a text file named \"filename\", so that
+  ;it would be easier for people to examine the parses.
+
+  ;The format is:
+  ;[sentence]
+  ;[word1#] [word1] [word2#] [word2]
+;"
+	;(define file-port (open-file filename "a"))
+
+	;; Given a WordInstanceNode, return its word sequence number
+	;(define (get-index w)
+		;(inexact->exact (string->number
+			;(cog-name (word-inst-get-number w)))))
+
+	;; Given a WordInstanceNode, return its corresponding word
+	;(define (get-word w)
+		;(cog-name (word-inst-get-word w)))
+
+	;; Export a single parse
+	;(define (export-parse word-insts)
+		;; Print the sentence first
+		;(if (not (null? word-insts))
+			;(display
+				;(format #f "~a\n"
+					;(string-join (map get-word (cdr word-insts)) " "))
+				;file-port))
+
+		;(for-each
+			;(lambda (w) ; WordInstanceNodes
+				;(for-each
+					;(lambda (cs) ; ConnectorSeq
+						;(for-each
+							;(lambda (c) ; Connector
+								;(if (equal? (cog-name (gdr c)) "+")
+									;(display
+										;(format #f "~a ~a ~a ~a\n"
+											;(get-index w)
+											;(get-word w)
+											;(get-index (gar c))
+											;(get-word (gar c)))
+										;file-port)))
+							;(cog-outgoing-set cs)))
+					;(cog-chase-link 'Section 'ConnectorSeq w)))
+			;word-insts
+		;)
+
+		;; Add a new line at the end
+		;(display "\n" file-port)
+	;)
+
+	;; Export the MST-parses
+	;(for-each
+		;(lambda (p)
+			;(export-parse (parse-get-words-in-order p)))
+		;(cog-get-atoms 'ParseNode))
+
+	;(close-port file-port)
+;)
 
 ; ---------------------------------------------------------------------
 ; ---------------------------------------------------------------------

--- a/opencog/nlp/ull-parser/scm/mst-parser.scm
+++ b/opencog/nlp/ull-parser/scm/mst-parser.scm
@@ -258,7 +258,9 @@
 
 (define-public (observe-mst-extra plain-text CNT-MODE DIST-MODE)
 "
-  observe-mst -- update pseduo-disjunct counts by observing raw text.
+  observe-mst-extra -- update pseduo-disjunct counts by observing raw text.
+
+  See also 'observe-mst'.
 
   This is the second part of the learning algo: simply count how
   often pseudo-disjuncts show up.
@@ -266,7 +268,7 @@
 	(define parse (mst-parse-text plain-text CNT-MODE DIST-MODE))
 	(export-mst-parse plain-text parse "mst-parses.txt")
 	; The count-one-atom function fetches from the SQL database,
-	; increments the count by 1, and stores the result back
+	; increments the count by one, and stores the result back
 	(for-each
 		(lambda (dj) (if (not (is-oversize? dj)) (count-one-atom dj 1)))
 		(make-sections parse)
@@ -325,7 +327,7 @@
 )
 
 ; ---------------------------------------------------------------------
-;(define-public (observe-mst-extra-manhin plain-text CNT-MODE DIST-MODE)
+;(define-public (observe-mst-extra plain-text CNT-MODE DIST-MODE)
 ;"
   ;observe-mst-extra -- update pseduo-disjunct counts by observing raw
   ;text.


### PR DESCRIPTION
Simplified the function that exports mst-parses to file, since we're not using ParseNodes now. I left Manhin's function (commented out), in case we need the parses later. @linas , please advice if this is appropriate.