### PR TITLE
Parametrize observe-text

### DIFF
--- a/opencog/nlp/learn/scm/link-pipeline.scm
+++ b/opencog/nlp/learn/scm/link-pipeline.scm
@@ -450,8 +450,10 @@
  an integer parameter:
  - tree: counts pairs of words linked by the LG parser in 'any' language.
  	   'count-reach' specifies how many linkages from LG-parser to use.
- - clique: pairs each word with all neighboring words located less than
-           'count-reach' spaces away.
+ - clique: itearates over each word in the sentence and pairs it with
+           every word located within distance 'count-reach' to its right.
+           Distance is defined as the difference between words positions
+           in the sentence, so neighboring words have distance of 1.
 
  This is the first part of the learning algo: simply count the words
  and word-pairs observed in incoming text. This takes in raw text, gets

--- a/opencog/nlp/learn/scm/link-pipeline.scm
+++ b/opencog/nlp/learn/scm/link-pipeline.scm
@@ -448,7 +448,7 @@
  
  There are currently two observing modes, set by observe-mode, both taking
  an integer parameter:
- - tree: counts pairs of words linked by the LG parser in 'any' language.
+ - any: counts pairs of words linked by the LG parser in 'any' language.
  	   'count-reach' specifies how many linkages from LG-parser to use.
  - clique: itearates over each word in the sentence and pairs it with
            every word located within distance 'count-reach' to its right.
@@ -487,7 +487,7 @@
 	; passed as argument, then delete the sentence.
 	(define (process-sent SENT cnt-mode win-size)
 		(update-word-counts SENT)
-		(if (equal? cnt-mode "tree")
+		(if (equal? cnt-mode "any")
 			(update-lg-link-counts SENT)
 			(update-clique-pair-counts SENT win-size #f))
 		(delete-sentence SENT)
@@ -560,7 +560,7 @@
 			(lambda ()
 				(let* ((phr (Phrase TXT))
 						; needs at least one linkage for tokenization
-						(num-parses (if (equal? obs-mode "tree") cnt-reach 1))
+						(num-parses (if (equal? obs-mode "any") cnt-reach 1))
 						(lgn (LgParseMinimal phr (LgDict "any") (Number num-parses)))
 						(sent (cog-execute! lgn))
 					)

--- a/opencog/nlp/learn/scm/link-pipeline.scm
+++ b/opencog/nlp/learn/scm/link-pipeline.scm
@@ -448,7 +448,7 @@
  
  There are currently two observing modes, set by observe-mode, both taking
  an integer parameter:
- - lg: counts pairs of words linked by the LG parser in 'any' language.
+ - tree: counts pairs of words linked by the LG parser in 'any' language.
  	   'count-reach' specifies how many linkages from LG-parser to use.
  - clique: pairs each word with all neighboring words located less than
            'count-reach' spaces away.
@@ -485,7 +485,7 @@
 	; passed as argument, then delete the sentence.
 	(define (process-sent SENT cnt-mode win-size)
 		(update-word-counts SENT)
-		(if (equal? cnt-mode "lg")
+		(if (equal? cnt-mode "tree")
 			(update-lg-link-counts SENT)
 			(update-clique-pair-counts SENT win-size #f))
 		(delete-sentence SENT)
@@ -558,7 +558,7 @@
 			(lambda ()
 				(let* ((phr (Phrase TXT))
 						; needs at least one linkage for tokenization
-						(num-parses (if (equal? obs-mode "lg") cnt-reach 1))
+						(num-parses (if (equal? obs-mode "tree") cnt-reach 1))
 						(lgn (LgParseMinimal phr (LgDict "any") (Number num-parses)))
 						(sent (cog-execute! lgn))
 					)

--- a/opencog/nlp/learn/scm/link-pipeline.scm
+++ b/opencog/nlp/learn/scm/link-pipeline.scm
@@ -441,7 +441,16 @@
 			(set! start-time now)
 			(set! run-time run))))
 
-; --------------------------------------------------------------------
+; ---------------------------------------------------------------------
+(define-public (observe-text plain-text)
+"
+ observe-text -- wrapper to call observe-text-mode.
+ Allows backwards compatibility by calling the function with the default 
+ observing mode (lg) and number of link-grammar parses to observe (24).
+"
+	(observe-text-mode plain-text "lg" 24))
+
+; ---------------------------------------------------------------------
 (define-public (observe-text-mode plain-text observe-mode count-reach)
 "
  observe-text -- update word and word-pair counts by observing raw text.


### PR DESCRIPTION
Modified observe-text function in NLP tools, to take as argument the observing mode:
- "lg" mode keeps current default functionality, but takes an integer specifying how many linkages to use for word-pair counting
- "clique" mode observes word-pairs using existing clique-pair counting capabilities, taking an integer to specify window size for observation.

Also included wrapper to old observe-text function for backwards compatibility
@linas , plase review and let me know if this is acceptable