### PR TITLE
Fix optional-wildcard pattern handling in Ghost

### DIFF
--- a/opencog/ghost/translator.scm
+++ b/opencog/ghost/translator.scm
@@ -99,10 +99,6 @@
                         (equal? (cadr term) (cons 'wildcard (cons 0 -1)))
                         (equal? 'wildcard (car (first prev))))
                    (cons term (cdr prev)))
-                  ; Same as the above, but for optionals
-                  ((and (equal? 'optionals (car term))
-                        (equal? 'wildcard (car (first prev))))
-                   (cons term (cdr prev)))
                   ; Similarly if there is a wildcard followed by a variable
                   ; that matches to "zero or more", e.g.
                   ; (wildcard 0 . -1) (variable (wildcard 0 . -1))


### PR DESCRIPTION
This includes https://github.com/singnet/opencog/pull/35, and fixes #3268 