### PR TITLE
fix inference-control-learning example

### DIFF
--- a/examples/pln/inference-control-learning/icl-utilities.scm
+++ b/examples/pln/inference-control-learning/icl-utilities.scm
@@ -112,7 +112,7 @@
   (null? (cog-incoming-set atom)))
 
 (define (null-confidence? atom)
-  (= 0 (cog-tv-conf (cog-tv atom))))
+  (= 0 (cog-tv-confidence (cog-tv atom))))
 
 ;; Copy all atoms from an atomspace to another atomspace
 (define (cp-as src dst)


### PR DESCRIPTION
rename cog-tv-conf -> cog-tv-confidence in inference-control-learning