### PR TITLE
Add incremental conjunction expansion to URE Pattern Miner

### DIFF
--- a/examples/miner/2-conjunct/2-conjunct.scm
+++ b/examples/miner/2-conjunct/2-conjunct.scm
@@ -41,6 +41,22 @@
 ;;       (Variable "$Y")
 ;;       (Variable "$Z"))))
 ;;
+;; Starting from pattern (conjunct-pattern 2), that is
+;;
+;; (Lambda
+;;   (VariableList
+;;     (Variable "$X")
+;;     (Variable "$Y")
+;;     (Variable "$Z")
+;;     (Variable "$W"))
+;;   (And
+;;     (Inheritance
+;;       (Variable "$X")
+;;       (Variable "$Y"))
+;;     (Inheritance
+;;       (Variable "$Z")
+;;       (Variable "$W"))))
+;;
 ;; TODO: the following bugs for no reason
 ;; (cog-mine (cog-atomspace) 2 #:initpat (conjunct-pattern 2))
 (cog-mine (list AB BC DE EF) 2 #:initpat (conjunct-pattern 2))

--- a/examples/miner/2-conjunct/README.md
+++ b/examples/miner/2-conjunct/README.md
@@ -1,5 +1,12 @@
-Simple pattern miner example starting with a pattern with 2
-conjunctions. Given the KB
+# Mine 2-conjunct Pattern
+
+Mine simple 2-conjunct (a.k.a. 2-gram) pattern starting with an
+abstract pattern of 2 conjuncts.
+
+## Overview
+
+Given the KB
+
 ```
 (Inheritance
   (Concept "A")
@@ -13,8 +20,11 @@ conjunctions. Given the KB
 (Inheritance
   (Concept "E")
   (Concept "F")))
+
 ```
+
 find pattern
+
 ```
 (Lambda
   (VariableList
@@ -29,3 +39,19 @@ find pattern
       (Variable "$Y")
       (Variable "$Z"))))
 ```
+
+## Alternative
+
+Another (usually more efficient) way to mine n-conjunct patterns is to
+use incremental conjunction expansion. See the ugly-male-soda-drinker
+example for that.
+
+## Usage
+
+Run `2-conjunct.scm` in the guile interpreter
+
+```
+guile -l 2-conjunct.scm
+```
+
+or paste scheme commends one by one in guile.

--- a/examples/miner/simple/README.md
+++ b/examples/miner/simple/README.md
@@ -1,4 +1,10 @@
-Ultra simple example. Given the KB
+# Mine Simple Pattern
+
+Mine simple 1-conjunct (a.k.a. 1-gram) pattern.
+
+## Overview
+
+Given the KB
 ```
 (Inheritance
   (Concept "A")
@@ -15,3 +21,13 @@ find pattern
     (Concept "A")
     (Variable "$X")))
 ```
+
+## Usage
+
+Run `simple.scm` in the guile interpreter
+
+```
+guile -l simple.scm
+```
+
+or paste scheme commends one by one in guile.

--- a/examples/miner/ugly-male-soda-drinker/README.md
+++ b/examples/miner/ugly-male-soda-drinker/README.md
@@ -1,0 +1,88 @@
+# Mine Ugly Male Soda Drinker Pattern
+
+Miner 3-conjunct (a.k.a. 3-gram) pattern by expanding pattern
+conjunctions in an incremental manner.
+
+## Overview
+
+Given a KB of people and their characteristics, such as `man`,
+`woman`, `ugly`, etc.
+
+```scheme
+(Inheritance
+  (Concept "Allen")
+  (Concept "man"))
+...
+(Inheritance
+  (Concept "Davion")
+  (Concept "ugly"))
+...
+(Inheritance
+  (Concept "Jenica")
+  (Concept "soda drinker"))
+```
+
+Mine patterns such as
+
+```scheme
+(Lambda
+  (Variable "$X")
+  (And
+    (Inheritance
+      (Variable "$X")
+      (Concept "man"))
+    (Inheritance
+      (Variable "$X")
+      (Concept "ugly"))
+    (Inheritance
+      (Variable "$X")
+      (Concept "soda drinker"))))
+```
+
+by starting from the top pattern
+
+```scheme
+(Lambda
+  (Variable "$X")
+  (Variable "$X"))
+```
+
+finding 1-conjunct (a.k.a. 1-gram) patterns first, such as
+
+```scheme
+(Lambda
+  (Variable "$X")
+  (Inheritance
+    (Variable "$X")
+    (Concept "soda drinker")))
+(Lambda
+  (Variable "$X")
+  (Inheritance
+    (Variable "$X")
+    (Concept "ugly")))
+```
+
+and combining them to create larger conjunctive patterns such as
+
+```scheme
+(Lambda
+  (Variable "$X")
+  (And
+    (Inheritance
+      (Variable "$X")
+      (Concept "soda drinker"))
+    (Inheritance
+      (Variable "$X")
+      (Concept "ugly"))))
+```
+
+## Usage
+
+Load `ugly-male-soda-drinker.scm` directly into guile to run the whole
+thing
+
+```bash
+guile -l ugly-male-soda-drinker.scm
+```
+
+or paste each scheme commend into guile.

--- a/examples/miner/ugly-male-soda-drinker/kb.scm
+++ b/examples/miner/ugly-male-soda-drinker/kb.scm
@@ -1,0 +1,299 @@
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Allen")
+  (ConceptNode "human")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Abe")
+  (ConceptNode "human")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Cason")
+  (ConceptNode "human")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Davion")
+  (ConceptNode "human")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Hessley")
+  (ConceptNode "human")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Jadrian")
+  (ConceptNode "human")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Rio")
+  (ConceptNode "human")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Bob")
+  (ConceptNode "human")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Mike")
+  (ConceptNode "human")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Zac")
+  (ConceptNode "human")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Lily")
+  (ConceptNode "human")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Emily")
+  (ConceptNode "human")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Lucy")
+  (ConceptNode "human")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Sophia")
+  (ConceptNode "human")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Alaura")
+  (ConceptNode "human")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Breonna")
+  (ConceptNode "human")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Jaleesa")
+  (ConceptNode "human")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Jassy")
+  (ConceptNode "human")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Jenica")
+  (ConceptNode "human")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Kecia")
+  (ConceptNode "human")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Allen")
+  (ConceptNode "man")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Abe")
+  (ConceptNode "man")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Cason")
+  (ConceptNode "man")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Davion")
+  (ConceptNode "man")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Hessley")
+  (ConceptNode "man")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Jadrian")
+  (ConceptNode "man")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Rio")
+  (ConceptNode "man")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Bob")
+  (ConceptNode "man")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Mike")
+  (ConceptNode "man")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Zac")
+  (ConceptNode "man")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Lily")
+  (ConceptNode "woman")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Emily")
+  (ConceptNode "woman")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Lucy")
+  (ConceptNode "woman")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Sophia")
+  (ConceptNode "woman")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Alaura")
+  (ConceptNode "woman")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Breonna")
+  (ConceptNode "woman")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Jaleesa")
+  (ConceptNode "woman")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Jassy")
+  (ConceptNode "woman")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Jenica")
+  (ConceptNode "woman")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Kecia")
+  (ConceptNode "woman")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Allen")
+  (ConceptNode "ugly")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Abe")
+  (ConceptNode "ugly")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Cason")
+  (ConceptNode "ugly")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Davion")
+  (ConceptNode "ugly")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Hessley")
+  (ConceptNode "ugly")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Lily")
+  (ConceptNode "ugly")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Emily")
+  (ConceptNode "ugly")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Lucy")
+  (ConceptNode "ugly")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Sophia")
+  (ConceptNode "ugly")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Alaura")
+  (ConceptNode "ugly")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Allen")
+  (ConceptNode "soda drinker")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Abe")
+  (ConceptNode "soda drinker")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Cason")
+  (ConceptNode "soda drinker")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Davion")
+  (ConceptNode "soda drinker")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Hessley")
+  (ConceptNode "soda drinker")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Breonna")
+  (ConceptNode "soda drinker")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Jaleesa")
+  (ConceptNode "soda drinker")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Jassy")
+  (ConceptNode "soda drinker")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Jenica")
+  (ConceptNode "soda drinker")
+)
+
+(InheritanceLink (stv 1.000000 1.000000)
+  (ConceptNode "Kecia")
+  (ConceptNode "soda drinker")
+)

--- a/examples/miner/ugly-male-soda-drinker/ugly-male-soda-drinker.scm
+++ b/examples/miner/ugly-male-soda-drinker/ugly-male-soda-drinker.scm
@@ -1,0 +1,33 @@
+;; Load the miner module
+(use-modules (opencog miner))
+
+;; For debugging
+(use-modules (opencog logger))
+(use-modules (opencog rule-engine))
+(ure-logger-set-level! "debug")
+
+;; Load KB
+(load "kb.scm")
+
+;; Call the miner on the entire atomspace with minimum support of 5,
+;; 100 iterations of forward chaining, a 0.1 strength and confidence
+;; of expanding conjunctions up at most 3 conjuncts.
+;;
+;; Expect to learn, amonst others, the following pattern
+;;
+;; (Lambda
+;;   (Variable "$X")
+;;   (And
+;;     (Inheritance
+;;       (Variable "$X")
+;;       (Concept "man"))
+;;     (Inheritance
+;;       (Variable "$X")
+;;       (Concept "ugly"))
+;;     (Inheritance
+;;       (Variable "$X")
+;;       (Concept "soda drinker"))))
+(cog-mine (cog-atomspace) 5
+          #:maxiter 100
+          #:incremental-expansion (stv 0.1 0.1)
+          #:max-conjuncts 3)

--- a/examples/pln/amusing-friend/README.md
+++ b/examples/pln/amusing-friend/README.md
@@ -41,4 +41,4 @@ Inference Chain Documentation
 The file Amusing_Friend_PLN_Demo.html documents the inference chain 
 steps of the demo. The file can be opened in a web browser. Detail 
 information about the PLN rules and Atomese involved at each step can be
-displayed by expanding the step panel sections. 
+displayed by expanding the step panel sections.

--- a/examples/pln/amusing-friend/pln-bc-config.scm
+++ b/examples/pln/amusing-friend/pln-bc-config.scm
@@ -101,7 +101,7 @@
 (ure-set-fuzzy-bool-parameter pln-rbs "URE:attention-allocation" 0)
 
 ;; Complexity penalty
-(ure-set-num-parameter pln-rbs "URE:BC:complexity-penalty" 1)
+(ure-set-num-parameter pln-rbs "URE:complexity-penalty" 1)
 
 ;; BIT reduction parameters
 (ure-set-num-parameter pln-rbs "URE:BC:maximum-bit-size" 20000)

--- a/examples/pln/inference-control-learning/pln-rb.scm
+++ b/examples/pln/inference-control-learning/pln-rb.scm
@@ -84,7 +84,7 @@
 (ure-set-num-parameter pln-rbs "URE:maximum-iterations" piter)
 
 ;; Complexity penalty
-(ure-set-num-parameter pln-rbs "URE:BC:complexity-penalty" 0.1)
+(ure-set-num-parameter pln-rbs "URE:complexity-penalty" 0.1)
 
 ;; Mixture Model compressiveness
 (ure-set-num-parameter pln-rbs "URE:BC:MM:compressiveness" 0.5)

--- a/examples/pln/inference-control-learning/preproof-expander-is-preproof.scm
+++ b/examples/pln/inference-control-learning/preproof-expander-is-preproof.scm
@@ -162,7 +162,7 @@
 ;; Complexity penalty, negative so that it always expands the biggest,
 ;; we can do that since the backward chainer is linear (it has only
 ;; one branch).
-(ure-set-num-parameter pep-rbs "URE:BC:complexity-penalty" -2)
+(ure-set-num-parameter pep-rbs "URE:complexity-penalty" -2)
 
 ;; Actually: to speed this up we instead reapply the following rule,
 ;; corresponding to a conditional instantiation followed by a

--- a/examples/pln/moses-pln-synergy/scm/pln-bc-config.scm
+++ b/examples/pln/moses-pln-synergy/scm/pln-bc-config.scm
@@ -101,7 +101,7 @@
 (ure-set-fuzzy-bool-parameter pln-rbs "URE:attention-allocation" 0)
 
 ;; Complexity penalty
-(ure-set-num-parameter pln-rbs "URE:BC:complexity-penalty" 1)
+(ure-set-num-parameter pln-rbs "URE:complexity-penalty" 1)
 
 ;; BIT reduction parameters
 (ure-set-num-parameter pln-rbs "URE:BC:maximum-bit-size" 100000)

--- a/examples/pln/sumo/pln-config1.scm
+++ b/examples/pln/sumo/pln-config1.scm
@@ -83,7 +83,7 @@
 (ure-set-fuzzy-bool-parameter pln-rbs "URE:attention-allocation" 0)
 
 ;; Complexity penalty
-(ure-set-num-parameter pln-rbs "URE:BC:complexity-penalty" 1)
+(ure-set-num-parameter pln-rbs "URE:complexity-penalty" 1)
 
 ;; BIT reduction parameters
 (ure-set-num-parameter pln-rbs "URE:BC:maximum-bit-size" 50000)

--- a/examples/pln/sumo/pln-config2.scm
+++ b/examples/pln/sumo/pln-config2.scm
@@ -83,7 +83,7 @@
 (ure-set-fuzzy-bool-parameter pln-rbs "URE:attention-allocation" 0)
 
 ;; Complexity penalty
-(ure-set-num-parameter pln-rbs "URE:BC:complexity-penalty" 1)
+(ure-set-num-parameter pln-rbs "URE:complexity-penalty" 1)
 
 ;; BIT reduction parameters
 (ure-set-num-parameter pln-rbs "URE:BC:maximum-bit-size" 50000)

--- a/examples/pln/sumo/pln-config3.scm
+++ b/examples/pln/sumo/pln-config3.scm
@@ -85,7 +85,7 @@
 (ure-set-fuzzy-bool-parameter pln-rbs "URE:attention-allocation" 0)
 
 ;; Complexity penalty
-(ure-set-num-parameter pln-rbs "URE:BC:complexity-penalty" 1)
+(ure-set-num-parameter pln-rbs "URE:complexity-penalty" 1)
 
 ;; BIT reduction parameters
 (ure-set-num-parameter pln-rbs "URE:BC:maximum-bit-size" 50000)

--- a/examples/pln/universal-instantiation/rb.scm
+++ b/examples/pln/universal-instantiation/rb.scm
@@ -67,4 +67,4 @@
 (ure-set-fuzzy-bool-parameter pln-rbs "URE:attention-allocation" 0)
 
 ;; Complexity penalty
-(ure-set-num-parameter pln-rbs "URE:BC:complexity-penalty" 1)
+(ure-set-num-parameter pln-rbs "URE:complexity-penalty" 1)

--- a/opencog/learning/PatternMiner/HTree.cc
+++ b/opencog/learning/PatternMiner/HTree.cc
@@ -29,154 +29,157 @@ namespace opencog {
 using namespace std;
 using namespace PatternMining;
 
-std::string HTreeNode::to_string() const
+std::string HTreeNode::to_string(const std::string& indent) const
 {
 	stringstream ss;
 	if (not pattern.empty())
-		ss << "pattern:" << std::endl
-		   << oc_to_string(pattern);
+		ss << indent << "pattern:" << std::endl
+		   << oc_to_string(pattern, indent + OC_TO_STRING_INDENT);
 	if (quotedPatternLink)
-		ss << "quotedPatternLink:" << std::endl
-		   << oc_to_string(quotedPatternLink);
+		ss << indent << "quotedPatternLink:" << std::endl
+		   << oc_to_string(quotedPatternLink, indent + OC_TO_STRING_INDENT);
 	if (not instances.empty())
-		ss << "instances:" << std::endl
-		   << oc_to_string(instances);
+		ss << indent << "instances:" << std::endl
+		   << oc_to_string(instances, indent + OC_TO_STRING_INDENT);
 	if (not parentLinks.empty())
-		ss << "parentLinks:" << std::endl
-		   << oc_to_string(parentLinks);
+		ss << indent << "parentLinks:" << std::endl
+		   << oc_to_string(parentLinks, indent + OC_TO_STRING_INDENT);
 	if (not childLinks.empty())
-		ss << "childLinks:" << std::endl
-		   << oc_to_string(childLinks);
+		ss << indent << "childLinks:" << std::endl
+		   << oc_to_string(childLinks, indent + OC_TO_STRING_INDENT);
 	if (not superPatternRelations.empty())
-		ss << "superPatternRelations:" << std::endl
-		   << oc_to_string(superPatternRelations);
+		ss << indent << "superPatternRelations:" << std::endl
+		   << oc_to_string(superPatternRelations, indent + OC_TO_STRING_INDENT);
 	if (not superRelation_b_list.empty())
-		ss << "superRelation_b_list:" << std::endl
-		   << oc_to_string(superRelation_b_list);
+		ss << indent << "superRelation_b_list:" << std::endl
+		   << oc_to_string(superRelation_b_list, indent + OC_TO_STRING_INDENT);
 	if (not SubRelation_b_map.empty())
-		ss << "SubRelation_b_map:" << std::endl
-		   << oc_to_string(SubRelation_b_map);
+		ss << indent << "SubRelation_b_map:" << std::endl
+		   << oc_to_string(SubRelation_b_map, indent + OC_TO_STRING_INDENT);
 	if (count)
-		ss << "count: " << count << std::endl;
+		ss << indent << "count: " << count << std::endl;
 	if (var_num)
-		ss << "var_num: " << var_num << std::endl;
+		ss << indent << "var_num: " << var_num << std::endl;
 	if (interactionInformation)
-		ss << "interactionInformation: " << interactionInformation << std::endl;
+		ss << indent << "interactionInformation: " << interactionInformation << std::endl;
 	if (nI_Surprisingness)
-		ss << "nI_Surprisingness: " << nI_Surprisingness << std::endl;
+		ss << indent << "nI_Surprisingness: " << nI_Surprisingness << std::endl;
 	if (nII_Surprisingness)
-		ss << "nII_Surprisingness: " << nII_Surprisingness << std::endl;
+		ss << indent << "nII_Surprisingness: " << nII_Surprisingness << std::endl;
 	if (nII_Surprisingness_b)
-		ss << "nII_Surprisingness_b: " << nII_Surprisingness_b << std::endl;
+		ss << indent << "nII_Surprisingness_b: " << nII_Surprisingness_b << std::endl;
 	if (max_b_subpattern_num)
-		ss << "max_b_subpattern_num: " << max_b_subpattern_num << std::endl;
+		ss << indent << "max_b_subpattern_num: " << max_b_subpattern_num << std::endl;
 	if (not surprisingnessInfo.empty())
-		ss << "surprisingnessInfo: " << surprisingnessInfo << std::endl;
+		ss << indent << "surprisingnessInfo: " << surprisingnessInfo << std::endl;
 	if (not sharedVarNodeList.empty())
-		ss << "sharedVarNodeList:" << std::endl
-		   << oc_to_string(sharedVarNodeList);
+		ss << indent << "sharedVarNodeList:" << std::endl
+		   << oc_to_string(sharedVarNodeList, indent + OC_TO_STRING_INDENT);
 	return ss.str();
 }
 
-std::string oc_to_string(const std::map<Handle, std::vector<SubRelation_b>>& sm, const std::string& /*indent*/)
+std::string oc_to_string(const std::map<Handle, std::vector<SubRelation_b>>& sm,
+                         const std::string& indent)
 {
-    std::stringstream ss;
-	ss << "size = " << sm.size();
+	std::stringstream ss;
+	ss << indent << "size = " << sm.size();
 	int i = 0;
 	for (const auto& el : sm) {
-		ss << "atom[" << i << "]:" << std::endl
-		   << oc_to_string(el.first)
-		   << "SubRelation_b sequence[" << i << "]:" << std::endl
-		   << oc_to_string(el.second);
+		ss << indent << "atom[" << i << "]:" << std::endl
+		   << oc_to_string(el.first, indent + OC_TO_STRING_INDENT)
+		   << indent << "SubRelation_b sequence[" << i << "]:" << std::endl
+		   << oc_to_string(el.second, indent + OC_TO_STRING_INDENT);
 		i++;
 	}
 	return ss.str();
 }
 
 std::string oc_to_string(const std::vector<SuperRelation_b>& srbs,
-                         const std::string& /*indent*/)
+                         const std::string& indent)
 {
-	return oc_to_string(srbs, "SuperRelation_b");
+	return oc_to_string(srbs, indent, "SuperRelation_b");
 }
 
 std::string oc_to_string(const std::vector<SubRelation_b>& srbs,
-                         const std::string& /*indent*/)
+                         const std::string& indent)
 {
-	return oc_to_string(srbs, "SubRelation_b");
+	return oc_to_string(srbs, indent, "SubRelation_b");
 }
 
 std::string oc_to_string(const SuperRelation_b& srb,
-                         const std::string& /*indent*/)
+                         const std::string& indent)
 {
 	stringstream ss;
-	ss << "superHTreeNode:" << std::endl
-	   << oc_to_string(srb.superHTreeNode)
-	   << "constNode:" << std::endl
-	   << oc_to_string(srb.constNode);
+	ss << indent << "superHTreeNode:" << std::endl
+	   << oc_to_string(srb.superHTreeNode, indent + OC_TO_STRING_INDENT)
+	   << indent << "constNode:" << std::endl
+	   << oc_to_string(srb.constNode, indent + OC_TO_STRING_INDENT);
 	return ss.str();
 }
 
 std::string oc_to_string(const SubRelation_b& srb,
-                         const std::string& /*indent*/)
+                         const std::string& indent)
 {
 	stringstream ss;
-	ss << "subHTreeNode:" << std::endl
-	   << oc_to_string(srb.subHTreeNode)
-	   << "constNode:" << std::endl
-	   << oc_to_string(srb.constNode);
+	ss << indent << "subHTreeNode:" << std::endl
+	   << oc_to_string(srb.subHTreeNode, indent + OC_TO_STRING_INDENT)
+	   << indent << "constNode:" << std::endl
+	   << oc_to_string(srb.constNode, indent + OC_TO_STRING_INDENT);
 	return ss.str();
 }
 
 std::string oc_to_string(const ExtendRelation& extrel,
-                         const std::string& /*indent*/)
+                         const std::string& indent)
 {
 	stringstream ss;
-	ss << "extendedHTreeNode:" << std::endl
-	   << oc_to_string(extrel.extendedHTreeNode)
-	   << "sharedLink:" << std::endl
-	   << oc_to_string(extrel.sharedLink)
-	   << "newExtendedLink:" << std::endl
-	   << oc_to_string(extrel.newExtendedLink)
-	   << "extendedNode:" << std::endl
-	   << oc_to_string(extrel.extendedNode)
-	   << "isExtendedFromVar: " << extrel.isExtendedFromVar << std::endl;
+	ss << indent << "extendedHTreeNode:" << std::endl
+	   << oc_to_string(extrel.extendedHTreeNode, indent + OC_TO_STRING_INDENT)
+	   << indent << "sharedLink:" << std::endl
+	   << oc_to_string(extrel.sharedLink, indent + OC_TO_STRING_INDENT)
+	   << indent << "newExtendedLink:" << std::endl
+	   << oc_to_string(extrel.newExtendedLink, indent + OC_TO_STRING_INDENT)
+	   << indent << "extendedNode:" << std::endl
+	   << oc_to_string(extrel.extendedNode, indent + OC_TO_STRING_INDENT)
+	   << indent << "isExtendedFromVar: " << extrel.isExtendedFromVar << std::endl;
 	return ss.str();
 }
 
 std::string oc_to_string(const std::vector<ExtendRelation>& extrels,
-                         const std::string& /*indent*/)
+                         const std::string& indent)
 {
-	return oc_to_string(extrels, "ExtendRelation");
+	return oc_to_string(extrels, indent, "ExtendRelation");
 }
 
 std::string oc_to_string(const std::vector<std::vector<HTreeNode*>>& htrees_seq,
-                         const std::string& /*indent*/)
+                         const std::string& indent)
 {
-	return oc_to_string(htrees_seq, "HTreeNodeSeq");
+	return oc_to_string(htrees_seq, indent, "htrees");
 }
 
 std::string oc_to_string(const std::vector<HTreeNode*>& htrees,
-                         const std::string& /*indent*/)
+                         const std::string& indent)
 {
-	return oc_to_string(htrees, "HTreeNode");
+	return oc_to_string(htrees, indent, "htree");
 }
 
 std::string oc_to_string(const std::set<HTreeNode*>& htrees,
-                         const std::string& /*indent*/)
+                         const std::string& indent)
 {
-	return oc_to_string(htrees, "HTreeNode");
+	return oc_to_string(htrees, indent, "HTreeNode");
 }
 
 std::string oc_to_string(const HTreeNode* htnptr,
-                         const std::string& /*indent*/)
+                         const std::string& indent)
 {
-	return htnptr ? htnptr->to_string() : string("none\n") ;
+	if (htnptr)
+		return htnptr->to_string(indent);
+	return indent + string("none\n");
 }
 
 std::string oc_to_string(const HTreeNode& htn,
-                         const std::string& /*indent*/)
+                         const std::string& indent)
 {
-	return htn.to_string();
+	return htn.to_string(indent);
 }
 
 }

