### PR TITLE
Also pass SystemActivityTable to threaded agent runners

### DIFF
--- a/opencog/cogserver/server/AgentRunnerBase.h
+++ b/opencog/cogserver/server/AgentRunnerBase.h
@@ -46,6 +46,8 @@ class AgentRunnerBase
 
         unsigned long get_cycle_count() const;
 
+        void set_activity_table(SystemActivityTable* sat);
+
     protected:
         /** The runner name; mainly used for logging purposes */
         std::string name;
@@ -75,7 +77,6 @@ class AgentRunnerBase
         /** Run an Agent and log its activity. */
         void run_agent(AgentPtr a);
 
-        void set_activity_table(SystemActivityTable* sat);
 };
 
 

--- a/opencog/cogserver/server/AgentRunnerThread.h
+++ b/opencog/cogserver/server/AgentRunnerThread.h
@@ -75,6 +75,8 @@ class AgentRunnerThread: public AgentRunnerBase
          */
         bool has_agents() const;
 
+        void set_activity_table(SystemActivityTable* sat) { this->sat = sat; };
+
     private:
         /** If running agents is enabled */
         std::atomic_bool running;

--- a/opencog/cogserver/server/CogServer.cc
+++ b/opencog/cogserver/server/CogServer.cc
@@ -303,6 +303,7 @@ void CogServer::startAgent(AgentPtr agent, bool dedicated_thread,
         else {
             agentThreads.emplace_back(new AgentRunnerThread);
             runner = agentThreads.back().get();
+            runner->set_activity_table(&_systemActivityTable);
             if (!thread_name.empty())
             {
                 runner->set_name(thread_name);


### PR DESCRIPTION
Agents either get run by the SimpleRunner in the CogServer thread or in an AgentRunnerThread.

I previously (#3281) had only dealt with the SimpleRunner case.

This should fix the failure of HebbianCreationModuleUTest and possible others https://github.com/opencog/opencog/pull/3281#discussion_r207089904