### PR TITLE
learning: move and expand DistributedPatternMiner ctor

### DIFF
--- a/opencog/learning/PatternMiner/DistributedPatternMiner.h
+++ b/opencog/learning/PatternMiner/DistributedPatternMiner.h
@@ -118,11 +118,7 @@ protected:
 
 public:
 
-    DistributedPatternMiner(AtomSpace& _original_as) : PatternMiner(_original_as)
-    {
-        is_distributed = true;
-        patternJsonArrays = new web::json::value[param.THREAD_NUM];
-    }
+    DistributedPatternMiner(AtomSpace& _original_as);
 
     void launchADistributedWorker();
     void launchCentralServer();


### PR DESCRIPTION
Cppcheck complains:
[opencog/learning/PatternMiner/DistributedPatternMiner.h:121]: (warning) Member variable 'DistributedPatternMiner::pattern_parse_thread_num' is not initialized in the constructor.
[opencog/learning/PatternMiner/DistributedPatternMiner.h:121]: (warning) Member variable 'DistributedPatternMiner::parsePatternTaskThreads' is not initialized in the constructor.
[opencog/learning/PatternMiner/DistributedPatternMiner.h:121]: (warning) Member variable 'DistributedPatternMiner::allWorkersStop' is not initialized in the constructor.
[opencog/learning/PatternMiner/DistributedPatternMiner.h:121]: (warning) Member variable 'DistributedPatternMiner::run_as_distributed_worker' is not initialized in the constructor.
[opencog/learning/PatternMiner/DistributedPatternMiner.h:121]: (warning) Member variable 'DistributedPatternMiner::run_as_central_server' is not initialized in the constructor.
[opencog/learning/PatternMiner/DistributedPatternMiner.h:121]: (warning) Member variable 'DistributedPatternMiner::httpClient' is not initialized in the constructor.
[opencog/learning/PatternMiner/DistributedPatternMiner.h:121]: (warning) Member variable 'DistributedPatternMiner::serverListener' is not initialized in the constructor.
[opencog/learning/PatternMiner/DistributedPatternMiner.h:121]: (warning) Member variable 'DistributedPatternMiner::cur_worker_mined_pattern_num' is not initialized in the constructor.
[opencog/learning/PatternMiner/DistributedPatternMiner.h:121]: (warning) Member variable 'DistributedPatternMiner::total_pattern_received' is not initialized in the constructor.
[opencog/learning/PatternMiner/DistributedPatternMiner.h:121]: (warning) Member variable 'DistributedPatternMiner::waitingForNewClients' is not initialized in the constructor.

This actually steals some initialization from
DistributedPatternMiner::launchCentralServer(), but I think it's more
appropriate to init those things in the constructor rather than in some
method.