### PR TITLE
Fix CogServerUTest take 2

### DIFF
--- a/opencog/cogserver/server/AgentRunnerBase.h
+++ b/opencog/cogserver/server/AgentRunnerBase.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <vector>
 #include <opencog/cogserver/server/Agent.h>
+#include <opencog/cogserver/server/SystemActivityTable.h>
 
 namespace opencog
 {
@@ -49,6 +50,9 @@ class AgentRunnerBase
         /** The runner name; mainly used for logging purposes */
         std::string name;
 
+        /** Pointer to SystemActivityTable, owned by CogServer */
+        SystemActivityTable* sat;
+
         /** Current cycle number (will reset to 0 if reaches max possible value) */
         unsigned long cycle_count;
 
@@ -70,6 +74,8 @@ class AgentRunnerBase
 
         /** Run an Agent and log its activity. */
         void run_agent(AgentPtr a);
+
+        void set_activity_table(SystemActivityTable* sat);
 };
 
 
@@ -104,6 +110,8 @@ class SimpleRunner: public AgentRunnerBase
          * frequency \endlink property.
          */
         void process_agents();
+
+        void set_activity_table(SystemActivityTable* sat) { this->sat = sat; };
 };
 
 } /* namespace opencog */

--- a/opencog/cogserver/server/CogServer.cc
+++ b/opencog/cogserver/server/CogServer.cc
@@ -145,6 +145,7 @@ CogServer::CogServer(AtomSpace* as) :
 #endif // HAVE_CYTHON
 
     _systemActivityTable.init(this);
+    agentScheduler.set_activity_table(&_systemActivityTable);
 
     agentsRunning = true;
 }
@@ -329,9 +330,6 @@ void CogServer::stopAllAgents(const std::string& id)
     agentScheduler.remove_all_agents(id);
     for (auto &runner: agentThreads)
         runner->remove_all_agents(id);
-//    // remove statistical record of their activities
-//    for (size_t n = 0; n < to_delete.size(); n++)
-//        _systemActivityTable.clearActivity(to_delete[n]);
 }
 
 void CogServer::startAgentLoop(void)


### PR DESCRIPTION
This is similar to #3275 - except that was only a partial fix.

The AgentRunnerBase was relying on a global singleton `cogserver()` to get the SystemActivityTable... this is a different cogserver instance to the one that is run in the test.