--- a/opencog/learning/PatternMiner/HTree.h
+++ b/opencog/learning/PatternMiner/HTree.h
@@ -86,7 +86,7 @@ public:
 
     HandleSeq sharedVarNodeList; // all the shared nodes in these links in the original AtomSpace, each handle is a shared node
 
-    std::string to_string() const;
+    std::string to_string(const std::string& indent=empty_string) const;
 
     HTreeNode()
         : count(0),
@@ -144,14 +144,14 @@ std::string oc_to_string(const HTreeNode& htn,
  * TODO: move this to cogutil
  */
 template<typename C>
-std::string oc_to_string(const C& c, const std::string& elname)
+std::string oc_to_string(const C& c, const std::string& indent, const std::string& elname)
 {
-    std::stringstream ss;
-	ss << "size = " << c.size() << std::endl;
+	std::stringstream ss;
+	ss << indent << "size = " << c.size() << std::endl;
 	int i = 0;
 	for (const auto& el : c) {
-		ss << elname << "[" << i << "]:" << std::endl
-		   << oc_to_string(el);
+		ss << indent << elname << "[" << i << "]:" << std::endl
+		   << oc_to_string(el, indent + OC_TO_STRING_INDENT);
 		i++;
 	}
 	return ss.str();

--- a/opencog/learning/PatternMiner/HTree.h
+++ b/opencog/learning/PatternMiner/HTree.h
@@ -38,64 +38,64 @@ class HTreeNode;
 
 struct ExtendRelation // to store a super pattern of a pattern
 {
-    HTreeNode* extendedHTreeNode; // super pattern HTreeNode
-    Handle sharedLink; // link in the original pattern that connect to new extended Link
-    Handle newExtendedLink; // in super pattern (contains variables, not the instance link), without unifying
-    Handle extendedNode; // node that being extended in the original AtomSpace (the value node, not its variable name node)
-    bool isExtendedFromVar;
+	HTreeNode* extendedHTreeNode; // super pattern HTreeNode
+	Handle sharedLink; // link in the original pattern that connect to new extended Link
+	Handle newExtendedLink; // in super pattern (contains variables, not the instance link), without unifying
+	Handle extendedNode; // node that being extended in the original AtomSpace (the value node, not its variable name node)
+	bool isExtendedFromVar;
 };
 
 struct SuperRelation_b // to store a super pattern of the same gram of a pattern
 {
-    HTreeNode* superHTreeNode; // the super pattern HTreeNode
-    Handle constNode; // the const Node
+	HTreeNode* superHTreeNode; // the super pattern HTreeNode
+	Handle constNode; // the const Node
 };
 
 struct SubRelation_b // to store a sub pattern of the same gram of a pattern
 {
-    HTreeNode* subHTreeNode; // the sub pattern HTreeNode
-    Handle constNode; // the const Node
+	HTreeNode* subHTreeNode; // the sub pattern HTreeNode
+	Handle constNode; // the const Node
 };
 
 class HTreeNode
 {
 public:
-    HandleSeq pattern;
-    Handle quotedPatternLink; // only used when if_quote_output_pattern = true
-    HandleSeqSeq instances; // the corresponding instances of this pattern in the original AtomSpace, only be used by breadth first mining
-    std::set<HTreeNode*> parentLinks;
-    std::set<HTreeNode*> childLinks;
+	HandleSeq pattern;
+	Handle quotedPatternLink; // only used when if_quote_output_pattern = true
+	HandleSeqSeq instances; // the corresponding instances of this pattern in the original AtomSpace, only be used by breadth first mining
+	std::set<HTreeNode*> parentLinks;
+	std::set<HTreeNode*> childLinks;
 
-    // set<string> instancesUidStrings;// all uid in each instance HandleSeq in all instances, in the form of 5152_815_201584. to prevent the same instance being count multiple times
+	// set<string> instancesUidStrings;// all uid in each instance HandleSeq in all instances, in the form of 5152_815_201584. to prevent the same instance being count multiple times
 
-    std::vector<ExtendRelation> superPatternRelations; // store all the connections to its super patterns
+	std::vector<ExtendRelation> superPatternRelations; // store all the connections to its super patterns
 
-    std::vector<SuperRelation_b> superRelation_b_list; // store all the superRelation_b
+	std::vector<SuperRelation_b> superRelation_b_list; // store all the superRelation_b
 
-    std::map<Handle, std::vector<SubRelation_b>> SubRelation_b_map;// map<VariableNode, vector<SubRelation_b>>
+	std::map<Handle, std::vector<SubRelation_b>> SubRelation_b_map;// map<VariableNode, vector<SubRelation_b>>
 
-    unsigned int count; // Number of instances grounding this pattern
-    unsigned int var_num; // Number of the variables in this pattern
-    double interactionInformation;
-    double nI_Surprisingness;
-    double nII_Surprisingness;
-    double nII_Surprisingness_b; // calculated from the other same gram patterns
-    unsigned int max_b_subpattern_num;
+	unsigned int count; // Number of instances grounding this pattern
+	unsigned int var_num; // Number of the variables in this pattern
+	double interactionInformation;
+	double nI_Surprisingness;
+	double nII_Surprisingness;
+	double nII_Surprisingness_b; // calculated from the other same gram patterns
+	unsigned int max_b_subpattern_num;
 
-    std::string surprisingnessInfo; // the middle info record the surpringness calculating process for this pattern
+	std::string surprisingnessInfo; // the middle info record the surpringness calculating process for this pattern
 
-    HandleSeq sharedVarNodeList; // all the shared nodes in these links in the original AtomSpace, each handle is a shared node
+	HandleSeq sharedVarNodeList; // all the shared nodes in these links in the original AtomSpace, each handle is a shared node
 
-    std::string to_string(const std::string& indent=empty_string) const;
+	std::string to_string(const std::string& indent=empty_string) const;
 
-    HTreeNode()
-        : count(0),
-          var_num(0),
-          interactionInformation(0.0),
-          nI_Surprisingness(0.0),
-          nII_Surprisingness(0.0),
-          nII_Surprisingness_b(1.0),
-          max_b_subpattern_num(0) {}
+	HTreeNode()
+		: count(0),
+		  var_num(0),
+		  interactionInformation(0.0),
+		  nI_Surprisingness(0.0),
+		  nII_Surprisingness(0.0),
+		  nII_Surprisingness_b(1.0),
+		  max_b_subpattern_num(0) {}
 };
 
 } // ~namespace PatterMining

--- a/opencog/learning/PatternMiner/PatternMiner.cc
+++ b/opencog/learning/PatternMiner/PatternMiner.cc
@@ -3129,7 +3129,7 @@ void PatternMiner::runInterestingnessEvaluation()
                 HTreeNode* pNode = patternsForGram[cur_gram-1][p];
 
                 // for patterns that have no superpatterns, nII_Surprisingness == -1.0, which should be taken into account
-                if ( (pNode->nII_Surprisingness < 0) || (pNode->nII_Surprisingness >= surprisingness_II_threshold) )
+                if ( (pNode->nII_Surprisingness < 0) || ((float)pNode->nII_Surprisingness >= surprisingness_II_threshold) )
                     finalPatternsForGram[cur_gram-1].push_back(pNode);
             }
 

--- a/opencog/learning/PatternMiner/PatternMiner.cc
+++ b/opencog/learning/PatternMiner/PatternMiner.cc
@@ -2319,7 +2319,7 @@ void PatternMiner::calculateSurprisingness(HTreeNode* HNode)
 //        cout << "\n ---- total_p = " << total_p << " ----\n" ;
 
         float diff = p - total_p;
-        diff = diff / total_p;
+        diff /= total_p;
 
         float abs_diff = std::abs(diff);
 
@@ -2335,7 +2335,7 @@ void PatternMiner::calculateSurprisingness(HTreeNode* HNode)
 
         if (OUTPUT_SURPRISINGNESS_CALCULATION_TO_FILE)
         {
-            HNode->surprisingnessInfo += ", expect = " + toString(total_p) + "x" + toString(allNum) + " = "
+            HNode->surprisingnessInfo += ", expect = " + toString(total_p) + "*" + toString(allNum) + " = "
                     + toString((total_p * ((float)allNum))) + ", nDiff = " + toString(diff) + "}";
         }
 
@@ -2349,7 +2349,7 @@ void PatternMiner::calculateSurprisingness(HTreeNode* HNode)
     // debug:
 //    cout << "nI_Surprisingness = " << HNode->nI_Surprisingness  << std::endl;
 
-    if (gram == param.MAX_GRAM ) // can't calculate II_Surprisingness for MAX_GRAM patterns, becasue it required gram +1 patterns
+    if (gram == param.MAX_GRAM ) // can't calculate II_Surprisingness for MAX_GRAM patterns, because it required gram +1 patterns
         return;
 
 

--- a/opencog/learning/PatternMiner/PatternMiner.h
+++ b/opencog/learning/PatternMiner/PatternMiner.h
@@ -611,12 +611,12 @@ public:
     void queryPatternsWithFrequencySurprisingnessIRanges(unsigned int min_frequency, unsigned int max_frequency, float min_surprisingness_I, float max_surprisingness_I, int gram);
 
     void queryPatternsWithSurprisingnessIAndIIRanges(unsigned int min_frequency, unsigned int max_frequency,
-                                                                   float min_surprisingness_I, float max_surprisingness_I,
-                                                                   float min_surprisingness_II, float max_surprisingness_II,int gram);
+                                                     float min_surprisingness_I, float max_surprisingness_I,
+                                                     float min_surprisingness_II, float max_surprisingness_II,int gram);
 
     void queryPatternsWithFrequencySurprisingnessBRanges(unsigned int min_frequency, unsigned int max_frequency,
-                                                                   float min_surprisingness_B, float max_surprisingness_B,
-                                                                   unsigned int min_subpattern_num, unsigned int max_subpattern_num,int gram);
+                                                         float min_surprisingness_B, float max_surprisingness_B,
+                                                         unsigned int min_subpattern_num, unsigned int max_subpattern_num,int gram);
 
     void queryPatternsWithFrequencyAndInteractionInformationRanges(unsigned int min_frequency, unsigned int max_frequency,
                                                                    float min_ii, float max_ii, int gram);

--- a/opencog/learning/PatternMiner/PatternMiner.h
+++ b/opencog/learning/PatternMiner/PatternMiner.h
@@ -160,7 +160,7 @@ struct MinedPatternInfo
 class PatternMiner
 {
     friend class ::PatternMinerUTest;
-	friend class opencog::PatternMinerSCM;
+    friend class opencog::PatternMinerSCM;
 
 protected:
 
@@ -183,7 +183,7 @@ protected:
 
     std::thread *threads;
 
-	Parameters param;
+    Parameters param;
 
     bool is_distributed;
 
@@ -349,12 +349,12 @@ protected:
      */
     void generateIndexesOfSharedVars(const Handle& link, const HandleSeq& orderedHandles, vector<vector<std::pair<int, size_t>>> &indexes);
 
-	/**
-	 * Given a mapping between handles, substitute all encountered
-	 * handle keys by their values in h. The produced handle is added
-	 * to the pattern miner atomspace and returned.
-	 */
-	Handle substitute(const Handle& h, const HandleMap& h2h);
+    /**
+     * Given a mapping between handles, substitute all encountered
+     * handle keys by their values in h. The produced handle is added
+     * to the pattern miner atomspace and returned.
+     */
+    Handle substitute(const Handle& h, const HandleMap& h2h);
 
     /**
      * Retrieve all nodes from a given link and its descendents. For
@@ -383,20 +383,20 @@ protected:
      */
     void extractConstNodes(const Handle& link, HandleSet& constNodes);
 
-	/**
-	 * Return true iff an atom contains only pattern variable nodes,
-	 * no const nodes.
-	 */
+    /**
+     * Return true iff an atom contains only pattern variable nodes,
+     * no const nodes.
+     */
     bool containOnlyVariables(Handle h);
 
-	/**
-	 * Return true iff an atom contains some pattern variable nodes.
-	 */
+    /**
+     * Return true iff an atom contains some pattern variable nodes.
+     */
     bool containSomeVariables(Handle link);
 
     void extractAllPossiblePatternsFromInputLinksBF(const HandleSeq& inputLinks, HTreeNode* parentNode, HandleSet& sharedNodes, unsigned int gram);
 
-	/**
+    /**
      * Copy the outgoings of `link` to `to_as` and return the copies
      *
      * Pattern variables are turned into regular variables while being
@@ -414,7 +414,7 @@ protected:
     Handle copyAtom(AtomSpace& to_as, const Handle& link,
                     HandleSeq& variables);
 
-	/**
+    /**
      * Copy `links` to `to_as` and return the copies.
      *
      * Pattern variables are turned into regular variables while being
@@ -441,10 +441,19 @@ protected:
 
     bool existInOneThreadExtractedLinks(unsigned int _gram, unsigned int cur_thread_index, string _extractedLinkUIDs);
 
-    void extendAPatternForOneMoreGramRecursively(const Handle& extendedLink, AtomSpace& from_as, const Handle& extendedNode, const HandleSeq& lastGramLinks,
-                                                 HTreeNode* parentNode, const HandleMap& lastGramValueToVarMap, const HandleMap& lastGramPatternVarMap,
-                                                 bool isExtendedFromVar, set<string>& allNewMinedPatternsCurTask, vector<HTreeNode*>& allHTreeNodesCurTask,
-                                                 vector<MinedPatternInfo>& allNewMinedPatternInfo, unsigned int thread_index, bool startFromLinkContainWhiteKeyword);
+    void extendPatternForOneMoreGramRecursively(const Handle& extendedLink,
+                                                AtomSpace& from_as,
+                                                const Handle& extendedNode,
+                                                const HandleSeq& lastGramLinks,
+                                                HTreeNode* parentNode,
+                                                const HandleMap& lastGramValueToVarMap,
+                                                const HandleMap& lastGramPatternVarMap,
+                                                bool isExtendedFromVar,
+                                                set<string>& allNewMinedPatternsCurTask,
+                                                vector<HTreeNode*>& allHTreeNodesCurTask,
+                                                vector<MinedPatternInfo>& allNewMinedPatternInfo,
+                                                unsigned int thread_index,
+                                                bool startFromLinkContainWhiteKeyword);
 
     /**
      * Return iff some sub-pattern contains only variables.
@@ -477,8 +486,18 @@ protected:
 
     void quoteAllThePatternSForGram(unsigned int gram);
 
-    HTreeNode* extractAPatternFromGivenVarCombination(HandleSeq &inputLinks, HandleMap &patternVarMap, HandleMap& orderedVarNameMap,HandleSeqSeq &oneOfEachSeqShouldBeVars, HandleSeq &leaves,HandleSeq &shouldNotBeVars, HandleSeq &shouldBeVars,
-                                                      unsigned int &extendedLinkIndex, set<string>& allNewMinedPatternsCurTask, bool &notOutPutPattern, bool &patternAlreadyExtractedInCurTask,bool startFromLinkContainWhiteKeyword);
+    HTreeNode* extractPatternFromVarCombination(HandleSeq &inputLinks,
+                                                HandleMap &patternVarMap,
+                                                HandleMap &orderedVarNameMap,
+                                                HandleSeqSeq &oneOfEachSeqShouldBeVars,
+                                                HandleSeq &leaves,
+                                                HandleSeq &shouldNotBeVars,
+                                                HandleSeq &shouldBeVars,
+                                                unsigned int &extendedLinkIndex,
+                                                set<string>& allNewMinedPatternsCurTask,
+                                                bool &notOutPutPattern,
+                                                bool &patternAlreadyExtractedInCurTask,
+                                                bool startFromLinkContainWhiteKeyword);
 
     void findAllInstancesForGivenPatternInNestedAtomSpace(HTreeNode* HNode);
 
@@ -496,9 +515,9 @@ protected:
 
     void evaluateInterestingnessTask();
 
-	/**
-	 * TODO Add comment + utest
-	 */
+    /**
+     * TODO Add comment + utest
+     */
     void generateNextCombinationGroup(bool* &indexes, int n_max);
 
     bool isLastNElementsAllTrue(bool* array, int size, int n);

--- a/opencog/learning/PatternMiner/PatternMinerDF.cc
+++ b/opencog/learning/PatternMiner/PatternMinerDF.cc
@@ -137,15 +137,35 @@ void PatternMiner::growPatternsDepthFirstTask(unsigned int thread_index)
             HandleSeq outVariableNodes;
             Handle newLink = copyAtom(*observing_as, cur_link, outVariableNodes);
 
-            extendAPatternForOneMoreGramRecursively(newLink, *observing_as, Handle::UNDEFINED, lastGramLinks, 0, lastGramValueToVarMap,patternVarMap, false,
-                                                    allNewMinedPatternsCurTask, allHTreeNodesCurTask, allNewMinedPatternInfo, thread_index, startFromLinkContainWhiteKeyword);
-
-
+            extendPatternForOneMoreGramRecursively(newLink,
+                                                   *observing_as,
+                                                   Handle::UNDEFINED,
+                                                   lastGramLinks,
+                                                   0,
+                                                   lastGramValueToVarMap,
+                                                   patternVarMap,
+                                                   false,
+                                                   allNewMinedPatternsCurTask,
+                                                   allHTreeNodesCurTask,
+                                                   allNewMinedPatternInfo,
+                                                   thread_index,
+                                                   startFromLinkContainWhiteKeyword);
         }
         else
         {
-            extendAPatternForOneMoreGramRecursively(cur_link, original_as, Handle::UNDEFINED, lastGramLinks, 0, lastGramValueToVarMap,patternVarMap, false,
-                                                    allNewMinedPatternsCurTask, allHTreeNodesCurTask, allNewMinedPatternInfo, thread_index,startFromLinkContainWhiteKeyword);
+            extendPatternForOneMoreGramRecursively(cur_link,
+                                                   original_as,
+                                                   Handle::UNDEFINED,
+                                                   lastGramLinks,
+                                                   0,
+                                                   lastGramValueToVarMap,
+                                                   patternVarMap,
+                                                   false,
+                                                   allNewMinedPatternsCurTask,
+                                                   allHTreeNodesCurTask,
+                                                   allNewMinedPatternInfo,
+                                                   thread_index,
+                                                   startFromLinkContainWhiteKeyword);
         }
 
         if (param.THREAD_NUM > 1)
@@ -215,13 +235,27 @@ void PatternMiner::runPatternMinerDepthFirst()
     cout << "\ntotalLinkNum = " << processedLinkNum << ", actualProcessedLinkNum = " << actualProcessedLinkNum << std::endl;
 }
 
