### PR TITLE
Dont delete the SystemActivityTable on the end of the serverloop

### DIFF
--- a/opencog/cogserver/server/CogServer.cc
+++ b/opencog/cogserver/server/CogServer.cc
@@ -201,7 +201,6 @@ void CogServer::serverLoop()
 
     // No way to process requests. Stop accepting network connections.
     disableNetworkServer();
-    _systemActivityTable.halt();
 }
 
 void CogServer::runLoopStep(void)


### PR DESCRIPTION
[See Amens comment on PR 120, cogutil](https://github.com/opencog/cogutil/pull/120)
Fix non-passing unit test

Note: as the SystemActivityTable is erased (SystemActivityTable::halt) in the destructor of the CogServer, this shouldnt cause memory leaks or equal