-// extendedLinkIndex is to return the index of extendedLink's patternlink in the unified pattern so as to identify where is the extended link in this pattern
-// vector<HTreeNode*> &allHTreeNodesCurTask is only used in distributed version
-// notOutPutPattern is passed from extendAPatternForOneMoreGramRecursively, also may be modify in this function.
-// it indicates if one pattern is only generated for middle process - calculate interestingness for its superpatterns, but not put in output results
-HTreeNode* PatternMiner::extractAPatternFromGivenVarCombination(HandleSeq &inputLinks, HandleMap &patternVarMap, HandleMap& orderedVarNameMap,HandleSeqSeq &oneOfEachSeqShouldBeVars, HandleSeq &leaves,
-                                                                HandleSeq &shouldNotBeVars, HandleSeq &shouldBeVars, unsigned int & extendedLinkIndex,
-                                                                set<string>& allNewMinedPatternsCurTask, bool& notOutPutPattern, bool &patternAlreadyExtractedInCurTask, bool startFromLinkContainWhiteKeyword)
+// extendedLinkIndex is to return the index of extendedLink's
+// patternlink in the unified pattern so as to identify where is the
+// extended link in this pattern vector<HTreeNode*>
+// &allHTreeNodesCurTask is only used in distributed version
+// notOutPutPattern is passed from
+// extendPatternForOneMoreGramRecursively, also may be modify in this
+// function.  it indicates if one pattern is only generated for middle
+// process - calculate interestingness for its superpatterns, but not
+// put in output results
+HTreeNode* PatternMiner::extractPatternFromVarCombination(HandleSeq &inputLinks,
+                                                          HandleMap &patternVarMap,
+                                                          HandleMap& orderedVarNameMap,
+                                                          HandleSeqSeq &oneOfEachSeqShouldBeVars,
+                                                          HandleSeq &leaves,
+                                                          HandleSeq &shouldNotBeVars,
+                                                          HandleSeq &shouldBeVars,
+                                                          unsigned int & extendedLinkIndex,
+                                                          set<string>& allNewMinedPatternsCurTask,
+                                                          bool& notOutPutPattern,
+                                                          bool &patternAlreadyExtractedInCurTask,
+                                                          bool startFromLinkContainWhiteKeyword)
 {
     HTreeNode* returnHTreeNode = nullptr;
     bool skip = false;
@@ -421,7 +455,7 @@ HTreeNode* PatternMiner::extractAPatternFromGivenVarCombination(HandleSeq &input
                         (tmpPatternsForGram[gram-1]).push_back(newHTreeNode);
                 }
                 else
-                    (patternsForGram[gram-1]).push_back(newHTreeNode);
+                    patternsForGram[gram-1].push_back(newHTreeNode);
 
                 if (param.THREAD_NUM > 1)
                     addNewPatternLock.unlock();
@@ -481,15 +515,28 @@ bool PatternMiner::existInOneThreadExtractedLinks(unsigned int _gram, unsigned i
     return false;
 }
 
-// when it's the first gram pattern: parentNode = 0, extendedNode = undefined, lastGramLinks is empty, lastGramValueToVarMap and lastGramPatternVarMap are empty
-// extendedNode is the value node in original AtomSpace
-// lastGramLinks is the original links the parentLink is extracted from
-// allNewMinedPatternsCurTask is to store all the pattern keystrings mined in current Link task, to avoid duplicate patterns being mined
-// allNewMinedPatternInfo is only used in distributed mode, to store all the new mined pattern info to send to server
-void PatternMiner::extendAPatternForOneMoreGramRecursively(const Handle &extendedLink, AtomSpace& from_as, const Handle &extendedNode, const HandleSeq &lastGramLinks,
-                 HTreeNode* parentNode, const HandleMap &lastGramValueToVarMap, const HandleMap &lastGramPatternVarMap, bool isExtendedFromVar,
-                 set<string>& allNewMinedPatternsCurTask, vector<HTreeNode*> &allHTreeNodesCurTask, vector<MinedPatternInfo> &allNewMinedPatternInfo, unsigned int thread_index,
-                 bool startFromLinkContainWhiteKeyword)
+// when it's the first gram pattern: parentNode = 0, extendedNode =
+// undefined, lastGramLinks is empty, lastGramValueToVarMap and
+// lastGramPatternVarMap are empty extendedNode is the value node in
+// original AtomSpace lastGramLinks is the original links the
+// parentLink is extracted from allNewMinedPatternsCurTask is to store
+// all the pattern keystrings mined in current Link task, to avoid
+// duplicate patterns being mined allNewMinedPatternInfo is only used
+// in distributed mode, to store all the new mined pattern info to
+// send to server
+void PatternMiner::extendPatternForOneMoreGramRecursively(const Handle &extendedLink,
+                                                          AtomSpace& from_as,
+                                                          const Handle &extendedNode,
+                                                          const HandleSeq &lastGramLinks,
+                                                          HTreeNode* parentNode,
+                                                          const HandleMap &lastGramValueToVarMap,
+                                                          const HandleMap &lastGramPatternVarMap,
+                                                          bool isExtendedFromVar,
+                                                          set<string>& allNewMinedPatternsCurTask,
+                                                          vector<HTreeNode*> &allHTreeNodesCurTask,
+                                                          vector<MinedPatternInfo> &allNewMinedPatternInfo,
+                                                          unsigned int thread_index,
+                                                          bool startFromLinkContainWhiteKeyword)
 {
     // the ground value node in the from_as to the variable handle in pattenmining Atomspace
     HandleMap valueToVarMap = lastGramValueToVarMap;
@@ -667,8 +714,18 @@ void PatternMiner::extendAPatternForOneMoreGramRecursively(const Handle &extende
             bool patternAlreadyExtractedInCurTask;
             HandleMap orderedVarNameMap;
 
-            HTreeNode* thisGramHTreeNode = extractAPatternFromGivenVarCombination(inputLinks, patternVarMap, orderedVarNameMap,oneOfEachSeqShouldBeVars, leaves, shouldNotBeVars, shouldBeVars,
-                                          extendedLinkIndex, allNewMinedPatternsCurTask, notOutPutPattern, patternAlreadyExtractedInCurTask, startFromLinkContainWhiteKeyword);
+            HTreeNode* thisGramHTreeNode = extractPatternFromVarCombination(inputLinks,
+                                                                            patternVarMap,
+                                                                            orderedVarNameMap,
+                                                                            oneOfEachSeqShouldBeVars,
+                                                                            leaves,
+                                                                            shouldNotBeVars,
+                                                                            shouldBeVars,
+                                                                            extendedLinkIndex,
+                                                                            allNewMinedPatternsCurTask,
+                                                                            notOutPutPattern,
+                                                                            patternAlreadyExtractedInCurTask,
+                                                                            startFromLinkContainWhiteKeyword);
 
             if (thisGramHTreeNode)
             {
@@ -974,8 +1031,19 @@ void PatternMiner::extendAPatternForOneMoreGramRecursively(const Handle &extende
                             }
 
                             // extract patterns from this child
-                            extendAPatternForOneMoreGramRecursively(extendedHandle,  from_as, extendNode, inputLinks, thisGramHTreeNode, valueToVarMap,patternVarMap,isNewExtendedFromVar,
-                                                                    allNewMinedPatternsCurTask, allHTreeNodesCurTask, allNewMinedPatternInfo, thread_index, startFromLinkContainWhiteKeyword);
+                            extendPatternForOneMoreGramRecursively(extendedHandle,
+                                                                   from_as,
+                                                                   extendNode,
+                                                                   inputLinks,
+                                                                   thisGramHTreeNode,
+                                                                   valueToVarMap,
+                                                                   patternVarMap,
+                                                                   isNewExtendedFromVar,
+                                                                   allNewMinedPatternsCurTask,
+                                                                   allHTreeNodesCurTask,
+                                                                   allNewMinedPatternInfo,
+                                                                   thread_index,
+                                                                   startFromLinkContainWhiteKeyword);
 
                         }
 //                        cout << "\n---------------end curvarstr = " << curvarstr << "---------------" <<std::endl;

--- a/opencog/learning/PatternMiner/PatternMinerDistributedWorker.cc
+++ b/opencog/learning/PatternMiner/PatternMinerDistributedWorker.cc
@@ -383,9 +383,19 @@ void DistributedPatternMiner::growPatternsDepthFirstTask(unsigned int thread_ind
                 startFromLinkContainWhiteKeyword = true;
         }
 
-        extendAPatternForOneMoreGramRecursively(newLink, *observing_as, Handle::UNDEFINED, lastGramLinks, 0, lastGramValueToVarMap,
-                                                patternVarMap, false, allNewMinedPatternsCurTask, allHTreeNodesCurTask, allNewMinedPatternInfo, thread_index,startFromLinkContainWhiteKeyword);
-
+        extendPatternForOneMoreGramRecursively(newLink,
+                                               *observing_as,
+                                               Handle::UNDEFINED,
+                                               lastGramLinks,
+                                               0,
+                                               lastGramValueToVarMap,
+                                               patternVarMap,
+                                               false,
+                                               allNewMinedPatternsCurTask,
+                                               allHTreeNodesCurTask,
+                                               allNewMinedPatternInfo,
+                                               thread_index,
+                                               startFromLinkContainWhiteKeyword);
 
         // send new mined patterns to the server
         for (MinedPatternInfo& pInfo : allNewMinedPatternInfo)

--- a/opencog/learning/miner/Miner.cc
+++ b/opencog/learning/miner/Miner.cc
@@ -112,8 +112,9 @@ HandleTree Miner::specialize(const Handle& pattern,
 
 	// Produce specializations from other variables than the front
 	// one.
-	HandleTree patterns = specialize(pattern, texts, valuations.erase_front(),
-	                                 maxdepth);
+	valuations.inc_focus_variable();
+	HandleTree patterns = specialize(pattern, texts, valuations, maxdepth);
+	valuations.dec_focus_variable();
 
 	// Produce specializations from shallow abstractions on the front
 	// variable, and so recusively.
@@ -168,7 +169,7 @@ bool Miner::terminate(const Handle& pattern,
 		// The pattern is constant, no specialization is possible
 		pattern->get_type() != LAMBDA_LINK or
 		// There is no more variable to specialize from
-		valuations.novar() or
+		valuations.no_focus() or
 		// The pattern doesn't have enough support
 		// TODO: it seems the text is always filtered prior anyway
 		not enough_support(pattern, texts);
@@ -182,7 +183,7 @@ HandleTree Miner::specialize_shabs(const Handle& pattern,
 	// Generate shallow patterns of the first variable of the
 	// valuations and associate the remaining valuations (excluding
 	// that variable) to them.
-	HandleSet shapats = MinerUtils::front_shallow_abstract(valuations, param.minsup);
+	HandleSet shapats = MinerUtils::focus_shallow_abstract(valuations, param.minsup);
 
 	// No shallow abstraction to use for specialization
 	if (shapats.empty())
@@ -192,7 +193,7 @@ HandleTree Miner::specialize_shabs(const Handle& pattern,
 	// pattern by composing it, and recursively specialize the result
 	// with the new resulting valuations.
 	HandleTree patterns;
-	Handle var = valuations.front_variable();
+	Handle var = valuations.focus_variable();
 	for (const auto& shapat : shapats)
 	{
 		// Specialize pattern by composing it with shapat, and

--- a/opencog/learning/miner/MinerSCM.cc
+++ b/opencog/learning/miner/MinerSCM.cc
@@ -65,6 +65,13 @@ protected:
 	 */
 	bool do_enough_support(Handle pattern, Handle texts, Handle ms);
 
+	/**
+	 * Construct the conjunction of 2 patterns. If cnjtion is a
+	 * conjunction, then expand it with pattern. It is assumed that
+	 * pattern cannot be a conjunction itself.
+	 */
+	Handle do_expand_conjunction(Handle cnjtion, Handle pattern);
+
 public:
 	MinerSCM();
 };
@@ -89,6 +96,9 @@ void MinerSCM::init(void)
 
 	define_scheme_primitive("cog-enough-support?",
 		&MinerSCM::do_enough_support, this, "miner");
+
+	define_scheme_primitive("cog-expand-conjunction",
+		&MinerSCM::do_expand_conjunction, this, "miner");
 }
 
 Handle MinerSCM::do_shallow_abstract(Handle pattern,
@@ -138,6 +148,13 @@ bool MinerSCM::do_enough_support(Handle pattern, Handle texts, Handle ms)
 	unsigned ms_uint = (unsigned)std::round(nn->get_value());
 
 	return MinerUtils::enough_support(pattern, texts_set, ms_uint);
+}
+
+Handle MinerSCM::do_expand_conjunction(Handle cnjtion, Handle pattern)
+{
+	AtomSpace *as = SchemeSmob::ss_get_env_as("cog-expand-conjunction");
+	Handle result = MinerUtils::expand_conjunction(cnjtion, pattern);
+	return as->add_atom(result);
 }
 
 extern "C" {

--- a/opencog/learning/miner/MinerSCM.cc
+++ b/opencog/learning/miner/MinerSCM.cc
@@ -70,7 +70,8 @@ protected:
 	 * conjunction, then expand it with pattern. It is assumed that
 	 * pattern cannot be a conjunction itself.
 	 */
-	Handle do_expand_conjunction(Handle cnjtion, Handle pattern);
+	Handle do_expand_conjunction(Handle cnjtion, Handle pattern,
+	                             Handle texts, Handle ms);
 
 public:
 	MinerSCM();
@@ -150,11 +151,21 @@ bool MinerSCM::do_enough_support(Handle pattern, Handle texts, Handle ms)
 	return MinerUtils::enough_support(pattern, texts_set, ms_uint);
 }
 
-Handle MinerSCM::do_expand_conjunction(Handle cnjtion, Handle pattern)
+Handle MinerSCM::do_expand_conjunction(Handle cnjtion, Handle pattern,
+                                       Handle texts, Handle ms)
 {
 	AtomSpace *as = SchemeSmob::ss_get_env_as("cog-expand-conjunction");
-	Handle result = MinerUtils::expand_conjunction(cnjtion, pattern);
-	return as->add_atom(result);
+
+	// Fetch all texts
+	HandleSet texts_set = MinerUtils::get_texts(texts);
+
+	// Fetch the minimum support
+	NumberNodePtr nn = NumberNodeCast(ms);
+	unsigned ms_uint = (unsigned)std::round(nn->get_value());
+
+	HandleSet results = MinerUtils::expand_conjunction(cnjtion, pattern,
+	                                                   texts_set, ms_uint);
+	return as->add_link(SET_LINK, HandleSeq(results.begin(), results.end()));
 }
 
 extern "C" {

--- a/opencog/learning/miner/MinerSCM.cc
+++ b/opencog/learning/miner/MinerSCM.cc
@@ -61,6 +61,27 @@ protected:
 
 	/**
 	 * Given a pattern, a texts concept and a minimum support, return
+	 * all shallow specializations reaching the minimum support.
+	 *
+	 * For instance, given
+	 *
+	 * pattern = (Lambda X Y (Inheritance X Y))
+	 * texts  = { (Inheritance A B),
+	 *            (Inheritance A C),
+	 *            (Inheritance D D),
+	 *            (Inheritance E E) }
+	 * ms = (Number 2)
+	 *
+	 * returns
+	 *
+	 * (Set
+	 *   (Lambda Y (Inheritance A Y))
+	 *   (Lambda Y (Inheritance Y Y)))
+	 */
+	Handle do_shallow_specialize(Handle pattern, Handle texts, Handle ms);
+
+	/**
+	 * Given a pattern, a texts concept and a minimum support, return
 	 * true iff the pattern has enough support.
 	 */
 	bool do_enough_support(Handle pattern, Handle texts, Handle ms);
@@ -94,6 +115,9 @@ void MinerSCM::init(void)
 {
 	define_scheme_primitive("cog-shallow-abstract",
 		&MinerSCM::do_shallow_abstract, this, "miner");
+
+	define_scheme_primitive("cog-shallow-specialize",
+		&MinerSCM::do_shallow_specialize, this, "miner");
 
 	define_scheme_primitive("cog-enough-support?",
 		&MinerSCM::do_enough_support, this, "miner");
@@ -136,6 +160,24 @@ Handle MinerSCM::do_shallow_abstract(Handle pattern,
 	}
 
 	return as->add_link(SET_LINK, HandleSeq(sa_lists.begin(), sa_lists.end()));
+}
+
+Handle MinerSCM::do_shallow_specialize(Handle pattern,
+                                       Handle texts,
+                                       Handle ms)
+{
+	AtomSpace *as = SchemeSmob::ss_get_env_as("cog-shallow-specialize");
+
+	// Fetch all texts
+	HandleSet texts_set = MinerUtils::get_texts(texts);
+
+	// Fetch the minimum support
+	unsigned ms_uint = MinerUtils::get_ms(ms);
+
+	// Generate all shallow specializations
+	HandleSet shaspes = MinerUtils::shallow_specialize(pattern, texts_set, ms_uint);
+
+	return as->add_link(SET_LINK, HandleSeq(shaspes.begin(), shaspes.end()));
 }
 
 bool MinerSCM::do_enough_support(Handle pattern, Handle texts, Handle ms)

--- a/opencog/learning/miner/MinerSCM.cc
+++ b/opencog/learning/miner/MinerSCM.cc
@@ -112,8 +112,7 @@ Handle MinerSCM::do_shallow_abstract(Handle pattern,
 	HandleSet texts_set = MinerUtils::get_texts(texts);
 
 	// Fetch the minimum support
-	NumberNodePtr nn = NumberNodeCast(ms);
-	unsigned ms_uint = (unsigned)std::round(nn->get_value());
+	unsigned ms_uint = MinerUtils::get_ms(ms);
 
 	// Generate all shallow abstractions
 	HandleSetSeq shabs_per_var =
@@ -145,8 +144,7 @@ bool MinerSCM::do_enough_support(Handle pattern, Handle texts, Handle ms)
 	HandleSet texts_set = MinerUtils::get_texts(texts);
 
 	// Fetch the minimum support
-	NumberNodePtr nn = NumberNodeCast(ms);
-	unsigned ms_uint = (unsigned)std::round(nn->get_value());
+	unsigned ms_uint = MinerUtils::get_ms(ms);
 
 	return MinerUtils::enough_support(pattern, texts_set, ms_uint);
 }
@@ -160,8 +158,7 @@ Handle MinerSCM::do_expand_conjunction(Handle cnjtion, Handle pattern,
 	HandleSet texts_set = MinerUtils::get_texts(texts);
 
 	// Fetch the minimum support
-	NumberNodePtr nn = NumberNodeCast(ms);
-	unsigned ms_uint = (unsigned)std::round(nn->get_value());
+	unsigned ms_uint = MinerUtils::get_ms(ms);
 
 	HandleSet results = MinerUtils::expand_conjunction(cnjtion, pattern,
 	                                                   texts_set, ms_uint);

--- a/opencog/learning/miner/MinerUtils.cc
+++ b/opencog/learning/miner/MinerUtils.cc
@@ -102,9 +102,8 @@ HandleSet MinerUtils::focus_shallow_abstract(const Valuations& valuations, unsig
 			continue;
 
 		// Otherwise generate its shallow abstraction
-		Handle shabs = val_shallow_abstract(value);
-		if (shabs)
-			shapats[val_shallow_abstract(value)] += val_count;
+		if (Handle shabs = val_shallow_abstract(value))
+			shapats[shabs] += val_count;
 	}
 
 	// Only consider shallow abstractions that reach the minimum

--- a/opencog/learning/miner/MinerUtils.cc
+++ b/opencog/learning/miner/MinerUtils.cc
@@ -128,8 +128,8 @@ HandleSet MinerUtils::focus_shallow_abstract(const Valuations& valuations, unsig
 		unsigned rv_idx = rv_scv.index(rv);
 
 		// Whether var and rv are in the same strongly connected
-		// valuations
-		bool same_scv = rv_scv == var_scv;
+		// valuations (using pointer equality to speed it up)
+		bool same_scv = &rv_scv == &var_scv;
 
 		// Ref to keep track of the number of text instances where the
 		// value of var is equal to the value to rv

--- a/opencog/learning/miner/MinerUtils.cc
+++ b/opencog/learning/miner/MinerUtils.cc
@@ -67,10 +67,8 @@ HandleSet MinerUtils::focus_shallow_abstract(const Valuations& valuations, unsig
 	if (valuations.no_focus())
 		return HandleSet();
 
-	// Variable to specialize
-	Handle var = valuations.focus_variable();
-
-	// Strongly connected valuations associated to that variable
+	// Strongly connected valuations associated to the variable under
+	// focus
 	const SCValuations& var_scv(valuations.focus_scvaluations());
 
 	////////////////////////////

--- a/opencog/learning/miner/MinerUtils.cc
+++ b/opencog/learning/miner/MinerUtils.cc
@@ -255,13 +255,10 @@ Handle MinerUtils::compose(const Handle& pattern, const HandleMap& var2pat)
 	// Get variable declaration of the composition
 	Handle vardecl = vardecl_compose(get_vardecl(pattern), var2subdecl);
 
-	// Turn the map into a vector of new bodies
-	const Variables variables = get_variables(pattern);
-	HandleSeq subodies = variables.make_sequence(var2subody);
-
 	// Perform composition of the pattern body with the sub-bodies)
 	// TODO: perhaps use RewriteLink partial_substitute
-	Handle body = variables.substitute_nocheck(get_body(pattern), subodies);
+	const Variables& variables = get_variables(pattern);
+	Handle body = variables.substitute_nocheck(get_body(pattern), var2subody);
 	body = RewriteLink::consume_quotations(vardecl, body, true);
 	// If root AndLink then simplify the pattern
 	if (body->get_type() == AND_LINK) {

--- a/opencog/learning/miner/MinerUtils.cc
+++ b/opencog/learning/miner/MinerUtils.cc
@@ -403,13 +403,8 @@ HandleSet MinerUtils::shallow_specialize(const Handle& pattern,
 		for (const Handle& sa : shabs) {
 			Handle npat = compose(pattern, {{vars.varseq[vari], sa}});
 			// Shallow_abstract should already have eliminated shallow
-			// abstraction that do not have enough support. Put a
-			// temporary assert here to make sure that is the case.
-			// OC_ASSERT(enough_support(npat, texts, ms),
-			//           "shallow_abstract should guaranty that."
-			//           "If it doesn't, there is probably a bug");
-			if (enough_support(npat, texts, ms))
-				results.insert(npat);
+			// abstraction that do not have enough support.
+			results.insert(npat);
 		}
 		vari++;
 	}

--- a/opencog/learning/miner/MinerUtils.cc
+++ b/opencog/learning/miner/MinerUtils.cc
@@ -31,6 +31,7 @@
 #include <opencog/atoms/base/Node.h>
 #include <opencog/atoms/core/LambdaLink.h>
 #include <opencog/atoms/core/RewriteLink.h>
+#include <opencog/atoms/core/NumberNode.h>
 #include <opencog/atoms/pattern/PatternLink.h>
 #include <opencog/atomutils/TypeUtils.h>
 #include <opencog/atomutils/FindUtils.h>
@@ -365,6 +366,12 @@ HandleSet MinerUtils::get_texts(const Handle& texts_cpt)
 			texts.insert(member);
 	}
 	return texts;
+}
+
+unsigned MinerUtils::get_ms(const Handle& ms)
+{
+	NumberNodePtr nn = NumberNodeCast(ms);
+	return (unsigned)std::round(nn->get_value());
 }
 
 unsigned MinerUtils::support(const Handle& pattern,

--- a/opencog/learning/miner/MinerUtils.cc
+++ b/opencog/learning/miner/MinerUtils.cc
@@ -574,7 +574,7 @@ Handle MinerUtils::remove_useless_clauses(const Handle& vardecl,
 void MinerUtils::remove_useless_clauses(const Handle& vardecl, HandleSeq& clauses)
 {
 	remove_constant_clauses(vardecl, clauses);
-	remove_redundant_clauses(clauses);
+	remove_redundant_subclauses(clauses);
 }
 
 void MinerUtils::remove_constant_clauses(const Handle& vardecl, HandleSeq& clauses)
@@ -589,7 +589,7 @@ void MinerUtils::remove_constant_clauses(const Handle& vardecl, HandleSeq& claus
 	boost::remove_erase_if(clauses, is_constant);
 }
 
-void MinerUtils::remove_redundant_clauses(HandleSeq& clauses)
+void MinerUtils::remove_redundant_subclauses(HandleSeq& clauses)
 {
 	// Check that each clause is not a subtree of another clause,
 	// remove it otherwise.
@@ -604,6 +604,15 @@ void MinerUtils::remove_redundant_clauses(HandleSeq& clauses)
 		else
 			++it;
 	}
+}
+
+void MinerUtils::remove_redundant_clauses(HandleSeq& clauses)
+{
+	boost::sort(clauses);
+	typedef std::equal_to<opencog::Handle> HandleEqual;
+	boost::erase(clauses,
+	             boost::unique<boost::return_found_end, HandleSeq, HandleEqual>
+	             (clauses, HandleEqual()));
 }
 
 Handle MinerUtils::alpha_convert(const Handle& pattern,

--- a/opencog/learning/miner/MinerUtils.cc
+++ b/opencog/learning/miner/MinerUtils.cc
@@ -418,6 +418,35 @@ HandleSetSeq MinerUtils::shallow_abstract(const Handle& pattern,
 	return shallow_abstract(valuations, ms);
 }
 
+HandleSet MinerUtils::shallow_specialize(const Handle& pattern,
+                                         const HandleSet& texts,
+                                         unsigned ms)
+{
+	// Calculate all shallow abstractions of pattern
+	HandleSetSeq shabs_per_var = shallow_abstract(pattern, texts, ms);
+
+	// For each variable of pattern, generate the corresponding shallow
+	// specializations
+	const Variables& vars = MinerUtils::get_variables(pattern);
+	size_t vari = 0;
+	HandleSet results;
+	for (const HandleSet& shabs : shabs_per_var) {
+		for (const Handle& sa : shabs) {
+			Handle npat = compose(pattern, {{vars.varseq[vari], sa}});
+			// Shallow_abstract should already have eliminated shallow
+			// abstraction that do not have enough support. Put a
+			// temporary assert here to make sure that is the case.
+			// OC_ASSERT(enough_support(npat, texts, ms),
+			//           "shallow_abstract should guaranty that."
+			//           "If it doesn't, there is probably a bug");
+			if (enough_support(npat, texts, ms))
+				results.insert(npat);
+		}
+		vari++;
+	}
+	return results;
+}
+
 Handle MinerUtils::mk_pattern(const Handle& vardecl, const HandleSeq& clauses)
 {
 	Handle fvd = filter_vardecl(vardecl, clauses);

--- a/opencog/learning/miner/MinerUtils.cc
+++ b/opencog/learning/miner/MinerUtils.cc
@@ -149,7 +149,7 @@ HandleSet MinerUtils::focus_shallow_abstract(const Valuations& valuations, unsig
 
 		for (const HandleSeq& valuation : var_scv.valuations) {
 			// Value associated to var
-			const Handle& val = valuation[0];
+			const Handle& val = valuation[var_scv.focus_index()];
 
 			// If the value of var is equal to that of rv, then
 			// increase rv factorization count

--- a/opencog/learning/miner/MinerUtils.cc
+++ b/opencog/learning/miner/MinerUtils.cc
@@ -118,8 +118,7 @@ HandleSet MinerUtils::focus_shallow_abstract(const Valuations& valuations, unsig
 	////////////////////////////////
 
 	// Add all subsequent factorizable variables
-	HandleSeq remvars(std::next(valuations.variables.varseq.begin()),
-	                  valuations.variables.varseq.end());
+	HandleSeq remvars = valuations.remaining_variables();
 	HandleUCounter facvars;
 	for (const Handle& rv : remvars) {
 		// Strongly connected valuations associated to that variable

--- a/opencog/learning/miner/MinerUtils.cc
+++ b/opencog/learning/miner/MinerUtils.cc
@@ -166,7 +166,7 @@ HandleSet MinerUtils::focus_shallow_abstract(const Valuations& valuations, unsig
 				}
 			}
 
-			// IF the minimum support has been reached, no need to
+			// If the minimum support has been reached, no need to
 			// keep counting
 			if (ms <= rv_count)
 				break;
@@ -525,8 +525,7 @@ Handle MinerUtils::gen_rand_variable()
 
 const Variables& MinerUtils::get_variables(const Handle& pattern)
 {
-	RewriteLinkPtr sc = RewriteLinkCast(pattern);
-	if (sc)
+	if (RewriteLinkPtr sc = RewriteLinkCast(pattern))
 		return RewriteLinkCast(pattern)->get_variables();
 	static Variables empty_variables;
 	return empty_variables;
@@ -534,8 +533,7 @@ const Variables& MinerUtils::get_variables(const Handle& pattern)
 
 Handle MinerUtils::get_vardecl(const Handle& pattern)
 {
-	RewriteLinkPtr sc = RewriteLinkCast(pattern);
-	if (sc) {
+	if (RewriteLinkPtr sc = RewriteLinkCast(pattern)) {
 		Handle vardecl = sc->get_vardecl();
 		if (not vardecl)
 			vardecl = sc->get_variables().get_vardecl();
@@ -546,9 +544,8 @@ Handle MinerUtils::get_vardecl(const Handle& pattern)
 
 const Handle& MinerUtils::get_body(const Handle& pattern)
 {
-	RewriteLinkPtr sc = RewriteLinkCast(pattern);
-	if (sc)
-		return RewriteLinkCast(pattern)->get_body();
+	if (RewriteLinkPtr sc = RewriteLinkCast(pattern))
+		return sc->get_body();
 	return pattern;
 }
 

--- a/opencog/learning/miner/MinerUtils.cc
+++ b/opencog/learning/miner/MinerUtils.cc
@@ -667,11 +667,7 @@ Handle MinerUtils::expand_conjunction_disconnect(const Handle& cnjtion,
 	nclauses.push_back(get_body(acpat));
 
 	// Remove redundant clauses
-	boost::sort(nclauses);
-	typedef std::equal_to<opencog::Handle> HandleEqual;
-	boost::erase(nclauses,
-	             boost::unique<boost::return_found_end, HandleSeq, HandleEqual>
-	             (nclauses, HandleEqual()));
+	remove_redundant_clauses(nclauses);
 
 	// Recreate expanded conjunction
 	Handle nvardecl = cnjtion_vars.get_vardecl(),
@@ -703,11 +699,7 @@ Handle MinerUtils::expand_conjunction_connect(const Handle& cnjtion,
 	nclauses.push_back(npat_body);
 
 	// Remove redundant clauses
-	boost::sort(nclauses);
-	typedef std::equal_to<opencog::Handle> HandleEqual;
-	boost::erase(nclauses,
-	             boost::unique<boost::return_found_end, HandleSeq, HandleEqual>
-	             (nclauses, HandleEqual()));
+	remove_redundant_clauses(nclauses);
 
 	// Recreate expanded conjunction
 	Handle nvardecl = cnjtion_vars.get_vardecl(),

--- a/opencog/learning/miner/MinerUtils.cc
+++ b/opencog/learning/miner/MinerUtils.cc
@@ -666,8 +666,10 @@ Handle MinerUtils::expand_conjunction_disconnect(const Handle& cnjtion,
 		cnjtion_body->getOutgoingSet() : HandleSeq{cnjtion_body};
 	nclauses.push_back(get_body(acpat));
 
-	// Remove redundant clauses
-	remove_redundant_clauses(nclauses);
+	// Remove redundant subclauses. This can happen if there's only one
+	// variable to connect, then some subclause turn out to be
+	// redundant.
+	remove_redundant_subclauses(nclauses);
 
 	// Recreate expanded conjunction
 	Handle nvardecl = cnjtion_vars.get_vardecl(),
@@ -698,8 +700,10 @@ Handle MinerUtils::expand_conjunction_connect(const Handle& cnjtion,
 		cnjtion_body->getOutgoingSet() : HandleSeq{cnjtion_body};
 	nclauses.push_back(npat_body);
 
-	// Remove redundant clauses
-	remove_redundant_clauses(nclauses);
+	// Remove redundant subclauses. This can happen if there's only one
+	// variable to connect, then some subclause turn out to be
+	// redundant.
+	remove_redundant_subclauses(nclauses);
 
 	// Recreate expanded conjunction
 	Handle nvardecl = cnjtion_vars.get_vardecl(),

--- a/opencog/learning/miner/MinerUtils.cc
+++ b/opencog/learning/miner/MinerUtils.cc
@@ -87,6 +87,22 @@ HandleSet MinerUtils::focus_shallow_abstract(const Valuations& valuations, unsig
 	for (const HandleSeq& valuation : var_scv.valuations) {
 		const Handle& value = var_scv.focus_value(valuation);
 
+		// If var_scv contains only one variable, then ignore shallow
+		// abstractions of nodes and nullary links as they create
+		// constant abstractions and
+		//
+		// 1. In case there is only one strongly connected component,
+		//    constant patterns cannot have support > 1.
+		//
+		// 2. In case there are more than one strongly connected
+		//    component, constant patterns are essentially useless
+		//    (don't affect the support), and they will no longer
+		//    reconnect, so they will remain useless.
+		//
+		// For these 2 reasons they can be safely ignored.
+		if (valuation.size() == 1 and is_nullary(value))
+			continue;
+
 		// Otherwise generate its shallow abstraction
 		Handle shabs = val_shallow_abstract(value);
 		if (shabs)

--- a/opencog/learning/miner/MinerUtils.h
+++ b/opencog/learning/miner/MinerUtils.h
@@ -69,8 +69,8 @@ public:
 
 	/**
 	 * Given valuations produce all shallow abstractions reaching
-	 * minimum support based on the values associated to the front
-	 * variable first variable. This shallow abstractions include
+	 * minimum support based on the values associated to the variable
+	 * in focus. This shallow abstractions include
 	 *
 	 * 1. Single operator patterns, like (Lambda X Y (Inheritance X Y))
 	 * 2. Constant nodes, like (Concept "A")
@@ -95,13 +95,18 @@ public:
 	 *                                            (Variable "$X1")
 	 *                                            (Variable "$X2"))) }
 	 */
-	static HandleSet front_shallow_abstract(const Valuations& valuations, unsigned ms);
+	static HandleSet focus_shallow_abstract(const Valuations& valuations, unsigned ms);
+
+	/**
+	 * Return true iff h is a node or a nullary link.
+	 */
+	static bool is_nullary(const Handle& h);
 
 	/**
 	 * Given an atom, a value, return its corresponding shallow
 	 * abstraction. A shallow abstraction of an atom is
 	 *
-	 * 1. itself if it is a node
+	 * 1. itself if it is nullary (see is_nullary)
 	 *
 	 * 2. (Lambda (VariableList X1 ... Xn) (L X1 ... Xn) if it is a
 	 *    link of arity n.

--- a/opencog/learning/miner/MinerUtils.h
+++ b/opencog/learning/miner/MinerUtils.h
@@ -240,6 +240,14 @@ public:
 	                                     unsigned ms);
 
 	/**
+	 * Return all shallow specializations of pattern with support ms
+	 * according to texts.
+	 */
+	static HandleSet shallow_specialize(const Handle& pattern,
+	                                    const HandleSet& texts,
+	                                    unsigned ms);
+
+	/**
 	 * Given a vardecl and a body, filter the vardecl to contain only
 	 * variable of the body, and create a Lambda with them.
 	 */

--- a/opencog/learning/miner/MinerUtils.h
+++ b/opencog/learning/miner/MinerUtils.h
@@ -192,12 +192,6 @@ public:
 	static Handle remove_unary_and(const Handle& h);
 
 	/**
-	 * Call alpha_conversion if pattern is a scope, return itself
-	 * otherwise.
-	 */
-	static Handle alpha_conversion(const Handle& pattern);
-
-	/**
 	 * Given a texts concept node, retrieve all its members
 	 */
 	static HandleSet get_texts(const Handle& texts_cpt);
@@ -354,11 +348,62 @@ public:
 	static void remove_redundant_clauses(HandleSeq& clauses);
 
 	/**
-	 * Construct the conjunction of 2 patterns. If cnjtion is a
-	 * conjunction, then expand it with pattern. It is assumed that
-	 * pattern cannot be a conjunction itself.
+	 * Alpha convert pattern so that none of its variables collide with
+	 * the variables in other_vars.
 	 */
-	static Handle expand_conjunction(const Handle& cnjtion, const Handle& pattern);
+	static Handle alpha_convert(const Handle& pattern,
+	                            const Variables& other_vars);
+
+	/**
+	 * Construct the conjunction of 2 patterns. If cnjtion is a
+	 * conjunction, then expand it with pattern (performing
+	 * alpha-conversion when necessary). It is assumed that pattern
+	 * cannot be a conjunction itself.
+	 *
+	 * This method will not attempt to connect the 2 patterns, thus,
+	 * assuming that cnjtion is itself strongly connected, the result
+	 * will be 2 strongly connected components.
+	 */
+	static Handle expand_conjunction_disconnect(const Handle& cnjtion,
+	                                            const Handle& pattern);
+
+	/**
+	 * Like expand_conjunction_disconnect but produced a single
+	 * strongly connected component, assuming that cnjtion is itself
+	 * strongly connected, given 2 connecting variables, one from
+	 * cnjtion, one from pattern.
+	 *
+	 * Unlike expand_conjunction_disconnect, no alpha conversion is
+	 * performed, cnjtion is assumed not to collide with pattern.
+	 */
+	static Handle expand_conjunction_connect(const Handle& cnjtion,
+	                                         const Handle& pattern,
+	                                         const Handle& cnjtion_var,
+	                                         const Handle& pattern_var);
+
+	/**
+	 * Given cnjtion and pattern, consider all possible connections and
+	 * expand cnjtion accordingly. For instance if
+	 *
+	 * cnjtion = (Inheritance X Y)
+	 * pattern = (Inheritance Z W)
+	 *
+	 * return
+	 *
+	 *   (And (Inheritance X Y) (Inheritance X W))
+	 *   (And (Inheritance X Y) (Inheritance Z X))
+	 *   (And (Inheritance X Y) (Inheritance Y W))
+	 *   (And (Inheritance X Y) (Inheritance X Y))
+	 *
+	 * It will also only include patterns with minimum support ms
+	 * according to texts, and perform alpha-conversion when necessary.
+	 * If an expansion is cnjtion itself it will be dismissed.
+	 */
+	static HandleSet expand_conjunction(const Handle& cnjtion,
+	                                    const Handle& pattern,
+	                                    const HandleSet& texts,
+	                                    unsigned ms);
+
 };
 
 } // ~namespace opencog

--- a/opencog/learning/miner/MinerUtils.h
+++ b/opencog/learning/miner/MinerUtils.h
@@ -38,10 +38,10 @@ class MinerUtils
 public:
 
 	/**
-	 * Given valuations produce all shallow abstractions reachind
+	 * Given valuations produce all shallow abstractions reaching
 	 * minimum support, over all variables. It basically applies
-	 * front_shallow_abstract recursively. See the specification of
-	 * front_shallow_abstract for more information.
+	 * focus_shallow_abstract recursively. See the specification of
+	 * focus_shallow_abstract for more information.
 	 *
 	 * For instance, given
 	 *

--- a/opencog/learning/miner/MinerUtils.h
+++ b/opencog/learning/miner/MinerUtils.h
@@ -157,8 +157,6 @@ public:
 	static Handle local_quote(const Handle& h);
 
 	/**
-	 * TODO replace by RewriteLink::beta_reduce
-	 *
 	 * Given a pattern, and mapping from variables to sub-patterns,
 	 * compose (as in function composition) the pattern with the
 	 * sub-patterns. That is replace variables in the pattern by their

--- a/opencog/learning/miner/MinerUtils.h
+++ b/opencog/learning/miner/MinerUtils.h
@@ -288,7 +288,7 @@ public:
 	 */
 	static Handle restricted_satisfying_set(const Handle& pattern,
 	                                        const HandleSet& texts,
-	                                        unsigned ms);
+	                                        unsigned ms=UINT_MAX);
 
 	/**
 	 * Return true iff the pattern is totally abstract like

--- a/opencog/learning/miner/MinerUtils.h
+++ b/opencog/learning/miner/MinerUtils.h
@@ -347,6 +347,13 @@ public:
 	 * there subtrees.
 	 */
 	static void remove_redundant_clauses(HandleSeq& clauses);
+
+	/**
+	 * Construct the conjunction of 2 patterns. If cnjtion is a
+	 * conjunction, then expand it with pattern. It is assumed that
+	 * pattern cannot be a conjunction itself.
+	 */
+	static Handle expand_conjunction(const Handle& cnjtion, const Handle& pattern);
 };
 
 } // ~namespace opencog

--- a/opencog/learning/miner/MinerUtils.h
+++ b/opencog/learning/miner/MinerUtils.h
@@ -197,6 +197,12 @@ public:
 	static HandleSet get_texts(const Handle& texts_cpt);
 
 	/**
+	 * Given a number node holding the minimum support return the
+	 * positive integer.
+	 */
+	static unsigned get_ms(const Handle& ms);
+
+	/**
 	 * Given a pattern and a text corpus, calculate the pattern
 	 * frequency up to ms (to avoid unnecessary calculations).
 	 */

--- a/opencog/learning/miner/MinerUtils.h
+++ b/opencog/learning/miner/MinerUtils.h
@@ -354,8 +354,13 @@ public:
 	                                    HandleSeq& clauses);
 
 	/**
-	 * Remove redundant clauses, such as ones identical to clauses of
-	 * there subtrees.
+	 * Remove redundant subclauses, such as ones identical to clauses
+	 * of there subtrees.
+	 */
+	static void remove_redundant_subclauses(HandleSeq& clauses);
+
+	/**
+	 * Remove redundant clauses.
 	 */
 	static void remove_redundant_clauses(HandleSeq& clauses);
 

--- a/opencog/learning/miner/README.md
+++ b/opencog/learning/miner/README.md
@@ -384,15 +384,15 @@ The forward chaining way starts with the initial pattern as source and
 derive inferences with the rule
 ```
 minsup(P, T, ms)
-shallow-abstraction(S, P, T, ms)
+abstraction(S, P, T, ms)
 |-
 minsup((Put P S), T, ms)
 ```
-where `shallow-abstraction` is a predicate that not only `S` is a
-shallow abstraction of `P` over `T` but also if `P` is composed with
-such, the resulting pattern will reach minimum support, which can
-indeed be determined by looking at the valuation set used to generate
-the shallow abstractions, as mentioned earlier.
+where `abstraction` is a predicate that not only `S` is a shallow
+abstraction of `P` over `T` but also if `P` is composed with such, the
+resulting pattern will reach minimum support, which can indeed be
+determined by looking at the valuation set used to generate the
+shallow abstractions, as mentioned earlier.
 
 The advantage of the forward technique is that it requires no control
 for the a priori property as it is built into the rule.

--- a/opencog/learning/miner/Valuations.cc
+++ b/opencog/learning/miner/Valuations.cc
@@ -56,6 +56,12 @@ const Handle& ValuationsBase::focus_variable() const
 	return variables.varseq[_var_idx];
 }
 
+HandleSeq ValuationsBase::remaining_variables() const
+{
+	return HandleSeq(std::next(variables.varseq.begin(), _var_idx + 1),
+	                 variables.varseq.end());
+}
+
 void ValuationsBase::inc_focus_variable() const
 {
 	_var_idx++;

--- a/opencog/learning/miner/Valuations.cc
+++ b/opencog/learning/miner/Valuations.cc
@@ -131,11 +131,6 @@ const Handle& SCValuations::focus_value(const HandleSeq& values) const
 	return values[_var_idx];
 }
 
-bool SCValuations::operator==(const SCValuations& other) const
-{
-	return variables == other.variables;
-}
-
 bool SCValuations::operator<(const SCValuations& other) const
 {
 	return variables < other.variables;

--- a/opencog/learning/miner/Valuations.cc
+++ b/opencog/learning/miner/Valuations.cc
@@ -174,6 +174,7 @@ Valuations::Valuations(const Variables& vars, const SCValuationsSet& sc)
 Valuations::Valuations(const Variables& vars)
 	: ValuationsBase(vars), _size(0) {}
 
+// TODO: maybe speed this up by sorting the SCValuation in order of variables
 const SCValuations& Valuations::get_scvaluations(const Handle& var) const
 {
 	for (const SCValuations& scv : scvs)

--- a/opencog/learning/miner/Valuations.cc
+++ b/opencog/learning/miner/Valuations.cc
@@ -41,18 +41,30 @@ namespace opencog
 // ValuationsBase //
 ////////////////////
 
-ValuationsBase::ValuationsBase(const Variables& vars) : variables(vars) {}
+ValuationsBase::ValuationsBase(const Variables& vars)
+	: variables(vars), _var_idx(0) {}
 
 ValuationsBase::ValuationsBase() {}
 
-bool ValuationsBase::novar() const
+bool ValuationsBase::no_focus() const
 {
-	return variables.empty();
+	return variables.varset.size() <= _var_idx;
 }
 
-Handle ValuationsBase::front_variable() const
+const Handle& ValuationsBase::focus_variable() const
 {
-	return variables.varseq[0];
+	return variables.varseq[_var_idx];
+}
+
+void ValuationsBase::inc_focus_variable() const
+{
+	_var_idx++;
+}
+
+void ValuationsBase::dec_focus_variable() const
+{
+	OC_ASSERT(0 < _var_idx);
+	_var_idx--;
 }
 
 Handle ValuationsBase::variable(unsigned i) const
@@ -90,34 +102,6 @@ SCValuations::SCValuations(const Variables& vars, const Handle& satset)
 	}
 }
 
-SCValuations SCValuations::erase_front() const
-{
-	return erase(front_variable());
-}
-
-SCValuations SCValuations::erase(const Handle& var) const
-{
-	// No variable, just return itself
-	if (not variables.is_in_varset(var))
-		return *this;
-
-	// Remove variable
-	Variables nvars(variables);
-	nvars.erase(var);
-	auto it = boost::find(variables.varseq, var);
-	int dst = std::distance(variables.varseq.begin(), it);
-	SCValuations nvals(nvars);
-	if (not nvals.novar())
-	{
-		for (HandleSeq vals : valuations)
-		{
-			vals.erase(std::next(vals.begin(), dst));
-			nvals.valuations.push_back(vals);
-		}
-	}
-	return nvals;
-}
-
 HandleUCounter SCValuations::values(const Handle& var) const
 {
 	return values(index(var));
@@ -129,6 +113,11 @@ HandleUCounter SCValuations::values(unsigned var_idx) const
 	for (const HandleSeq& valuation : valuations)
 		vals[valuation[var_idx]]++;
 	return vals;
+}
+
+const Handle& SCValuations::focus_value(const HandleSeq& values) const
+{
+	return values[_var_idx];
 }
 
 bool SCValuations::operator==(const SCValuations& other) const
@@ -144,6 +133,17 @@ bool SCValuations::operator<(const SCValuations& other) const
 unsigned SCValuations::size() const
 {
 	return valuations.size();
+}
+
+std::string SCValuations::to_string(const std::string& indent) const
+{
+	std::stringstream ss;
+	ss << indent << "variables:" << std::endl
+	   << oc_to_string(variables, indent + OC_TO_STRING_INDENT)
+		<< indent << "valuations:" << std::endl
+	   << oc_to_string(valuations, indent + OC_TO_STRING_INDENT)
+	   << indent << "_var_idx = " << _var_idx;
+	return ss.str();
 }
 
 ////////////////
@@ -174,30 +174,6 @@ Valuations::Valuations(const Variables& vars, const SCValuationsSet& sc)
 Valuations::Valuations(const Variables& vars)
 	: ValuationsBase(vars), _size(0) {}
 
-Valuations Valuations::erase_front() const
-{
-	// Take remaining variables
-	Variables nvars(variables);
-	Handle var = front_variable();
-	nvars.erase(var);
-	Valuations nvals(nvars);
-
-	// Move values from remaining variables to new Valuations
-	for (const SCValuations& scv : scvs)
-	{
-		SCValuations nscvals(scv.erase(var));
-		if (not nscvals.novar())
-			nvals.scvs.insert(nscvals);
-	}
-
-	// Keep the previous size as we still need to consider those
-	// combinations
-	nvals._size = _size;
-
-	// Return new Valuations
-	return nvals;
-}
-
 const SCValuations& Valuations::get_scvaluations(const Handle& var) const
 {
 	for (const SCValuations& scv : scvs)
@@ -206,9 +182,38 @@ const SCValuations& Valuations::get_scvaluations(const Handle& var) const
 	throw RuntimeException(TRACE_INFO, "There's likely a bug");
 }
 
+const SCValuations& Valuations::focus_scvaluations() const
+{
+	return get_scvaluations(focus_variable());
+}
+
+void Valuations::inc_focus_variable() const
+{
+	focus_scvaluations().inc_focus_variable();
+	ValuationsBase::inc_focus_variable();
+}
+
+void Valuations::dec_focus_variable() const
+{
+	ValuationsBase::dec_focus_variable();
+	focus_scvaluations().dec_focus_variable();
+}
+
 unsigned Valuations::size() const
 {
 	return _size;
+}
+
+std::string Valuations::to_string(const std::string& indent) const
+{
+	std::stringstream ss;
+	ss << indent << "size = " << size() << std::endl
+		<< indent << "variables:" << std::endl
+	   << oc_to_string(variables, indent + OC_TO_STRING_INDENT)
+	   << indent << "scvaluations set:" << std::endl
+	   << oc_to_string(scvs, indent + OC_TO_STRING_INDENT) << std::endl
+	   << indent << "_var_idx = " << _var_idx;
+	return ss.str();
 }
 
 void Valuations::setup_size()
@@ -220,12 +225,7 @@ void Valuations::setup_size()
 
 std::string oc_to_string(const SCValuations& scv, const std::string& indent)
 {
-	std::stringstream ss;
-	ss << indent << "variables:" << std::endl
-	   << oc_to_string(scv.variables, indent + OC_TO_STRING_INDENT);
-	ss << indent << "valuations:" << std::endl
-	   << oc_to_string(scv.valuations, indent + OC_TO_STRING_INDENT);
-	return ss.str();
+	return scv.to_string(indent);
 }
 
 std::string oc_to_string(const SCValuationsSet& scvs, const std::string& indent)
@@ -244,13 +244,7 @@ std::string oc_to_string(const SCValuationsSet& scvs, const std::string& indent)
 
 std::string oc_to_string(const Valuations& valuations, const std::string& indent)
 {
-	std::stringstream ss;
-	ss << indent << "size = " << valuations.size() << std::endl;
-	ss << indent << "variables:" << std::endl
-	   << oc_to_string(valuations.variables, indent + OC_TO_STRING_INDENT);
-	ss << indent << "scvaluations set:" << std::endl
-	   << oc_to_string(valuations.scvs, indent + OC_TO_STRING_INDENT);
-	return ss.str();
+	return valuations.to_string(indent);
 }
 
 std::string oc_to_string(const HandleValuationsMap& h2vals, const std::string& indent)

--- a/opencog/learning/miner/Valuations.cc
+++ b/opencog/learning/miner/Valuations.cc
@@ -165,7 +165,7 @@ Valuations::Valuations(const Handle& pattern, const HandleSet& texts)
 	Handle reduced_pattern = MinerUtils::remove_useless_clauses(pattern);
 	for (const Handle& cp : MinerUtils::get_component_patterns(reduced_pattern))
 	{
-		Handle satset = MinerUtils::restricted_satisfying_set(cp, texts, texts.size());
+		Handle satset = MinerUtils::restricted_satisfying_set(cp, texts);
 		scvs.insert(SCValuations(MinerUtils::get_variables(cp), satset));
 	}
 	setup_size();

--- a/opencog/learning/miner/Valuations.cc
+++ b/opencog/learning/miner/Valuations.cc
@@ -56,6 +56,11 @@ const Handle& ValuationsBase::focus_variable() const
 	return variables.varseq[_var_idx];
 }
 
+unsigned ValuationsBase::focus_index() const
+{
+	return _var_idx;
+}
+
 HandleSeq ValuationsBase::remaining_variables() const
 {
 	return HandleSeq(std::next(variables.varseq.begin(), _var_idx + 1),

--- a/opencog/learning/miner/Valuations.h
+++ b/opencog/learning/miner/Valuations.h
@@ -37,15 +37,22 @@ public:
 	ValuationsBase();               // TODO: just till be use dummy valuations
 
 	/**
-	 * Return true iff the valuation contains no variable (thus is
-	 * empty).
+	 * Return true iff the valuation contains no variable to focus on
+	 * (empty or _var_idx is out of range).
 	 */
-	bool novar() const;
+	bool no_focus() const;
 
 	/**
-	 * Return the front variable.
+	 * Return the variable under focus (at _var_idx)
 	 */
-	Handle front_variable() const;
+	const Handle& focus_variable() const;
+
+	/**
+	 * Move focus to the next (or previous) variable. That is increment
+	 * (or decrement) _var_idx.
+	 */
+	void inc_focus_variable() const;
+	void dec_focus_variable() const;
 
 	/**
 	 * Return the variable at index i.
@@ -63,6 +70,11 @@ public:
 	unsigned size() const;
 
 	Variables variables;
+
+protected:
+	// Index pointing to the current variable of focus. Useful for
+	// MinerUtils::shallow_abstract recursive calls.
+	mutable unsigned _var_idx;
 };
 
 /**
@@ -82,25 +94,16 @@ public:
 	SCValuations(const Variables& variables, const Handle& satset=Handle::UNDEFINED);
 
 	/**
-	 * Erase the front variable with all its corresponding values on a
-	 * copy of this valuations.
-	 *
-	 * TODO: instead of erasing the front it would be better to move
-	 * some pointer to the next variable.
-	 */
-	SCValuations erase_front() const;
-
-	/**
-	 * Erase the given variable, if exists, with all its corresponding
-	 * values on a copy of this valuations.
-	 */
-	SCValuations erase(const Handle& var) const;
-
-	/**
 	 * Return all counted values corresponding to var.
 	 */
 	HandleUCounter values(const Handle& var) const;
 	HandleUCounter values(unsigned var_idx) const;
+
+	/**
+	 * Return the value under focus (at var_idx) of a give row of
+	 * values.
+	 */
+	const Handle& focus_value(const HandleSeq& values) const;
 
 	/**
 	 * Compare if 2 SCValuations are equal, in fact only looking at
@@ -121,6 +124,8 @@ public:
 	 * values.
 	 */
 	unsigned size() const;
+
+	std::string to_string(const std::string& indent=empty_string) const;
 
 	// Actual valuations, sequence of tuples of values associated to
 	// each variable.
@@ -145,12 +150,6 @@ public:
 	Valuations(const Handle& pattern, const HandleSet& texts);
 	Valuations(const Variables& variables, const SCValuationsSet& scvs);
 	Valuations(const Variables& variables);
-	
-	/**
-	 * Erase the front variable with all its corresponding associated
-	 * values on a copy of this valuations.
-	 */
-	Valuations erase_front() const;
 
 	/**
 	 * Get the SCValuations containing the given variable.
@@ -158,11 +157,26 @@ public:
 	const SCValuations& get_scvaluations(const Handle& var) const;
 
 	/**
+	 * Get the SCValuations containing the variable under focus
+	 */
+	const SCValuations& focus_scvaluations() const;
+
+	/**
+	 * Move focus to the next (or previous) variable. That is increment
+	 * (or decrement) _var_idx, as well as move focus of corresponding
+	 * variable of the corresponding strongly connected component.
+	 */
+	void inc_focus_variable() const;
+	void dec_focus_variable() const;
+
+	/**
 	 * Return the size of the Valuations, that is its totally number
 	 * of values accounting for the potential combinations of values
 	 * between the strongly connected valuations.
 	 */
 	unsigned size() const;
+
+	std::string to_string(const std::string& indent) const;
 
 	SCValuationsSet scvs;
 

--- a/opencog/learning/miner/Valuations.h
+++ b/opencog/learning/miner/Valuations.h
@@ -116,13 +116,6 @@ public:
 	const Handle& focus_value(const HandleSeq& values) const;
 
 	/**
-	 * Compare if 2 SCValuations are equal, in fact only looking at
-	 * their variables, as it is enough it the context in which they
-	 * will be used.
-	 */
-	bool operator==(const SCValuations& other) const;
-
-	/**
 	 * Less than relationship according to Variables, because it's
 	 * cheap and no 2 SCValuations with same variables will be in the
 	 * same set at once.

--- a/opencog/learning/miner/Valuations.h
+++ b/opencog/learning/miner/Valuations.h
@@ -48,6 +48,11 @@ public:
 	const Handle& focus_variable() const;
 
 	/**
+	 * Return all variables following (and not including) the variable under focus.
+	 */
+	HandleSeq remaining_variables() const;
+
+	/**
 	 * Move focus to the next (or previous) variable. That is increment
 	 * (or decrement) _var_idx.
 	 */

--- a/opencog/learning/miner/Valuations.h
+++ b/opencog/learning/miner/Valuations.h
@@ -48,6 +48,11 @@ public:
 	const Handle& focus_variable() const;
 
 	/**
+	 * Return the index of the variable under focus, _var_idx
+	 */
+	unsigned focus_index() const;
+
+	/**
 	 * Return all variables following (and not including) the variable under focus.
 	 */
 	HandleSeq remaining_variables() const;

--- a/opencog/learning/miner/miner-utils.scm
+++ b/opencog/learning/miner/miner-utils.scm
@@ -80,18 +80,14 @@
 
 (define (configure-mandatory-rules pm-rbs)
   ;; Load and associate mandatory rules to pm-rbs
-  (let* ((base-rule-files (list "shallow-abstraction.scm"
-                                "specialization.scm"))
+  (let* ((base-rule-files (list "shallow-specialization.scm"))
          (rule-files (map mk-full-rule-path base-rule-files))
-         (rules (list ;; TODO somehow shallow-abstraction-rule-name
-                      ;; and specialization-rule-name are not
-                      ;; accessible thom here after loading
-                      ;; shallow-abstraction.scm and
-                      ;; specialization.scm. For that reason we use
-                      ;; their Atomese definitions instead. This
+         (rules (list ;; TODO somehow shallow-specialization-rule-name
+                      ;; are not accessible thom here after loading
+                      ;; shallow-specialization.scm. For that reason
+                      ;; we use its Atomese definition instead. This
                       ;; might be a guile bug.
-                      (DefinedSchemaNode "shallow-abstraction-rule")
-                      (DefinedSchemaNode "specialization-rule"))))
+                      (DefinedSchemaNode "shallow-specialization-rule"))))
     (for-each load-from-path rule-files)
     (ure-add-rules pm-rbs rules)))
 

--- a/opencog/learning/miner/miner-utils.scm
+++ b/opencog/learning/miner/miner-utils.scm
@@ -133,6 +133,7 @@
 (define* (configure-miner pm-rbs
                           #:key
                           (maxiter 1000)
+                          (complexity-penalty 1)
                           (incremental-expansion (stv 0 1))
                           (max-conjuncts 3))
 "
@@ -140,13 +141,23 @@
   pattern miner. Automatically configure it with the appropriate
   rules and parameters.
 
-  Usage: (configure-miner pm-rbs #:maxiter mi)
+  Usage: (configure-miner pm-rbs
+                          #:maxiter mi
+                          #:complexity-penalty cp
+                          #:incremental-expansion tv
+                          #:max-conjuncts mc)
 
   pm-rbs: Concept node of the rule-based system to configure
 
   mi: [optional, default=1000] Maximum number of iterations allocated.
       If negative then the pattern miner keeps running till all patterns
       have been exhausted (not recommended unless you know what you're doing).
+
+  cp: [optional, default=1] Complexity penalty parameter passed to the forward
+      chainer. It controls breadth vs depth search. A high value means more
+      breadth. A value of 0 means a equilibrium between breadth and depth.
+      A negative value means more depth. Possible range is (-inf, +inf)
+      but it's rarely necessary in practice to go outside of [-10, 10].
 
   tv: [optional, default=(stv 0 1)] Truth value of a rule to expand existing
       conjunctions of patterns. It will only expand conjunctions with enough
@@ -166,6 +177,7 @@
 
   ;; Set parameters
   (ure-set-maximum-iterations pm-rbs maxiter)
+  (ure-set-complexity-penalty pm-rbs complexity-penalty)
 
   ;; If there is no incremental expansion then each rule is
   ;; deterministic, thus no need to retry exhausted sources
@@ -284,8 +296,9 @@
 
 (define* (cog-mine texts ms
                    #:key
-                   (maxiter 1000)
                    (initpat (top))
+                   (maxiter 1000)
+                   (complexity-penalty 1)
                    (incremental-expansion (stv 0 1))
                    (max-conjuncts 3))
 "
@@ -293,9 +306,9 @@
   using maxiter iterations and starting from the initial pattern initpat.
 
   Usage: (cog-mine texts ms
-                   ;; Optional arguments
-                   #:maxiter mi
                    #:initpat ip
+                   #:maxiter mi
+                   #:complexity-penalty cp
                    #:incremental-expansion tv
                    #:max-conjuncts mc)
 
@@ -327,12 +340,18 @@
   ms: Minimum support. All pattern with frequency below ms are
       discarded
 
+  ip: [optional, default=(top)] Initial pattern to start the search from.
+      All mined patterns will be specializations of this pattern.
+
   mi: [optional, default=1000] Maximum number of iterations allocated.
       If negative then the pattern miner keeps running till all patterns
       have been exhausted (not recommended unless you know what you're doing).
 
-  ip: [optional, default=(top)] Initial pattern to start the search from.
-      All mined patterns will be specializations of this pattern.
+  cp: [optional, default=1] Complexity penalty parameter passed to the forward
+      chainer. It controls breadth vs depth search. A high value means more
+      breadth. A value of 0 means an equilibrium between breadth and depth.
+      A negative value means more depth. Possible range is (-inf, +inf)
+      but it's rarely necessary in practice to go outside of [-10, 10].
 
   tv: [optional, default=(stv 0 1)] Truth value of a rule to expand existing
       conjunctions of patterns. It will only expand conjunctions with enough
@@ -398,6 +417,7 @@
                (miner-rbs (random-miner-rbs-cpt)))
           (configure-miner miner-rbs
                            #:maxiter maxiter
+                           #:complexity-penalty complexity-penalty
                            #:incremental-expansion incremental-expansion
                            #:max-conjuncts max-conjuncts)
           (let* (;; Run the pattern miner in a forward way

--- a/opencog/learning/miner/rules/CMakeLists.txt
+++ b/opencog/learning/miner/rules/CMakeLists.txt
@@ -2,5 +2,6 @@ ADD_GUILE_MODULE (FILES
   miner-rule-utils.scm
   shallow-abstraction.scm
   specialization.scm
+  conjunction-expansion.scm
   MODULE_DESTINATION "${DATADIR}/scm/opencog/miner/rules"
 )

--- a/opencog/learning/miner/rules/CMakeLists.txt
+++ b/opencog/learning/miner/rules/CMakeLists.txt
@@ -2,6 +2,7 @@ ADD_GUILE_MODULE (FILES
   miner-rule-utils.scm
   shallow-abstraction.scm
   specialization.scm
+  shallow-specialization.scm
   conjunction-expansion.scm
   MODULE_DESTINATION "${DATADIR}/scm/opencog/miner/rules"
 )

--- a/opencog/learning/miner/rules/conjunction-expansion.scm
+++ b/opencog/learning/miner/rules/conjunction-expansion.scm
@@ -233,9 +233,3 @@
   (DefinedSchemaNode "conjunction-expansion-8ary-rule"))
 (DefineLink conjunction-expansion-8ary-rule-name
   (gen-conjunction-expansion-rule 8))
-
-;; Define novenary conjunction expansion
-(define conjunction-expansion-9ary-rule-name
-  (DefinedSchemaNode "conjunction-expansion-9ary-rule"))
-(DefineLink conjunction-expansion-9ary-rule-name
-  (gen-conjunction-expansion-rule 9))

--- a/opencog/learning/miner/rules/conjunction-expansion.scm
+++ b/opencog/learning/miner/rules/conjunction-expansion.scm
@@ -121,9 +121,9 @@
               ;; Fake conclusion, since we can't statistically define its
               ;; pattern ATM
               (minsup-eval (top) texts ms)
-              ;; Premises
-              minsup-f
-              minsup-g))))
+              ;; Premises, wrap in Set because their order does not matter
+              (Set minsup-f
+                   minsup-g)))))
 
       ;; Left pattern has 1 < nary arity
       (let* (;; Variables
@@ -154,21 +154,26 @@
             ;; Fake conclusion, since we can't statistically define its
             ;; pattern ATM
             (minsup-eval (top) texts ms)
-            ;; Premises
-            minsup-f
-            minsup-g))))))
+            ;; Premises, wrap in Set because their order does not matter
+            (Set minsup-f
+                 minsup-g)))))))
 
 ;; Conjunction expansion formula
 (define (conjunction-expansion-formula conclusion . premises)
   ;; (cog-logger-debug "conjunction-expansion-formula conclusion = ~a, premises = ~a" conclusion premises)
-  (if (= (length premises) 2)
-      (let* ((minsup-f (car premises))
-             (minsup-g (cadr premises))
+  (if (= (length premises) 1)
+      (let* ((minsup-fg (car premises))
+             (minsup-f (cog-outgoing-atom minsup-fg 0))
+             (minsup-g (cog-outgoing-atom minsup-fg 1))
              (f (get-pattern minsup-f))
              (g (get-pattern minsup-g))
              (texts (get-texts minsup-f))
              (ms (get-ms minsup-f))
-             (fgs (cog-expand-conjunction f g texts ms))
+             ;; Swap f and g to make sure the second argument of
+             ;; cog-expand-conjunction is never a conjunction
+             (fgs (if (unary-conjunction? (get-body g))
+                      (cog-expand-conjunction f g texts ms)
+                      (cog-expand-conjunction g f texts ms)))
              (mk-minsup (lambda (fg) (minsup-eval-true fg texts ms)))
              ;; cog-expand-conjunction only return patterns with
              ;; enough support

--- a/opencog/learning/miner/rules/conjunction-expansion.scm
+++ b/opencog/learning/miner/rules/conjunction-expansion.scm
@@ -52,50 +52,111 @@
 
 (load "miner-rule-utils.scm")
 
-(define conjunction-expansion-rule
-  (let* (;; Variables
-         (f-vardecl (Variable "$f-vardecl"))
-         (g-vardecl (Variable "$g-vardecl"))
-         (f-body (Variable "$f-body"))
-         (g-body (Variable "$g-body"))
-         (texts (Variable "$texts"))
-         (ms (Variable "$ms"))
-         ;; Types
-         (ConceptT (Type "ConceptNode"))
-         (NumberT (Type "NumberNode"))
-         ;; Vardecls
-         (texts-decl (TypedVariable texts ConceptT))
-         (ms-decl (TypedVariable ms NumberT))
-         ;; clauses
-         (f (Quote (Lambda (Unquote f-vardecl) (Unquote f-body))))
-         (g (Quote (Lambda (Unquote g-vardecl) (Unquote g-body))))
-         (minsup-f (minsup-eval f texts ms))
-         (minsup-g (minsup-eval g texts ms)))
-    (Bind
-      (VariableList
-        f-vardecl
-        g-vardecl
-        f-body
-        g-body
-        texts-decl
-        ms-decl)
-      (And
-        minsup-f
-        minsup-g
-        (absolutely-true-eval minsup-f)
-        (absolutely-true-eval minsup-g)
-        (single-conjunct-eval g-body)
-        (Not (Equal f (top)))
-        (Not (Equal g (top))))
-      (ExecutionOutput
-        (GroundedSchema "scm: conjunction-expansion-formula")
-        (List
-          ;; Fake conclusion, since we can't statistically define its
-          ;; pattern ATM
-          (minsup-eval (top) texts ms)
-          ;; Premises
+;; Generate a conjunction expansion rule so that the left pattern, f,
+;; is a nary conjunction. Lets call f the left conjunction. Thus the
+;; produced pattern, will be a nary+1 conjunction, and the right
+;; pattern, g, is a unary conjunction.
+;;
+;; * nary <= 0: generate a rule that doesn't restrict the arity of the
+;;              left conjunction.
+;;
+;; * 0 < nary: generate a rule that restricts the arity of the left
+;;             conjunction to nary.
+(define (gen-conjunction-expansion-rule nary)
+  ;; Shared variables
+  (define f-vardecl (Variable "$f-vardecl"))
+  (define g-vardecl (Variable "$g-vardecl"))
+  (define texts (Variable "$texts"))
+  (define ms (Variable "$ms"))
+  (define g-body (Variable "$g-body"))
+  ;; Shared types
+  (define ConceptT (Type "ConceptNode"))
+  (define NumberT (Type "NumberNode"))
+  (define AndT (Type "AndLink"))
+  ;; Shared variable declarations
+  (define f-vardecl-decl f-vardecl)
+  (define g-vardecl-decl g-vardecl)
+  (define g-body-decl g-body)
+  (define texts-decl (TypedVariable texts ConceptT))
+  (define ms-decl (TypedVariable ms NumberT))
+  ;; Shared clauses
+  (define g (Quote (Lambda (Unquote g-vardecl) (Unquote g-body))))
+  (define minsup-g (minsup-eval g texts ms))
+
+  ;; Generate rule by nary cases
+  (if (<= nary 1)
+      ;; There are 2 cases
+      ;; 1. no restriction on the arity of the left conjunction,
+      ;; 2. unary left conjunction
+      (let* (;; Variables
+             (f-body (Variable "$f-body"))
+             ;; Vardecls
+             (f-body-decl f-body)
+             ;; clauses
+             (f (Quote (Lambda (Unquote f-vardecl) (Unquote f-body))))
+             (minsup-f (minsup-eval f texts ms)))
+        (Bind
+          (VariableList
+            f-vardecl-decl
+            g-vardecl-decl
+            f-body-decl
+            g-body-decl
+            texts-decl
+            ms-decl)
+          (And
+            minsup-f
+            minsup-g
+            (absolutely-true-eval minsup-f)
+            (absolutely-true-eval minsup-g)
+            (not-equal-top f)
+            (not-equal-top g)
+            (unary-conjunction-eval g-body)
+            ;; If nary equals to 1, make sure the left conjunction is unary
+            (if (= nary 1)
+                (unary-conjunction-eval f-body)
+                '()))
+          (ExecutionOutput
+            (GroundedSchema "scm: conjunction-expansion-formula")
+            (List
+              ;; Fake conclusion, since we can't statistically define its
+              ;; pattern ATM
+              (minsup-eval (top) texts ms)
+              ;; Premises
+              minsup-f
+              minsup-g))))
+
+      ;; Left pattern has 1 < nary arity
+      (let* (;; Variables
+             (f-conjuncts (gen-variables "$f-conjunct" nary))
+             ;; Vardecls
+             (f-conjuncts-decls f-conjuncts)
+             ;; clauses
+             (f (Quote (Lambda (Unquote f-vardecl) (And (map Unquote f-conjuncts)))))
+             (minsup-f (minsup-eval f texts ms)))
+      (Bind
+        (VariableList
+          f-vardecl-decl
+          g-vardecl-decl
+          f-conjuncts-decls
+          g-body-decl
+          texts-decl
+          ms-decl)
+        (And
           minsup-f
-          minsup-g)))))
+          minsup-g
+          (absolutely-true-eval minsup-f)
+          (absolutely-true-eval minsup-g)
+          (not-equal-top g)
+          (unary-conjunction-eval g-body))
+        (ExecutionOutput
+          (GroundedSchema "scm: conjunction-expansion-formula")
+          (List
+            ;; Fake conclusion, since we can't statistically define its
+            ;; pattern ATM
+            (minsup-eval (top) texts ms)
+            ;; Premises
+            minsup-f
+            minsup-g))))))
 
 ;; Conjunction expansion formula
 (define (conjunction-expansion-formula conclusion . premises)
@@ -105,13 +166,47 @@
              (minsup-g (cadr premises))
              (f (get-pattern minsup-f))
              (g (get-pattern minsup-g))
-             (fg (cog-expand-conjunction f g))
              (texts (get-texts minsup-f))
-             (ms (get-ms minsup-f)))
-        (minsup-eval-true fg texts ms))))
+             (ms (get-ms minsup-f))
+             (fgs (cog-expand-conjunction f g texts ms))
+             (mk-minsup (lambda (fg) (minsup-eval-true fg texts ms)))
+             ;; cog-expand-conjunction only return patterns with
+             ;; enough support
+             (minsup-fgs (map mk-minsup (cog-outgoing-set fgs))))
+        (Set minsup-fgs))))
 
-;; Define conjunction expansion
+;; Define arbitrary nary conjunction expansion
 (define conjunction-expansion-rule-name
   (DefinedSchemaNode "conjunction-expansion-rule"))
 (DefineLink conjunction-expansion-rule-name
-  conjunction-expansion-rule)
+  (gen-conjunction-expansion-rule 0))
+
+;; Define unary conjunction expansion
+(define conjunction-expansion-1ary-rule-name
+  (DefinedSchemaNode "conjunction-expansion-1ary-rule"))
+(DefineLink conjunction-expansion-1ary-rule-name
+  (gen-conjunction-expansion-rule 1))
+
+;; Define binary conjunction expansion
+(define conjunction-expansion-2ary-rule-name
+  (DefinedSchemaNode "conjunction-expansion-2ary-rule"))
+(DefineLink conjunction-expansion-2ary-rule-name
+  (gen-conjunction-expansion-rule 2))
+
+;; Define ternary conjunction expansion
+(define conjunction-expansion-3ary-rule-name
+  (DefinedSchemaNode "conjunction-expansion-3ary-rule"))
+(DefineLink conjunction-expansion-3ary-rule-name
+  (gen-conjunction-expansion-rule 3))
+
+;; Define quaternary conjunction expansion
+(define conjunction-expansion-4ary-rule-name
+  (DefinedSchemaNode "conjunction-expansion-4ary-rule"))
+(DefineLink conjunction-expansion-4ary-rule-name
+  (gen-conjunction-expansion-rule 4))
+
+;; Define quaternary conjunction expansion
+(define conjunction-expansion-5ary-rule-name
+  (DefinedSchemaNode "conjunction-expansion-5ary-rule"))
+(DefineLink conjunction-expansion-5ary-rule-name
+  (gen-conjunction-expansion-rule 5))

--- a/opencog/learning/miner/rules/conjunction-expansion.scm
+++ b/opencog/learning/miner/rules/conjunction-expansion.scm
@@ -1,0 +1,115 @@
+;; Rule to expand a conjunction with an existing pattern given that
+;; both the conjunction and the existing pattern have enough support.
+;;
+;; Semi-formally
+;;
+;; Evaluation (stv 1 1)
+;;   Predicate "minsup"
+;;   List
+;;     Lambda
+;;       <f-vardecl>
+;;       <f-body>
+;;     <texts>
+;;     <ms>
+;; Evaluation (stv 1 1)
+;;   Predicate "minsup"
+;;   List
+;;     Lambda
+;;       <g-vardecl>
+;;       <g-body>
+;;     <texts>
+;;     <ms>
+;; |-
+;; Evaluation (stv 1 1)
+;;   Predicate "minsup"
+;;   List
+;;     Lambda
+;;       VariableList
+;;         <f-vardecl>
+;;         <g-vardecl>
+;;       And
+;;         <f-body>
+;;         <g-body>
+;;     <texts>
+;;     <ms>
+;;
+;; Where <f-body> may be a conjunction of multiple conjuncts, while
+;; <g-body> may only be a single conjunct. Also it is assumed that
+;; variables are properly alpha-converted to avoid any variable name
+;; collision. Finally,
+;;
+;; VariableList
+;;   <f-vardecl>
+;;   <g-vardecl>
+;;
+;; and
+;;
+;; And
+;;   <f-body>
+;;   <g-body>
+;;
+;; are flattened.
+
+(load "miner-rule-utils.scm")
+
+(define conjunction-expansion-rule
+  (let* (;; Variables
+         (f-vardecl (Variable "$f-vardecl"))
+         (g-vardecl (Variable "$g-vardecl"))
+         (f-body (Variable "$f-body"))
+         (g-body (Variable "$g-body"))
+         (texts (Variable "$texts"))
+         (ms (Variable "$ms"))
+         ;; Types
+         (ConceptT (Type "ConceptNode"))
+         (NumberT (Type "NumberNode"))
+         ;; Vardecls
+         (texts-decl (TypedVariable texts ConceptT))
+         (ms-decl (TypedVariable ms NumberT))
+         ;; clauses
+         (f (Quote (Lambda (Unquote f-vardecl) (Unquote f-body))))
+         (g (Quote (Lambda (Unquote g-vardecl) (Unquote g-body))))
+         (minsup-f (minsup-eval f texts ms))
+         (minsup-g (minsup-eval g texts ms)))
+    (Bind
+      (VariableList
+        f-vardecl
+        g-vardecl
+        f-body
+        g-body
+        texts-decl
+        ms-decl)
+      (And
+        minsup-f
+        minsup-g
+        (absolutely-true-eval minsup-f)
+        (absolutely-true-eval minsup-g)
+        (single-conjunct-eval g-body))
+      (ExecutionOutput
+        (GroundedSchema "scm: conjunction-expansion-formula")
+        (List
+          ;; Fake conclusion, since we can't statistically define its
+          ;; pattern ATM
+          (minsup-eval (top) texts ms)
+          ;; Premises
+          minsup-f
+          minsup-g)))))
+
+;; Conjunction expansion formula
+(define (conjunction-expansion-formula conclusion . premises)
+  ;; (cog-logger-debug "conjunction-expansion-formula conclusion = ~a, premises = ~a" conclusion premises)
+  (if (= (length premises) 2)
+      (let* ((minsup-f (car premises))
+             (minsup-g (cadr premises))
+             (f (get-pattern minsup-f))
+             (g (get-pattern minsup-g))
+             (fg (cog-expand-conjunction f g))
+             (texts (get-texts minsup-f))
+             (ms (get-ms minsup-f)))
+        (minsup-eval-true fg texts ms))))
+
+;; Define conjunction expansion
+(define conjunction-expansion-rule-name
+  (DefinedSchemaNode "conjunction-expansion-rule"))
+(DefineLink conjunction-expansion-rule-name
+  conjunction-expansion-rule)

--- a/opencog/learning/miner/rules/conjunction-expansion.scm
+++ b/opencog/learning/miner/rules/conjunction-expansion.scm
@@ -84,7 +84,9 @@
         minsup-g
         (absolutely-true-eval minsup-f)
         (absolutely-true-eval minsup-g)
-        (single-conjunct-eval g-body))
+        (single-conjunct-eval g-body)
+        (Not (Equal f (top)))
+        (Not (Equal g (top))))
       (ExecutionOutput
         (GroundedSchema "scm: conjunction-expansion-formula")
         (List

--- a/opencog/learning/miner/rules/conjunction-expansion.scm
+++ b/opencog/learning/miner/rules/conjunction-expansion.scm
@@ -210,8 +210,32 @@
 (DefineLink conjunction-expansion-4ary-rule-name
   (gen-conjunction-expansion-rule 4))
 
-;; Define quaternary conjunction expansion
+;; Define quinary conjunction expansion
 (define conjunction-expansion-5ary-rule-name
   (DefinedSchemaNode "conjunction-expansion-5ary-rule"))
 (DefineLink conjunction-expansion-5ary-rule-name
   (gen-conjunction-expansion-rule 5))
+
+;; Define senary conjunction expansion
+(define conjunction-expansion-6ary-rule-name
+  (DefinedSchemaNode "conjunction-expansion-6ary-rule"))
+(DefineLink conjunction-expansion-6ary-rule-name
+  (gen-conjunction-expansion-rule 6))
+
+;; Define septenary conjunction expansion
+(define conjunction-expansion-7ary-rule-name
+  (DefinedSchemaNode "conjunction-expansion-7ary-rule"))
+(DefineLink conjunction-expansion-7ary-rule-name
+  (gen-conjunction-expansion-rule 7))
+
+;; Define octonary conjunction expansion
+(define conjunction-expansion-8ary-rule-name
+  (DefinedSchemaNode "conjunction-expansion-8ary-rule"))
+(DefineLink conjunction-expansion-8ary-rule-name
+  (gen-conjunction-expansion-rule 8))
+
+;; Define novenary conjunction expansion
+(define conjunction-expansion-9ary-rule-name
+  (DefinedSchemaNode "conjunction-expansion-9ary-rule"))
+(DefineLink conjunction-expansion-9ary-rule-name
+  (gen-conjunction-expansion-rule 9))

--- a/opencog/learning/miner/rules/miner-rule-utils.scm
+++ b/opencog/learning/miner/rules/miner-rule-utils.scm
@@ -17,9 +17,9 @@
 (define (get-body f)
   (cog-outgoing-atom f 1))
 
-(define (shallow-abstraction-eval shabs-list minsup-g)
+(define (abstraction-eval shabs-list minsup-g)
   (Evaluation
-    (Predicate "shallow-abstraction")
+    (Predicate "abstraction")
     (List
       shabs-list
       minsup-g)))

--- a/opencog/learning/miner/rules/miner-rule-utils.scm
+++ b/opencog/learning/miner/rules/miner-rule-utils.scm
@@ -6,12 +6,16 @@
 
 ;; Given an atom created with minsup-eval, get the pattern, texts and
 ;; ms
-(define (get-pattern minsup-g)
-  (cog-outgoing-atom (gdr minsup-g) 0))
-(define (get-texts minsup-g)
-  (cog-outgoing-atom (gdr minsup-g) 1))
-(define (get-ms minsup-g)
-  (cog-outgoing-atom (gdr minsup-g) 2))
+(define (get-pattern minsup-f)
+  (cog-outgoing-atom (gdr minsup-f) 0))
+(define (get-texts minsup-f)
+  (cog-outgoing-atom (gdr minsup-f) 1))
+(define (get-ms minsup-f)
+  (cog-outgoing-atom (gdr minsup-f) 2))
+(define (get-vardecl f)
+  (cog-outgoing-atom f 0))
+(define (get-body f)
+  (cog-outgoing-atom f 1))
 
 (define (shallow-abstraction-eval shabs-list minsup-g)
   (Evaluation
@@ -19,3 +23,16 @@
     (List
       shabs-list
       minsup-g)))
+
+(define (single-conjunct-eval body)
+  (Evaluation
+    (GroundedPredicate "scm: single-conjunct")
+    body))
+
+(define (single-conjunct? body)
+  (let ((body-type (cog-type body)))
+    (and (not (equal? body-type 'PresentLink))
+         (not (equal? body-type 'AndLink)))))
+
+(define (single-conjunct body)
+  (bool->tv (single-conjunct? body)))

--- a/opencog/learning/miner/rules/miner-rule-utils.scm
+++ b/opencog/learning/miner/rules/miner-rule-utils.scm
@@ -24,15 +24,21 @@
       shabs-list
       minsup-g)))
 
-(define (single-conjunct-eval body)
+(define (unary-conjunction-eval body)
   (Evaluation
-    (GroundedPredicate "scm: single-conjunct")
+    (GroundedPredicate "scm: unary-conjunction")
     body))
 
-(define (single-conjunct? body)
+(define (unary-conjunction? body)
   (let ((body-type (cog-type body)))
     (and (not (equal? body-type 'PresentLink))
          (not (equal? body-type 'AndLink)))))
 
-(define (single-conjunct body)
-  (bool->tv (single-conjunct? body)))
+(define (unary-conjunction body)
+  (bool->tv (unary-conjunction? body)))
+
+(define (equal-top x)
+  (Equal x (top)))
+
+(define (not-equal-top x)
+  (Not (equal-top x)))

--- a/opencog/learning/miner/rules/shallow-abstraction.scm
+++ b/opencog/learning/miner/rules/shallow-abstraction.scm
@@ -15,7 +15,7 @@
 ;; |-
 ;; Set
 ;;   Evaluation (stv 1 1)
-;;     Predicate "shallow-abstraction"
+;;     Predicate "abstraction"
 ;;     List
 ;;       List
 ;;         <f1>
@@ -91,7 +91,7 @@
              (ms (get-ms minsup-g))
              (shabs-lists (cog-shallow-abstract g texts ms))
              (list->eval (lambda (x) (cog-set-tv!
-                                      (shallow-abstraction-eval x minsup-g)
+                                      (abstraction-eval x minsup-g)
                                       (stv 1 1))))
              (shabs-evals (map list->eval (cog-outgoing-set shabs-lists))))
         (Set shabs-evals))))

--- a/opencog/learning/miner/rules/shallow-abstraction.scm
+++ b/opencog/learning/miner/rules/shallow-abstraction.scm
@@ -96,7 +96,7 @@
              (shabs-evals (map list->eval (cog-outgoing-set shabs-lists))))
         (Set shabs-evals))))
 
-;; Define specialization
+;; Define shallow abstraction
 (define shallow-abstraction-rule-name
   (DefinedSchemaNode "shallow-abstraction-rule"))
 (DefineLink shallow-abstraction-rule-name

--- a/opencog/learning/miner/rules/shallow-abstraction.scm
+++ b/opencog/learning/miner/rules/shallow-abstraction.scm
@@ -1,3 +1,7 @@
+;; Note: For now shallow specialization rule is used instead of
+;; shallow the abstraction rule. Using shallow specialization allows
+;; to perform in one step shallow abstraction and specialization.
+;;
 ;; Rule to generate shallow abstractions of a given pattern,
 ;; specifically
 ;;

--- a/opencog/learning/miner/rules/shallow-specialization.scm
+++ b/opencog/learning/miner/rules/shallow-specialization.scm
@@ -1,0 +1,87 @@
+;; Rule combine both a shallow abstraction and a specialization in one
+;; step.
+;;
+;; The advantage of that rule is that it doesn't create intermediary
+;; abstraction structure such as
+;;
+;; Evaluation
+;;   Predicate "abstraction"
+;;   List
+;;     <abstractions>
+;;     minsup(pattern, texts, ms)
+;;
+;; Instead, given a minsup(pattern, texts, ms) evaluation, it directly
+;; generate shallow specializations of pattern.
+;;
+;; Evaluation (stv 1 1)
+;;   Predicate "minsup"
+;;   List
+;;     <pattern>
+;;     <texts>
+;;     <ms>
+;; |-
+;; Set
+;;   Evaluation (stv 1 1)
+;;     Predicate "minsup"
+;;     List
+;;       <pattern-shallow-specialization-1>
+;;       <texts>
+;;       <ms>
+;; ...
+
+(load "miner-rule-utils.scm")
+
+(define shallow-specialization-rule
+  (let* (;; Variables
+         (pattern (Variable "$pattern"))
+         (texts (Variable "$texts"))
+         (ms (Variable "$ms"))
+         ;; Types
+         (LambdaT (Type "LambdaLink"))
+         (ConceptT (Type "ConceptNode"))
+         (NumberT (Type "NumberNode"))
+         ;; Vardecls
+         (pattern-decl (TypedVariable pattern LambdaT))
+         (texts-decl (TypedVariable texts ConceptT))
+         (ms-decl (TypedVariable ms NumberT))
+         ;; Clauses
+         (minsup-pattern (minsup-eval pattern texts ms)))
+  (Bind
+    (VariableList
+      pattern-decl
+      texts-decl
+      ms-decl)
+    (And
+      minsup-pattern
+      (absolutely-true-eval minsup-pattern))
+    (ExecutionOutput
+      (GroundedSchema "scm: shallow-specialization-formula")
+      (List
+        (Set)               ; Cannot know the structure of the rule
+                            ; conclusion in advance, because we don't
+                            ; know the number of shallow specializations,
+                            ; thus we cannot build the Set. Need to
+                            ; support ConsLink, or ConsSetLink or
+                            ; such. Or perhaps use Glob.
+        minsup-pattern)))))
+
+;; Shallow specialization formula
+(define (shallow-specialization-formula conclusion . premises)
+  ;; (cog-logger-debug "shallow-specialization-formula conclusion = ~a, premises = ~a" conclusion premises)
+  (if (= (length premises) 1)
+      (let* ((minsup-pattern (car premises))
+             (pattern (get-pattern minsup-pattern))
+             (texts (get-texts minsup-pattern))
+             (ms (get-ms minsup-pattern))
+             (shaspes (cog-shallow-specialize pattern texts ms))
+             (minsup-shaspe (lambda (x) (cog-set-tv!
+                                         (minsup-eval x texts ms)
+                                         (stv 1 1))))
+             (minsup-shaspes (map minsup-shaspe (cog-outgoing-set shaspes))))
+        (Set minsup-shaspes))))
+
+;; Define shallow specialization
+(define shallow-specialization-rule-name
+  (DefinedSchemaNode "shallow-specialization-rule"))
+(DefineLink shallow-specialization-rule-name
+  shallow-specialization-rule)

--- a/opencog/learning/miner/rules/specialization.scm
+++ b/opencog/learning/miner/rules/specialization.scm
@@ -18,7 +18,7 @@
 ;;     <texts>
 ;;     <ms>
 ;; Evaluation <tv2>
-;;   Predicate "shallow-abstraction"
+;;   Predicate "abstraction"
 ;;   List
 ;;     List
 ;;       <x1>
@@ -91,7 +91,7 @@
          (vardecl (VariableList g-decl texts-decl ms-decl xs-f-decl))
          ;; Clauses
          (minsup-g (minsup-eval g texts ms))
-         (shabs-eval (shallow-abstraction-eval xs-f minsup-g))
+         (shabs-eval (abstraction-eval xs-f minsup-g))
          ;; Make sure the pattern has the minimum support
          (precond-1 (absolutely-true-eval minsup-g))
          (precond-2 (absolutely-true-eval shabs-eval))

--- a/opencog/learning/miner/rules/specialization.scm
+++ b/opencog/learning/miner/rules/specialization.scm
@@ -1,7 +1,11 @@
-;; Rule to specialize a pattern by composing it with a shallow
-;; abstraction, which can be pattern with just one link and all
-;; variables as outgoings, a constant, or a variable, and checks that
-;; it has enough support.
+;; Note: For now shallow specialization rule is used instead of the
+;; generic specialization rule. Using shallow specialization allows to
+;; perform in one step shallow abstraction and specialization.
+;;
+;; Rule to specialize a pattern by composing it with an abstraction,
+;; which can be pattern with just one link and all variables as
+;; outgoings, a constant, or a variable, and checks that it has enough
+;; support.
 ;;
 ;; Given g with arity n and with support ms, and f, specialize g by
 ;; composing it with f over one of its variables, xi.

--- a/opencog/pln/rules/propositional/fuzzy-disjunction-introduction.scm
+++ b/opencog/pln/rules/propositional/fuzzy-disjunction-introduction.scm
@@ -14,19 +14,7 @@
 ;; -----------------------------------------------------------------------------
 
 (use-modules (srfi srfi-1))
-
-;; Generate variable (Variable prefix + "-" + to_string(i))
-(define (gen-variable prefix i)
-  (Variable (string-append prefix "-" (number->string i))))
-
-;; Generate a list of variables (Variable prefix + "-" + to_string(n))
-(define (gen-variables prefix n)
-  (if (= n 0)
-      ;; Base case
-      '()
-      ;; Recursive case
-      (append (gen-variables prefix (- n 1))
-              (list (gen-variable prefix (- n 1))))))
+(use-modules (opencog rule-engine))
 
 ;; Generate a fuzzy disjunction introduction rule for an n-ary
 ;; disjunction

--- a/scripts/benchmark_utests.sh
+++ b/scripts/benchmark_utests.sh
@@ -19,7 +19,7 @@ BUILD_DIR_NAME=build
 # Get the script directory
 PRG_PATH="$(readlink -f "$0")"
 PRG_DIR="$(dirname "$PRG_PATH")"
-UTEST_DIR="$PRG_DIR/../$BUILD_DIR_NAME/tests/learning/miner"
+UTEST_DIR="$PRG_DIR/../$BUILD_DIR_NAME"
 
 #############
 # Functions #
@@ -33,8 +33,7 @@ get_real_time() {
 # Run all query unit tests
 run_utests() {
     cd "$UTEST_DIR";
-    ./MinerUTest
-    # make -j4 test ARGS=-j4
+    make -j4 test ARGS=-j4
     cd -
 }
 

--- a/scripts/benchmark_utests.sh
+++ b/scripts/benchmark_utests.sh
@@ -19,7 +19,7 @@ BUILD_DIR_NAME=build
 # Get the script directory
 PRG_PATH="$(readlink -f "$0")"
 PRG_DIR="$(dirname "$PRG_PATH")"
-UTEST_DIR="$PRG_DIR/../$BUILD_DIR_NAME"
+UTEST_DIR="$PRG_DIR/../$BUILD_DIR_NAME/tests/learning/miner"
 
 #############
 # Functions #
@@ -33,7 +33,8 @@ get_real_time() {
 # Run all query unit tests
 run_utests() {
     cd "$UTEST_DIR";
-    make -j4 test ARGS=-j4
+    ./MinerUTest
+    # make -j4 test ARGS=-j4
     cd -
 }
 

--- a/tests/learning/PatternMiner/PatternMinerUTest.cxxtest
+++ b/tests/learning/PatternMiner/PatternMinerUTest.cxxtest
@@ -60,6 +60,7 @@ public:
 
 	// Simple pattern miner tests
 	void test_PatternMiner_AB_AC();
+	void test_PatternMiner_2gram_AB_BC12();
 	// void test_PatternMiner_AB_ABC(); // will probably not be supported
 	// void test_PatternMiner_ABCD(); // will probably not be supported
 
@@ -231,6 +232,43 @@ void PatternMinerUTest::test_PatternMiner_AB_AC()
 	logger().info("The result top 1-gram pattern: \n%s", patternStr.c_str());
 
 	TS_ASSERT_EQUALS(patternStr, expectedStr);
+}
+
+void PatternMinerUTest::test_PatternMiner_2gram_AB_BC12()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle A = an(CONCEPT_NODE, "A"),
+		B = an(CONCEPT_NODE, "B"),
+		C1 = an(CONCEPT_NODE, "C1"),
+		C2 = an(CONCEPT_NODE, "C2"),
+		AB = al(INHERITANCE_LINK, A, B),
+		BC1 = al(INHERITANCE_LINK, B, C1),
+		BC2 = al(INHERITANCE_LINK, B, C2);
+
+	config().set("Pattern_Max_Gram", "3");
+	config().set("Max_thread_num", "1");
+	PatternMiner pm(_as);
+	pm.runPatternMiner(false);
+
+	vector<HTreeNode*>& top2gramPatterns = pm.getFinalPatternsForGram(2);
+
+	string patternStr = pm.unifiedPatternToKeyString(top2gramPatterns[0]->pattern),
+		// One of the expected pattern would be
+		//
+		// (And
+		//   (Inheritance (Variable "$X") (Variable "$Y"))
+		//   (Inheritance (Variable "$Y") (Variable "$Z")))
+		//
+		// but some reason the pattern miner can't reach it.
+		expectedStr = "TODO";
+
+	logger().info("The result top 2-gram pattern: \n%s", patternStr.c_str());
+
+	TS_ASSERT(true);
+
+	// For some reason the pattern miner can't reach the desired pattern
+	// TS_ASSERT_EQUALS(patternStr, expectedStr);
 }
 
 // void PatternMinerUTest::test_PatternMiner_AB_ABC()

--- a/tests/learning/miner/CMakeLists.txt
+++ b/tests/learning/miner/CMakeLists.txt
@@ -1,4 +1,5 @@
 ADD_CXXTEST(MinerUTest)
 TARGET_LINK_LIBRARIES(MinerUTest
   miner
+  guile-miner
 )

--- a/tests/learning/miner/MinerUTest.cxxtest
+++ b/tests/learning/miner/MinerUTest.cxxtest
@@ -676,12 +676,14 @@ void MinerUTest::test_shallow_abstract()
 		Emily = an(CONCEPT_NODE, "Emily"),
 		Hessley = an(CONCEPT_NODE, "Hessley"),
 		Lily = an(CONCEPT_NODE, "Lily"),
+		Lucy = an(CONCEPT_NODE, "Lucy"),
 		Sophia = an(CONCEPT_NODE, "Sophia"),
 		human = an(CONCEPT_NODE, "human"),
 		man = an(CONCEPT_NODE, "man"),
 		soda_drinker = an(CONCEPT_NODE, "soda drinker"),
 		woman = an(CONCEPT_NODE, "woman");
-	HandleSetSeq expect{ { Abe, Allen, Cason, Davion, Emily, Lily, Sophia },
+	HandleSetSeq expect{ { Abe, Alaura, Allen, Cason, Davion,
+	                       Emily, Hessley, Lily, Lucy, Sophia },
 	                     { soda_drinker, W, ugly, man, human, woman },
 	                     { soda_drinker, ugly, man, human, woman } };
 

--- a/tests/learning/miner/MinerUTest.cxxtest
+++ b/tests/learning/miner/MinerUTest.cxxtest
@@ -1058,7 +1058,7 @@ void MinerUTest::test_2conjuncts_3()
 	TS_ASSERT(content_is_in(cpp_expected, cpp_results));
 
 	// Run URE pattern miner
-	Handle ure_results = ure_pm(texts, 2, 10, mk_nconjunct(2)),
+	Handle ure_results = ure_pm(texts, 2, 20, mk_nconjunct(2)),
 		ure_expected = mk_minsup_eval(2,
 		                              al(LAMBDA_LINK,
 		                                 VarXYZ,
@@ -1102,7 +1102,7 @@ void MinerUTest::test_2conjuncts_4()
 	TS_ASSERT(content_is_in(cpp_expected, cpp_results));
 
 	// Run URE pattern miner
-	Handle ure_results = ure_pm(texts, 4, 20, mk_nconjunct(2)),
+	Handle ure_results = ure_pm(texts, 4, 50, mk_nconjunct(2)),
 		ure_expected = mk_minsup_eval(4,
 		                              al(LAMBDA_LINK,
 		                                 VarXYZ,
@@ -1286,7 +1286,7 @@ void MinerUTest::test_InferenceControl()
 	TS_ASSERT(content_is_in(expected, cpp_results));
 
 	// Run URE pattern miner
-	Handle ure_results = ure_pm(_tmp_as, 2, 200, initpat),
+	Handle ure_results = ure_pm(_tmp_as, 2, 50, initpat),
 		ure_expected = mk_minsup_eval(2, expected);
 
 	logger().debug() << "ure_results = " << oc_to_string(ure_results);

--- a/tests/learning/miner/MinerUTest.cxxtest
+++ b/tests/learning/miner/MinerUTest.cxxtest
@@ -188,6 +188,7 @@ public:
 	void test_expand_conjunction_disconnect();
 	void test_expand_conjunction_1();
 	void test_expand_conjunction_2();
+	void test_shallow_abstract();
 
 	// Pattern miner
 	void test_A();
@@ -634,6 +635,60 @@ void MinerUTest::test_expand_conjunction_2()
 	logger().debug() << "expected = " << oc_to_string(expected);
 
 	TS_ASSERT(content_eq(results, expected));
+}
+
+void MinerUTest::test_shallow_abstract()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Load ugly-male-soda-drinker-corpus.scm
+	std::string rs =
+		_tmp_scm.eval("(load-from-path \"ugly-male-soda-drinker-corpus.scm\")");
+	logger().debug() << "rs = " << rs;
+
+	// Define pattern
+	Handle VarXZW = al(VARIABLE_LIST, X, Z, W),
+		ugly = an(CONCEPT_NODE, "ugly"),
+		clauses = al(AND_LINK,
+		             al(INHERITANCE_LINK, X, ugly),
+		             al(INHERITANCE_LINK, X, Z),
+		             al(INHERITANCE_LINK, X, W)),
+		pattern = al(LAMBDA_LINK, VarXZW, clauses);
+
+	// Define texts
+	HandleSet texts;
+	_tmp_as.get_handles_by_type(std::inserter(texts, texts.end()),
+	                            opencog::ATOM, true);
+
+	// Define minimum support
+	int ms = 5;
+
+	// Calculate the shallow abstractions
+	HandleSetSeq result = MinerUtils::shallow_abstract(pattern, texts, ms);
+
+	// Construct expected shallow abstractions
+	Handle
+		Abe = an(CONCEPT_NODE, "Abe"),
+		Alaura = an(CONCEPT_NODE, "Alaura"),
+		Allen = an(CONCEPT_NODE, "Allen"),
+		Cason = an(CONCEPT_NODE, "Cason"),
+		Davion = an(CONCEPT_NODE, "Davion"),
+		Emily = an(CONCEPT_NODE, "Emily"),
+		Hessley = an(CONCEPT_NODE, "Hessley"),
+		Lily = an(CONCEPT_NODE, "Lily"),
+		Sophia = an(CONCEPT_NODE, "Sophia"),
+		human = an(CONCEPT_NODE, "human"),
+		man = an(CONCEPT_NODE, "man"),
+		soda_drinker = an(CONCEPT_NODE, "soda drinker"),
+		woman = an(CONCEPT_NODE, "woman");
+	HandleSetSeq expect{ { Abe, Allen, Cason, Davion, Emily, Lily, Sophia },
+	                     { soda_drinker, W, ugly, man, human, woman },
+	                     { soda_drinker, ugly, man, human, woman } };
+
+	logger().debug() << "result = " << oc_to_string(result);
+	logger().debug() << "expect = " << oc_to_string(expect);
+
+	TS_ASSERT(content_eq(result, expect));
 }
 
 void MinerUTest::test_A()

--- a/tests/learning/miner/MinerUTest.cxxtest
+++ b/tests/learning/miner/MinerUTest.cxxtest
@@ -26,6 +26,7 @@
 
 #include <opencog/util/Config.h>
 #include <opencog/util/algorithm.h>
+#include <opencog/truthvalue/TruthValue.h>
 #include <opencog/truthvalue/SimpleTruthValue.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/query/BindLinkAPI.h>
@@ -35,6 +36,7 @@
 #include <opencog/rule-engine/backwardchainer/BackwardChainer.h>
 #include <opencog/rule-engine/URELogger.h>
 #include <opencog/guile/SchemeEval.h>
+#include <opencog/guile/SchemeSmob.h>
 
 #include <vector>
 
@@ -126,9 +128,13 @@ private:
 	 * then backward to gather the results, and output them.
 	 */
 	Handle ure_pm(const AtomSpace& texts_as, int minsup,
-	              int max_iter=-1, Handle initpat=Handle::UNDEFINED);
+	              int max_iter=-1, Handle initpat=Handle::UNDEFINED,
+	              TruthValuePtr incremental_expansion=TruthValue::FALSE_TV(),
+	              double complexity_penalty=0.0);
 	Handle ure_pm(const HandleSet& texts, int minsup,
-	              int max_iter=-1, Handle initpat=Handle::UNDEFINED);
+	              int max_iter=-1, Handle initpat=Handle::UNDEFINED,
+	              TruthValuePtr incremental_expansion=TruthValue::FALSE_TV(),
+	              double complexity_penalty=0.0);
 
 	/**
 	 * Configure the C++ Miner and run it.
@@ -160,6 +166,9 @@ private:
 	 */
 	Handle mk_ugly_soda_drinker();
 
+	void configure_mandatory_rules();
+	void configure_optional_rules(TruthValuePtr incremental_expansion);
+
 public:
 	MinerUTest();
 	~MinerUTest();
@@ -172,6 +181,8 @@ public:
 	void test_match();
 	void test_compose_1();
 	void test_compose_2();
+	void test_expand_conjunction_1();
+	void test_expand_conjunction_2();
 
 	// Pattern miner
 	void test_A();
@@ -244,16 +255,21 @@ HandleSeq MinerUTest::gen_variables(const std::string& prefix, int n)
 }
 
 Handle MinerUTest::ure_pm(const AtomSpace& texts_as, int minsup,
-                          int maxiter, Handle initpat)
+                          int maxiter, Handle initpat,
+                          TruthValuePtr incremental_expansion,
+                          double complexity_penalty)
 {
 	HandleSet texts;
 	texts_as.get_handles_by_type(std::inserter(texts, texts.end()),
 	                             opencog::ATOM, true);
-	return ure_pm(texts, minsup, maxiter, initpat);
+	return ure_pm(texts, minsup, maxiter, initpat,
+	              incremental_expansion, complexity_penalty);
 }
 
 Handle MinerUTest::ure_pm(const HandleSet& texts, int minsup,
-                          int maxiter, Handle initpat)
+                          int maxiter, Handle initpat,
+                          TruthValuePtr incremental_expansion,
+                          double complexity_penalty)
 {
 	// Make (Member text (Concept "texts)) links
 	for (const Handle& text : texts)
@@ -270,13 +286,21 @@ Handle MinerUTest::ure_pm(const HandleSet& texts, int minsup,
 	// If it doesn't have enough support return the empty solution
 	if (not es)
 		return al(SET_LINK);
-	TruthValuePtr tv = SimpleTruthValue::createTV(1.0, 1.0);
+
+	// Add incremental conjunction expansion if necessary
+	bool inc_exp_enabled = incremental_expansion != TruthValue::FALSE_TV();
+	if (inc_exp_enabled)
+		configure_optional_rules(incremental_expansion);
+
+	// Otherwise prepare the source
+	TruthValuePtr tv = TruthValue::TRUE_TV();
 	Handle source = mk_minsup_eval(minsup, initpat, tv);
 
-	// Run the foward chainer from the initial pattern
+	// Run the forward chainer from the initial pattern
 	ForwardChainer fc(_as, pm_rb, source);
 	fc.get_config().set_maximum_iterations(maxiter);
-	fc.get_config().set_retry_sources(false);
+	fc.get_config().set_retry_exhausted_sources(inc_exp_enabled);
+	fc.get_config().set_complexity_penalty(complexity_penalty);
 	fc.do_chain();
 
 	// Run the pattern matcher query to gather the knowledge of
@@ -331,16 +355,34 @@ Handle MinerUTest::mk_ugly_soda_drinker()
 	return ugly_soda_drinker;
 }
 
+void MinerUTest::configure_mandatory_rules()
+{
+	std::string rs = _scm.eval("(configure-mandatory-rules (Concept \"pm-rbs\"))");
+	logger().debug() << "MinerUTest::configure_mandatory_rules() rs = " << rs;
+}
+
+void MinerUTest::configure_optional_rules(TruthValuePtr incremental_expansion)
+{
+	string call = "(configure-optional-rules (Concept \"pm-rbs\") ";
+	call += "#:incremental-expansion ";
+	call += SchemeSmob::tv_to_string(incremental_expansion);
+	call += ")";
+	std::string rs = _scm.eval(call);
+	logger().debug() << "MinerUTest::configure_optional_rules() rs = " << rs;
+}
+
 MinerUTest::MinerUTest() : _scm(&_as), _tmp_scm(&_tmp_as)
 {
+	randGen().seed(0);
+
 	// Main logger
-	logger().set_level(Logger::INFO);
+	logger().set_level(Logger::DEBUG);
 	logger().set_timestamp_flag(false);
 	// logger().set_sync_flag(true);
 	logger().set_print_to_stdout_flag(true);
 
 	// URE logger
-	ure_logger().set_level(Logger::INFO);
+	ure_logger().set_level(Logger::DEBUG);
 	ure_logger().set_timestamp_flag(false);
 	// ure_logger().set_sync_flag(true);
 	ure_logger().set_print_to_stdout_flag(true);
@@ -385,8 +427,7 @@ void MinerUTest::setUp()
 	top = al(LAMBDA_LINK, X, X);
 
 	// Load URE-based pattern miner
-	std::string rs = _scm.eval("(configure-rules (Concept \"pm-rbs\"))");
-	logger().debug() << "setUp() rs = " << rs;
+	configure_mandatory_rules();
 }
 
 void MinerUTest::tearDown()
@@ -479,6 +520,39 @@ void MinerUTest::test_compose_2()
 	TS_ASSERT(content_eq(npat, expected));
 }
 
+void MinerUTest::test_expand_conjunction_1()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle result = MinerUtils::expand_conjunction(top, top),
+		expected = al(LAMBDA_LINK,
+		              al(VARIABLE_LIST, X, Y),
+		              al(AND_LINK, X, Y));
+
+	TS_ASSERT(content_eq(result, expected));
+}
+
+void MinerUTest::test_expand_conjunction_2()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle XY = al(INHERITANCE_LINK, X, Y),
+		p1 = al(LAMBDA_LINK,
+		        al(VARIABLE_LIST, X, Y),
+		        al(AND_LINK, XY, XY)),
+		p2 = al(LAMBDA_LINK,
+		        al(VARIABLE_LIST, X, Y),
+		        XY);
+
+	Handle result = MinerUtils::expand_conjunction(p1, p2),
+		ZW = al(INHERITANCE_LINK, Z, W),
+		expected = al(LAMBDA_LINK,
+		              al(VARIABLE_LIST, X, Y, Z, W),
+		              al(AND_LINK, XY, ZW));
+
+	TS_ASSERT(content_eq(result, expected));
+}
+
 void MinerUTest::test_A()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
@@ -556,7 +630,7 @@ void MinerUTest::test_AB_AC()
 
 	// Run URE pattern miner (using _as for testing more diverse
 	// content)
-	Handle ure_results = ure_pm(_as, 2, 20),
+	Handle ure_results = ure_pm(_as, 2, 40),
 		ure_expected = mk_minsup_eval(2, al(LAMBDA_LINK, Y, InhAY));
 
 	logger().debug() << "ure_results = " << oc_to_string(ure_results);
@@ -1225,29 +1299,17 @@ void MinerUTest::test_SodaDrinker_incremental()
 
 	logger().debug() << "expected = " << oc_to_string(expected);
 
-	// Run C++ pattern miner
-	HandleTree cpp_results = cpp_pm(_tmp_as,
-	                                5/*minsup*/, 1/*nconjuncts*/,
-	                                initpat, 3/*maxdepth*/, 1/*info*/);
-
-	logger().debug() << "cpp_results = " << oc_to_string(cpp_results);
-
-	// TODO: the C++ pattern miner doesn't (and might never) support
-	// incremental conjunct search.
-	TS_ASSERT(true);
-	// TS_ASSERT(content_is_in(expected, cpp_results));
-
 	// Run URE pattern miner
-	Handle ure_results = ure_pm(_tmp_as, 5, 1000, initpat),
+	TruthValuePtr incremental_expansion = SimpleTruthValue::createSTV(0.001, 1.0);
+	// VT: get rid of stupid shallow abstractions, such as ones that
+	// would change the number of conjunctions of the pattern
+	Handle ure_results = ure_pm(_tmp_as, 5, 1000, initpat, incremental_expansion, 0.1),
 		ure_expected = mk_minsup_eval(5, expected);
 
 	logger().debug() << "ure_results = " << oc_to_string(ure_results);
 	logger().debug() << "ure_expected = " << oc_to_string(ure_expected);
 
-	// TODO: the URE pattern miner doesn't support incremental conjunct
-	// search for now.
-	TS_ASSERT(true);
-	// TS_ASSERT(is_in(ure_expected, ure_results->getOutgoingSet()));
+	TS_ASSERT(is_in(ure_expected, ure_results->getOutgoingSet()));
 }
 
 void MinerUTest::xtest_lojban()

--- a/tests/learning/miner/MinerUTest.cxxtest
+++ b/tests/learning/miner/MinerUTest.cxxtest
@@ -171,6 +171,7 @@ public:
 	void test_2conjuncts_5();
 	void test_InferenceControl();
 	void test_SodaDrinker();
+	void test_SodaDrinker_incremental();
 	void xtest_lojban();         // TODO: add support
 };
 
@@ -1151,6 +1152,69 @@ void MinerUTest::test_SodaDrinker()
 	// Run C++ pattern miner
 	HandleTree cpp_results = cpp_pm(_tmp_as,
 	                                5/*minsup*/, 3/*nconjuncts*/,
+	                                initpat, 3/*maxdepth*/, 1/*info*/);
+
+	logger().debug() << "cpp_results = " << oc_to_string(cpp_results);
+
+	TS_ASSERT(content_is_in(expected, cpp_results));
+
+	// Run URE pattern miner
+	Handle ure_results = ure_pm(_tmp_as, 5, 1000, initpat),
+		ure_expected = mk_minsup_eval(5, expected);
+
+	logger().debug() << "ure_results = " << oc_to_string(ure_results);
+	logger().debug() << "ure_expected = " << oc_to_string(ure_expected);
+
+	TS_ASSERT(is_in(ure_expected, ure_results->getOutgoingSet()));
+}
+
+// Like test_SodaDrinker but starts with the most abstract pattern and
+// incrementally adds conjuncts
+void MinerUTest::test_SodaDrinker_incremental()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Define texts
+	// Load ugly-male-soda-drinker-corpus.scm
+	std::string rs =
+		_tmp_scm.eval("(load-from-path \"ugly-male-soda-drinker-corpus.scm\")");
+	logger().debug() << "rs = " << rs;
+
+	// Define initial pattern (to speed up mining)
+	Handle initpat = top;
+
+	// The pattern of interest looks like
+	//
+	// Lambda
+	//   X
+	//   And
+	//     Inheritance
+	//       X
+	//       Concept "man"
+	//     Inheritance
+	//       X
+	//       Concept "soda drinker"
+	//     Inheritance
+	//       X
+	//       Concept "ugly"
+	Handle man = an(CONCEPT_NODE, "man"),
+		soda_drinker = an(CONCEPT_NODE, "soda drinker"),
+		ugly = an(CONCEPT_NODE, "ugly"),
+		is_man = al(INHERITANCE_LINK, X, man),
+		is_soda_drinker = al(INHERITANCE_LINK, X, soda_drinker),
+		is_ugly = al(INHERITANCE_LINK, X, ugly),
+		expected = al(LAMBDA_LINK,
+		              X,
+		              al(AND_LINK,
+		                 is_man,
+		                 is_soda_drinker,
+		                 is_ugly));
+
+	logger().debug() << "expected = " << oc_to_string(expected);
+
+	// Run C++ pattern miner
+	HandleTree cpp_results = cpp_pm(_tmp_as,
+	                                5/*minsup*/, 1/*nconjuncts*/,
 	                                initpat, 3/*maxdepth*/, 1/*info*/);
 
 	logger().debug() << "cpp_results = " << oc_to_string(cpp_results);

--- a/tests/learning/miner/MinerUTest.cxxtest
+++ b/tests/learning/miner/MinerUTest.cxxtest
@@ -184,6 +184,7 @@ public:
 	void test_match();
 	void test_compose_1();
 	void test_compose_2();
+	void test_compose_3();
 	void test_expand_conjunction_disconnect();
 	void test_expand_conjunction_1();
 	void test_expand_conjunction_2();
@@ -522,6 +523,27 @@ void MinerUTest::test_compose_2()
 		                 al(EVALUATION_LINK,
 		                    gpn,
 		                    al(UNQUOTE_LINK, X))));
+
+	logger().debug() << "npat = " << oc_to_string(npat);
+	logger().debug() << "expected = " << oc_to_string(expected);
+
+	TS_ASSERT(content_eq(npat, expected));
+}
+
+void MinerUTest::test_compose_3()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle X = an(VARIABLE_NODE, "$X"),
+		Y = an(VARIABLE_NODE, "$Y"),
+		VarXY = al(VARIABLE_LIST, X, Y),
+		pattern = al(LAMBDA_LINK,
+		             al(IMPLICATION_LINK, X, Y));
+
+	Handle npat = MinerUtils::compose(pattern, {{Y, Y}}),
+		expected = al(LAMBDA_LINK,
+		              VarXY,
+		              al(IMPLICATION_LINK, X, Y));
 
 	logger().debug() << "npat = " << oc_to_string(npat);
 	logger().debug() << "expected = " << oc_to_string(expected);

--- a/tests/learning/miner/MinerUTest.cxxtest
+++ b/tests/learning/miner/MinerUTest.cxxtest
@@ -142,6 +142,24 @@ private:
 	                  const Handle& initpat=Handle::UNDEFINED,
 	                  int maxdepth=-1, double info=1.0);
 
+	/**
+	 * Build the following pattern
+	 *
+	 * Lambda
+	 *   X
+	 *   And
+	 *     Inheritance
+	 *       X
+	 *       Concept "man"
+	 *     Inheritance
+	 *       X
+	 *       Concept "soda drinker"
+	 *     Inheritance
+	 *       X
+	 *       Concept "ugly"
+	 */
+	Handle mk_ugly_soda_drinker();
+
 public:
 	MinerUTest();
 	~MinerUTest();
@@ -294,6 +312,23 @@ HandleTree MinerUTest::cpp_pm(const HandleSet& texts,
 	MinerParameters param(minsup, conjuncts, initpat, maxdepth, info);
 	Miner pm(param);
 	return pm(texts);
+}
+
+Handle MinerUTest::mk_ugly_soda_drinker()
+{
+	Handle man = an(CONCEPT_NODE, "man"),
+		soda_drinker = an(CONCEPT_NODE, "soda drinker"),
+		ugly = an(CONCEPT_NODE, "ugly"),
+		is_man = al(INHERITANCE_LINK, X, man),
+		is_soda_drinker = al(INHERITANCE_LINK, X, soda_drinker),
+		is_ugly = al(INHERITANCE_LINK, X, ugly),
+		ugly_soda_drinker = al(LAMBDA_LINK,
+		                       X,
+		                       al(AND_LINK,
+		                          is_man,
+		                          is_soda_drinker,
+		                          is_ugly));
+	return ugly_soda_drinker;
 }
 
 MinerUTest::MinerUTest() : _scm(&_as), _tmp_scm(&_tmp_as)
@@ -1134,18 +1169,7 @@ void MinerUTest::test_SodaDrinker()
 	//     Inheritance
 	//       X
 	//       Concept "ugly"
-	Handle man = an(CONCEPT_NODE, "man"),
-		soda_drinker = an(CONCEPT_NODE, "soda drinker"),
-		ugly = an(CONCEPT_NODE, "ugly"),
-		is_man = al(INHERITANCE_LINK, X, man),
-		is_soda_drinker = al(INHERITANCE_LINK, X, soda_drinker),
-		is_ugly = al(INHERITANCE_LINK, X, ugly),
-		expected = al(LAMBDA_LINK,
-		              X,
-		              al(AND_LINK,
-		                 is_man,
-		                 is_soda_drinker,
-		                 is_ugly));
+	Handle expected = mk_ugly_soda_drinker();
 
 	logger().debug() << "expected = " << oc_to_string(expected);
 
@@ -1197,18 +1221,7 @@ void MinerUTest::test_SodaDrinker_incremental()
 	//     Inheritance
 	//       X
 	//       Concept "ugly"
-	Handle man = an(CONCEPT_NODE, "man"),
-		soda_drinker = an(CONCEPT_NODE, "soda drinker"),
-		ugly = an(CONCEPT_NODE, "ugly"),
-		is_man = al(INHERITANCE_LINK, X, man),
-		is_soda_drinker = al(INHERITANCE_LINK, X, soda_drinker),
-		is_ugly = al(INHERITANCE_LINK, X, ugly),
-		expected = al(LAMBDA_LINK,
-		              X,
-		              al(AND_LINK,
-		                 is_man,
-		                 is_soda_drinker,
-		                 is_ugly));
+	Handle expected = mk_ugly_soda_drinker();
 
 	logger().debug() << "expected = " << oc_to_string(expected);
 

--- a/tests/learning/miner/MinerUTest.cxxtest
+++ b/tests/learning/miner/MinerUTest.cxxtest
@@ -691,7 +691,7 @@ void MinerUTest::test_AB_AC()
 
 	// Run URE pattern miner (using _as for testing more diverse
 	// content)
-	Handle ure_results = ure_pm(_as, 2, 40),
+	Handle ure_results = ure_pm(_as, 2, 10),
 		ure_expected = mk_minsup_eval(2, al(LAMBDA_LINK, Y, InhAY));
 
 	logger().debug() << "ure_results = " << oc_to_string(ure_results);
@@ -728,7 +728,7 @@ void MinerUTest::test_AB_AC_BC()
 	TS_ASSERT(content_eq(cpp_results, cpp_expected));
 
 	// Run URE pattern miner
-	Handle ure_results = ure_pm(texts, 2, 100),
+	Handle ure_results = ure_pm(texts, 2, 10),
 		ure_expected = mk_minsup_evals(2,
 		                               { top,
 		                                 al(LAMBDA_LINK, VarXY, InhXY),
@@ -768,7 +768,7 @@ void MinerUTest::test_AB_ABC()
 	TS_ASSERT(content_eq(cpp_results, cpp_expected));
 
 	// Run URE pattern miner
-	Handle ure_results = ure_pm(texts, 2, 100),
+	Handle ure_results = ure_pm(texts, 2, 10),
 		ure_expected = mk_minsup_evals(2,
 		                               { top,
 		                                 al(LAMBDA_LINK, VarXY, InhXY),
@@ -819,7 +819,7 @@ void MinerUTest::test_ABCD()
 	TS_ASSERT(content_eq(cpp_expected, cpp_results));
 
 	// Run URE pattern miner
-	Handle ure_results = ure_pm(texts, 2, 100, initpat),
+	Handle ure_results = ure_pm(texts, 2, 10, initpat),
 		ure_expected = mk_minsup_evals(2,
 		                               { al(LAMBDA_LINK, ImpXY),
 		                                 al(LAMBDA_LINK,
@@ -864,7 +864,7 @@ void MinerUTest::test_ABAB()
 	TS_ASSERT(content_is_in(cpp_expected, cpp_results));
 
 	// Run URE pattern miner
-	Handle ure_results = ure_pm(texts, 2, 100, initpat),
+	Handle ure_results = ure_pm(texts, 2, 10, initpat),
 		ure_expected = mk_minsup_eval(2,
 		                              al(LAMBDA_LINK,
 		                                 VarXY,
@@ -907,7 +907,7 @@ void MinerUTest::test_AAAA()
 	TS_ASSERT(content_is_in(cpp_expected, cpp_results));
 
 	// Run URE pattern miner
-	Handle ure_results = ure_pm(texts, 2, 100, initpat),
+	Handle ure_results = ure_pm(texts, 2, 50, initpat),
 		ure_expected = mk_minsup_eval(2,
 		                              al(LAMBDA_LINK,
 		                                 al(IMPLICATION_LINK,
@@ -993,7 +993,7 @@ void MinerUTest::test_2conjuncts_2()
 	TS_ASSERT(content_is_in(cpp_expected, cpp_results));
 
 	// Run URE pattern miner
-	Handle ure_results = ure_pm(texts, 2, 100, initpat),
+	Handle ure_results = ure_pm(texts, 2, 2, initpat),
 		ure_expected = mk_minsup_eval(2,
 		                              al(LAMBDA_LINK,
 		                                 VarXYZ,
@@ -1036,7 +1036,7 @@ void MinerUTest::test_2conjuncts_3()
 	TS_ASSERT(content_is_in(cpp_expected, cpp_results));
 
 	// Run URE pattern miner
-	Handle ure_results = ure_pm(texts, 2, 500, mk_nconjunct(2)),
+	Handle ure_results = ure_pm(texts, 2, 10, mk_nconjunct(2)),
 		ure_expected = mk_minsup_eval(2,
 		                              al(LAMBDA_LINK,
 		                                 VarXYZ,
@@ -1080,7 +1080,7 @@ void MinerUTest::test_2conjuncts_4()
 	TS_ASSERT(content_is_in(cpp_expected, cpp_results));
 
 	// Run URE pattern miner
-	Handle ure_results = ure_pm(texts, 4, 500, mk_nconjunct(2)),
+	Handle ure_results = ure_pm(texts, 4, 20, mk_nconjunct(2)),
 		ure_expected = mk_minsup_eval(4,
 		                              al(LAMBDA_LINK,
 		                                 VarXYZ,
@@ -1264,7 +1264,7 @@ void MinerUTest::test_InferenceControl()
 	TS_ASSERT(content_is_in(expected, cpp_results));
 
 	// Run URE pattern miner
-	Handle ure_results = ure_pm(_tmp_as, 2, 1000, initpat),
+	Handle ure_results = ure_pm(_tmp_as, 2, 200, initpat),
 		ure_expected = mk_minsup_eval(2, expected);
 
 	logger().debug() << "ure_results = " << oc_to_string(ure_results);
@@ -1318,7 +1318,7 @@ void MinerUTest::test_SodaDrinker()
 	TS_ASSERT(content_is_in(expected, cpp_results));
 
 	// Run URE pattern miner
-	Handle ure_results = ure_pm(_tmp_as, 5, 1000, initpat),
+	Handle ure_results = ure_pm(_tmp_as, 5, 100, initpat),
 		ure_expected = mk_minsup_eval(5, expected);
 
 	logger().debug() << "ure_results = " << oc_to_string(ure_results);

--- a/tests/learning/miner/MinerUTest.cxxtest
+++ b/tests/learning/miner/MinerUTest.cxxtest
@@ -1232,7 +1232,10 @@ void MinerUTest::test_SodaDrinker_incremental()
 
 	logger().debug() << "cpp_results = " << oc_to_string(cpp_results);
 
-	TS_ASSERT(content_is_in(expected, cpp_results));
+	// TODO: the C++ pattern miner doesn't (and might never) support
+	// incremental conjunct search.
+	TS_ASSERT(true);
+	// TS_ASSERT(content_is_in(expected, cpp_results));
 
 	// Run URE pattern miner
 	Handle ure_results = ure_pm(_tmp_as, 5, 1000, initpat),
@@ -1241,7 +1244,10 @@ void MinerUTest::test_SodaDrinker_incremental()
 	logger().debug() << "ure_results = " << oc_to_string(ure_results);
 	logger().debug() << "ure_expected = " << oc_to_string(ure_expected);
 
-	TS_ASSERT(is_in(ure_expected, ure_results->getOutgoingSet()));
+	// TODO: the URE pattern miner doesn't support incremental conjunct
+	// search for now.
+	TS_ASSERT(true);
+	// TS_ASSERT(is_in(ure_expected, ure_results->getOutgoingSet()));
 }
 
 void MinerUTest::xtest_lojban()

--- a/tests/learning/miner/MinerUTest.cxxtest
+++ b/tests/learning/miner/MinerUTest.cxxtest
@@ -130,10 +130,12 @@ private:
 	Handle ure_pm(const AtomSpace& texts_as, int minsup,
 	              int max_iter=-1, Handle initpat=Handle::UNDEFINED,
 	              TruthValuePtr incremental_expansion=TruthValue::FALSE_TV(),
+	              int max_conjuncts=-1,
 	              double complexity_penalty=0.0);
 	Handle ure_pm(const HandleSet& texts, int minsup,
 	              int max_iter=-1, Handle initpat=Handle::UNDEFINED,
 	              TruthValuePtr incremental_expansion=TruthValue::FALSE_TV(),
+	              int max_conjuncts=-1,
 	              double complexity_penalty=0.0);
 
 	/**
@@ -167,7 +169,8 @@ private:
 	Handle mk_ugly_soda_drinker();
 
 	void configure_mandatory_rules();
-	void configure_optional_rules(TruthValuePtr incremental_expansion);
+	void configure_optional_rules(TruthValuePtr incremental_expansion,
+	                              int max_conjuncts=-1);
 
 public:
 	MinerUTest();
@@ -181,6 +184,7 @@ public:
 	void test_match();
 	void test_compose_1();
 	void test_compose_2();
+	void test_expand_conjunction_disconnect();
 	void test_expand_conjunction_1();
 	void test_expand_conjunction_2();
 
@@ -257,18 +261,20 @@ HandleSeq MinerUTest::gen_variables(const std::string& prefix, int n)
 Handle MinerUTest::ure_pm(const AtomSpace& texts_as, int minsup,
                           int maxiter, Handle initpat,
                           TruthValuePtr incremental_expansion,
+                          int max_conjuncts,
                           double complexity_penalty)
 {
 	HandleSet texts;
 	texts_as.get_handles_by_type(std::inserter(texts, texts.end()),
 	                             opencog::ATOM, true);
 	return ure_pm(texts, minsup, maxiter, initpat,
-	              incremental_expansion, complexity_penalty);
+	              incremental_expansion, max_conjuncts, complexity_penalty);
 }
 
 Handle MinerUTest::ure_pm(const HandleSet& texts, int minsup,
                           int maxiter, Handle initpat,
                           TruthValuePtr incremental_expansion,
+                          int max_conjuncts,
                           double complexity_penalty)
 {
 	// Make (Member text (Concept "texts)) links
@@ -290,7 +296,7 @@ Handle MinerUTest::ure_pm(const HandleSet& texts, int minsup,
 	// Add incremental conjunction expansion if necessary
 	bool inc_exp_enabled = incremental_expansion != TruthValue::FALSE_TV();
 	if (inc_exp_enabled)
-		configure_optional_rules(incremental_expansion);
+		configure_optional_rules(incremental_expansion, max_conjuncts);
 
 	// Otherwise prepare the source
 	TruthValuePtr tv = TruthValue::TRUE_TV();
@@ -361,11 +367,14 @@ void MinerUTest::configure_mandatory_rules()
 	logger().debug() << "MinerUTest::configure_mandatory_rules() rs = " << rs;
 }
 
-void MinerUTest::configure_optional_rules(TruthValuePtr incremental_expansion)
+void MinerUTest::configure_optional_rules(TruthValuePtr incremental_expansion,
+                                          int max_conjuncts)
 {
-	string call = "(configure-optional-rules (Concept \"pm-rbs\") ";
-	call += "#:incremental-expansion ";
+	string call = "(configure-optional-rules (Concept \"pm-rbs\")";
+	call += " #:incremental-expansion ";
 	call += SchemeSmob::tv_to_string(incremental_expansion);
+	call += " #:max-conjuncts ";
+	call += std::to_string(max_conjuncts);
 	call += ")";
 	std::string rs = _scm.eval(call);
 	logger().debug() << "MinerUTest::configure_optional_rules() rs = " << rs;
@@ -376,13 +385,13 @@ MinerUTest::MinerUTest() : _scm(&_as), _tmp_scm(&_tmp_as)
 	randGen().seed(0);
 
 	// Main logger
-	logger().set_level(Logger::DEBUG);
+	logger().set_level(Logger::INFO);
 	logger().set_timestamp_flag(false);
 	// logger().set_sync_flag(true);
 	// logger().set_print_to_stdout_flag(true);
 
 	// URE logger
-	ure_logger().set_level(Logger::DEBUG);
+	ure_logger().set_level(Logger::INFO);
 	ure_logger().set_timestamp_flag(false);
 	// ure_logger().set_sync_flag(true);
 	// ure_logger().set_print_to_stdout_flag(true);
@@ -520,11 +529,11 @@ void MinerUTest::test_compose_2()
 	TS_ASSERT(content_eq(npat, expected));
 }
 
-void MinerUTest::test_expand_conjunction_1()
+void MinerUTest::test_expand_conjunction_disconnect()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-	Handle result = MinerUtils::expand_conjunction(top, top),
+	Handle result = MinerUtils::expand_conjunction_disconnect(top, top),
 		expected = al(LAMBDA_LINK,
 		              al(VARIABLE_LIST, X, Y),
 		              al(AND_LINK, X, Y));
@@ -532,25 +541,77 @@ void MinerUTest::test_expand_conjunction_1()
 	TS_ASSERT(content_eq(result, expected));
 }
 
+void MinerUTest::test_expand_conjunction_1()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Texts
+	Handle
+		InhAB = al(INHERITANCE_LINK, A, B),
+		InhBC = al(INHERITANCE_LINK, B, C);
+	HandleSet texts{InhAB, InhBC};
+
+	Handle InhXY = al(INHERITANCE_LINK, X, Y),
+		VarXY = al(VARIABLE_LIST, X, Y),
+		p1 = al(LAMBDA_LINK,
+		        VarXY,
+		        al(AND_LINK, InhXY, InhXY)),
+		p2 = al(LAMBDA_LINK,
+		         VarXY,
+		         InhXY);
+
+	HandleSet results = MinerUtils::expand_conjunction(p1, p2, texts, 1);
+	Handle
+		InhXW = al(INHERITANCE_LINK, X, W),
+		InhZX = al(INHERITANCE_LINK, Z, X),
+		InhYW = al(INHERITANCE_LINK, Y, W),
+		InhZY = al(INHERITANCE_LINK, Z, Y),
+		VarXYW = al(VARIABLE_LIST, X, Y, W),
+		VarXYZ = al(VARIABLE_LIST, X, Y, Z),
+		InhXYXW = al(LAMBDA_LINK,
+		             VarXYW,
+		             al(AND_LINK, InhXY, InhXW)),
+		InhXYZX = al(LAMBDA_LINK,
+		             VarXYZ,
+		             al(AND_LINK, InhXY, InhZX)),
+		InhXYYW = al(LAMBDA_LINK,
+		             VarXYW,
+		             al(AND_LINK, InhXY, InhYW)),
+		InhXYZY = al(LAMBDA_LINK,
+		             VarXYZ,
+		             al(AND_LINK, InhXY, InhZY));
+	HandleSet expected{InhXYXW, InhXYZX, InhXYYW, InhXYZY};
+
+	logger().debug() << "results = " << oc_to_string(results);
+	logger().debug() << "expected = " << oc_to_string(expected);
+
+	TS_ASSERT(content_eq(results, expected));
+}
+
 void MinerUTest::test_expand_conjunction_2()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-	Handle XY = al(INHERITANCE_LINK, X, Y),
-		p1 = al(LAMBDA_LINK,
-		        al(VARIABLE_LIST, X, Y),
-		        al(AND_LINK, XY, XY)),
-		p2 = al(LAMBDA_LINK,
-		        al(VARIABLE_LIST, X, Y),
-		        XY);
+	// Texts
+	Handle
+		InhAC = al(INHERITANCE_LINK, A, C),
+		InhBC = al(INHERITANCE_LINK, B, C);
+	HandleSet texts{InhAC, InhBC};
 
-	Handle result = MinerUtils::expand_conjunction(p1, p2),
-		ZW = al(INHERITANCE_LINK, Z, W),
-		expected = al(LAMBDA_LINK,
-		              al(VARIABLE_LIST, X, Y, Z, W),
-		              al(AND_LINK, XY, ZW));
+	Handle InhXC = al(INHERITANCE_LINK, X, C),
+		pat = al(LAMBDA_LINK,
+		         X,
+		         InhXC);
 
-	TS_ASSERT(content_eq(result, expected));
+	HandleSet results = MinerUtils::expand_conjunction(pat, pat, texts, 1);
+	// Empty because the only result is equal to pat, thus rejected as
+	// worthwhile expansion
+	HandleSet expected{};
+
+	logger().debug() << "results = " << oc_to_string(results);
+	logger().debug() << "expected = " << oc_to_string(expected);
+
+	TS_ASSERT(content_eq(results, expected));
 }
 
 void MinerUTest::test_A()
@@ -1301,7 +1362,13 @@ void MinerUTest::test_SodaDrinker_incremental()
 
 	// Run URE pattern miner
 	TruthValuePtr incremental_expansion = SimpleTruthValue::createSTV(0.0001, 1.0);
-	Handle ure_results = ure_pm(_tmp_as, 5, 10000, initpat, incremental_expansion, 10),
+	int max_conjuncts = 3;
+	double complexity_penalty = 1;
+	Handle ure_results = ure_pm(_tmp_as, 5, 100,
+	                            initpat,
+	                            incremental_expansion,
+	                            max_conjuncts,
+	                            complexity_penalty),
 		ure_expected = mk_minsup_eval(5, expected);
 
 	logger().debug() << "ure_results = " << oc_to_string(ure_results);

--- a/tests/learning/miner/MinerUTest.cxxtest
+++ b/tests/learning/miner/MinerUTest.cxxtest
@@ -1115,7 +1115,7 @@ void MinerUTest::test_2conjuncts_3()
 	TS_ASSERT(content_is_in(cpp_expected, cpp_results));
 
 	// Run URE pattern miner
-	Handle ure_results = ure_pm(texts, 2, 20, mk_nconjunct(2)),
+	Handle ure_results = ure_pm(texts, 2, 50, mk_nconjunct(2)),
 		ure_expected = mk_minsup_eval(2,
 		                              al(LAMBDA_LINK,
 		                                 VarXYZ,
@@ -1159,7 +1159,7 @@ void MinerUTest::test_2conjuncts_4()
 	TS_ASSERT(content_is_in(cpp_expected, cpp_results));
 
 	// Run URE pattern miner
-	Handle ure_results = ure_pm(texts, 4, 50, mk_nconjunct(2)),
+	Handle ure_results = ure_pm(texts, 4, 100, mk_nconjunct(2)),
 		ure_expected = mk_minsup_eval(4,
 		                              al(LAMBDA_LINK,
 		                                 VarXYZ,
@@ -1443,7 +1443,7 @@ void MinerUTest::test_SodaDrinker_incremental()
 	TruthValuePtr incremental_expansion = SimpleTruthValue::createSTV(0.0001, 1.0);
 	int max_conjuncts = 3;
 	double complexity_penalty = 1;
-	Handle ure_results = ure_pm(_tmp_as, 5, 100,
+	Handle ure_results = ure_pm(_tmp_as, 5, 200,
 	                            initpat,
 	                            incremental_expansion,
 	                            max_conjuncts,

--- a/tests/learning/miner/MinerUTest.cxxtest
+++ b/tests/learning/miner/MinerUTest.cxxtest
@@ -379,13 +379,13 @@ MinerUTest::MinerUTest() : _scm(&_as), _tmp_scm(&_tmp_as)
 	logger().set_level(Logger::DEBUG);
 	logger().set_timestamp_flag(false);
 	// logger().set_sync_flag(true);
-	logger().set_print_to_stdout_flag(true);
+	// logger().set_print_to_stdout_flag(true);
 
 	// URE logger
 	ure_logger().set_level(Logger::DEBUG);
 	ure_logger().set_timestamp_flag(false);
 	// ure_logger().set_sync_flag(true);
-	ure_logger().set_print_to_stdout_flag(true);
+	// ure_logger().set_print_to_stdout_flag(true);
 
 	// Configure scheme load-paths that are common for all tests.
 	_scm.eval("(add-to-load-path \"" PROJECT_SOURCE_DIR
@@ -1300,10 +1300,8 @@ void MinerUTest::test_SodaDrinker_incremental()
 	logger().debug() << "expected = " << oc_to_string(expected);
 
 	// Run URE pattern miner
-	TruthValuePtr incremental_expansion = SimpleTruthValue::createSTV(0.001, 1.0);
-	// VT: get rid of stupid shallow abstractions, such as ones that
-	// would change the number of conjunctions of the pattern
-	Handle ure_results = ure_pm(_tmp_as, 5, 1000, initpat, incremental_expansion, 0.1),
+	TruthValuePtr incremental_expansion = SimpleTruthValue::createSTV(0.0001, 1.0);
+	Handle ure_results = ure_pm(_tmp_as, 5, 10000, initpat, incremental_expansion, 10),
 		ure_expected = mk_minsup_eval(5, expected);
 
 	logger().debug() << "ure_results = " << oc_to_string(ure_results);

--- a/tests/learning/miner/MinerUTest.cxxtest
+++ b/tests/learning/miner/MinerUTest.cxxtest
@@ -26,6 +26,7 @@
 
 #include <opencog/util/Config.h>
 #include <opencog/util/algorithm.h>
+#include <opencog/util/random.h>
 #include <opencog/truthvalue/TruthValue.h>
 #include <opencog/truthvalue/SimpleTruthValue.h>
 #include <opencog/atomspace/AtomSpace.h>

--- a/tests/pln/MOSESPLNSynergyUTest.cxxtest
+++ b/tests/pln/MOSESPLNSynergyUTest.cxxtest
@@ -80,12 +80,13 @@ void MOSESPLNSynergyUTest::tearDown()
 
 void MOSESPLNSynergyUTest::setUp()
 {
-	string cur_pp_dir = string(PROJECT_SOURCE_DIR),
+	std::string cur_pp_dir = std::string(PROJECT_SOURCE_DIR),
 		cur_dir = cur_pp_dir + "/tests/pln";
-	vector<string> load_paths = {cur_pp_dir, cur_dir};
-	for (string& p : load_paths)
+	std::vector<std::string> load_paths = {cur_pp_dir, cur_dir};
+	for (std::string& p : load_paths)
 	{
-		string eval_str = string("(add-to-load-path \"") + p + string("\")");
+		std::string eval_str =
+			std::string("(add-to-load-path \"") + p + std::string("\")");
 		eval.eval(eval_str);
 	}
 


### PR DESCRIPTION
From https://github.com/singnet/opencog/pull/44

The URE pattern miner can now efficiently begin with a 1-conjunct (1-gram) pattern and incrementally grow patterns to more conjuncts (n-gram).

It has gone through major optimizations as well (~8x faster)

1. The shallow-abstraction specialization rule pair has been packed into a single shallow-specialization rule.
2. Any redundant support checking has been eliminated.
3. Relies on better forward chainer control.
4. And more (including fixing some bugs as well).

The URE pattern miner is now a bit faster (~1.5x) than it's C++ counter part (mainly due to better forward chainer control). :-)