### PR TITLE
Correct atom_types refs

### DIFF
--- a/opencog/attention/AttentionParamQuery.cc
+++ b/opencog/attention/AttentionParamQuery.cc
@@ -1,5 +1,5 @@
 
-#include <opencog/atoms/value/NameServer.h>
+#include <opencog/atoms/atom_types/NameServer.h>
 #include <opencog/atomutils/Neighbors.h>
 #include <opencog/atoms/base/Link.h>
 #include <opencog/guile/SchemeEval.h>
@@ -119,5 +119,5 @@ HandleSeq AttentionParamQuery::get_params(void)
 void AttentionParamQuery::load_default_values(void)
 {
      SchemeEval scm(_as);
-     scm.eval("(load \"" GUILE_SITE_DIR "/opencog/attention/default-param-values.scm\")");
+     scm.eval("(load \" GUILE_SITE_DIR/opencog/attention/default-param-values.scm\")");
 }

--- a/opencog/attention/AttentionParamQuery.h
+++ b/opencog/attention/AttentionParamQuery.h
@@ -27,7 +27,7 @@
 
 #include <sstream>
 #include <string>
-#include <opencog/atoms/value/atom_types.h>
+#include <opencog/atoms/atom_types/atom_types.h>
 #include <opencog/atomspace/AtomSpace.h>
 
 namespace opencog

--- a/opencog/attention/AttentionUtils.cc
+++ b/opencog/attention/AttentionUtils.cc
@@ -1,5 +1,5 @@
 #include "AttentionUtils.h"
-#include <opencog/atoms/value/NameServer.h>
+#include <opencog/atoms/atom_types/NameServer.h>
 #include <opencog/attention/atom_types.h>
 
 namespace opencog

--- a/opencog/attention/CMakeLists.txt
+++ b/opencog/attention/CMakeLists.txt
@@ -25,6 +25,7 @@ TARGET_LINK_LIBRARIES(attention-types
 	${ATOMSPACE_atomcore_LIBRARY}
 	${ATOMSPACE_atombase_LIBRARY}
 	${ATOMSPACE_atomproto_LIBRARY}
+	${ATOMSPACE_atomtypes_LIBRARY}
 )
 
 # --------------------------------------------------

--- a/opencog/attention/HebbianCreationAgent.cc
+++ b/opencog/attention/HebbianCreationAgent.cc
@@ -22,7 +22,7 @@
 #include <opencog/util/Config.h>
 #include <opencog/util/algorithm.h>
 
-#include <opencog/atoms/value/NameServer.h>
+#include <opencog/atoms/atom_types/NameServer.h>
 #include <opencog/atoms/base/Link.h>
 #include <opencog/truthvalue/IndefiniteTruthValue.h>
 #include <opencog/truthvalue/SimpleTruthValue.h>

--- a/opencog/attention/atom_types_init.cc
+++ b/opencog/attention/atom_types_init.cc
@@ -25,4 +25,4 @@
 #define INHERITANCE_FILE "opencog/attention/atom_types.inheritance"
 #define INITNAME attention_types_init
 
-#include <opencog/atoms/value/atom_types.cc>
+#include <opencog/atoms/atom_types/atom_types.cc>

--- a/opencog/cogserver/modules/events/AtomSpacePublisherModule.cc
+++ b/opencog/cogserver/modules/events/AtomSpacePublisherModule.cc
@@ -35,7 +35,7 @@
 #include <opencog/util/Logger.h>
 #include <opencog/util/tbb.h>
 
-#include <opencog/atoms/value/NameServer.h>
+#include <opencog/atoms/atom_types/NameServer.h>
 
 #include <opencog/truthvalue/ProbabilisticTruthValue.h>
 #include <opencog/truthvalue/FuzzyTruthValue.h>

--- a/opencog/cogserver/server/ListRequest.cc
+++ b/opencog/cogserver/server/ListRequest.cc
@@ -25,8 +25,8 @@
 #include "ListRequest.h"
 
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/atoms/value/NameServer.h>
-#include <opencog/atoms/value/types.h>
+#include <opencog/atoms/atom_types/NameServer.h>
+#include <opencog/atoms/atom_types/types.h>
 #include <opencog/cogserver/server/CogServer.h>
 
 using namespace opencog;

--- a/opencog/learning/PatternMiner/PatternMiner.cc
+++ b/opencog/learning/PatternMiner/PatternMiner.cc
@@ -43,7 +43,7 @@
 
 #include <opencog/atoms/base/ClassServer.h>
 #include <opencog/atoms/base/Handle.h>
-#include <opencog/atoms/value/atom_types.h>
+#include <opencog/atoms/atom_types/atom_types.h>
 #include <opencog/query/BindLinkAPI.h>
 
 #include "PatternMiner.h"

--- a/opencog/learning/PatternMiner/PatternMinerDF.cc
+++ b/opencog/learning/PatternMiner/PatternMinerDF.cc
@@ -34,7 +34,7 @@
 #include <thread>
 
 #include <opencog/atoms/base/Handle.h>
-#include <opencog/atoms/value/atom_types.h>
+#include <opencog/atoms/atom_types/atom_types.h>
 #include <opencog/util/Config.h>
 #include <opencog/util/algorithm.h>
 

--- a/opencog/learning/PatternMiner/PatternMinerDistributedWorker.cc
+++ b/opencog/learning/PatternMiner/PatternMinerDistributedWorker.cc
@@ -35,7 +35,7 @@
 #include <ifaddrs.h>
 
 #include <opencog/atoms/base/Handle.h>
-#include <opencog/atoms/value/atom_types.h>
+#include <opencog/atoms/atom_types/atom_types.h>
 #include <opencog/query/BindLinkAPI.h>
 #include <opencog/util/Config.h>
 #include <opencog/util/algorithm.h>

--- a/opencog/learning/PatternMiner/PatternMinerSCM.cc
+++ b/opencog/learning/PatternMiner/PatternMinerSCM.cc
@@ -27,7 +27,7 @@
 #ifndef _OPENCOG_PATTERNMINER_SCM_H
 #define _OPENCOG_PATTERNMINER_SCM_H
 
-#include <opencog/atoms/value/NameServer.h>
+#include <opencog/atoms/atom_types/NameServer.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/learning/PatternMiner/PatternMiner.h>
 

--- a/opencog/learning/PatternMiner/types/PatternMinerTypes.cc
+++ b/opencog/learning/PatternMiner/types/PatternMinerTypes.cc
@@ -10,4 +10,4 @@
 #define INHERITANCE_FILE "opencog/learning/PatternMiner/types/atom_types.inheritance"
 #define INITNAME patternminer_types_init
 
-#include <opencog/atoms/value/atom_types.cc>
+#include <opencog/atoms/atom_types/atom_types.cc>

--- a/opencog/learning/dimensionalembedding/DimEmbedModule.cc
+++ b/opencog/learning/dimensionalembedding/DimEmbedModule.cc
@@ -30,7 +30,7 @@
 #include <utility>
 
 #include <opencog/atomspaceutils/AtomSpaceUtils.h>
-#include <opencog/atoms/value/NameServer.h>
+#include <opencog/atoms/atom_types/NameServer.h>
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atoms/base/Node.h>
 #include <opencog/truthvalue/SimpleTruthValue.h>

--- a/opencog/learning/pattern-index/PatternIndexAPI.cc
+++ b/opencog/learning/pattern-index/PatternIndexAPI.cc
@@ -4,7 +4,7 @@
 #include <sstream>
 #include <iostream>
 
-#include <opencog/atoms/value/NameServer.h>
+#include <opencog/atoms/atom_types/NameServer.h>
 #include <opencog/guile/SchemePrimitive.h>
 #include <opencog/util/Config.h>
 #include "SCMLoader.h"

--- a/opencog/learning/pattern-index/TypeFrame.cc
+++ b/opencog/learning/pattern-index/TypeFrame.cc
@@ -1,5 +1,5 @@
 #include "TypeFrame.h"
-#include <opencog/atoms/value/NameServer.h>
+#include <opencog/atoms/atom_types/NameServer.h>
 
 using namespace opencog;
 using namespace std;

--- a/opencog/nlp/chatbot-old/question/FrameQuery.cc
+++ b/opencog/nlp/chatbot-old/question/FrameQuery.cc
@@ -26,7 +26,7 @@
 
 #include <stdio.h>
 
-#include <opencog/atoms/value/NameServer.h>
+#include <opencog/atoms/atom_types/NameServer.h>
 #include <opencog/atomspace/Node.h>
 #include <opencog/util/platform.h>
 

--- a/opencog/nlp/chatbot-old/question/WordRelQuery.cc
+++ b/opencog/nlp/chatbot-old/question/WordRelQuery.cc
@@ -38,7 +38,7 @@
 
 #include <stdio.h>
 
-#include <opencog/atoms/value/NameServer.h>
+#include <opencog/atoms/atom_types/NameServer.h>
 #include <opencog/atomspace/ForeachChaseLink.h>
 #include <opencog/atomspace/Node.h>
 

--- a/opencog/nlp/lg-dict/LGDictEntry.cc
+++ b/opencog/nlp/lg-dict/LGDictEntry.cc
@@ -21,7 +21,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/atoms/value/NameServer.h>
+#include <opencog/atoms/atom_types/NameServer.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include "LGDictNode.h"
 #include "LGDictEntry.h"

--- a/opencog/nlp/lg-dict/LGDictNode.cc
+++ b/opencog/nlp/lg-dict/LGDictNode.cc
@@ -23,7 +23,7 @@
 #include <mutex>
 
 #include <link-grammar/link-includes.h>
-#include <opencog/atoms/value/NameServer.h>
+#include <opencog/atoms/atom_types/NameServer.h>
 #include <opencog/util/Logger.h>
 #include <opencog/nlp/types/atom_types.h>
 

--- a/opencog/nlp/lg-parse/LGParseLink.cc
+++ b/opencog/nlp/lg-parse/LGParseLink.cc
@@ -25,7 +25,7 @@
 #include <uuid/uuid.h>
 #include <link-grammar/link-includes.h>
 
-#include <opencog/atoms/value/NameServer.h>
+#include <opencog/atoms/atom_types/NameServer.h>
 #include <opencog/atoms/base/Node.h>
 #include <opencog/atoms/core/NumberNode.h>
 #include <opencog/atomspace/AtomSpace.h>

--- a/opencog/nlp/sureal/SuRealCache.cc
+++ b/opencog/nlp/sureal/SuRealCache.cc
@@ -23,7 +23,7 @@
 
 #include "SuRealCache.h"
 
-#include <opencog/atoms/value/NameServer.h>
+#include <opencog/atoms/atom_types/NameServer.h>
 #include <opencog/atoms/base/Atom.h>
 
 using namespace opencog::nlp;

--- a/opencog/nlp/types/NLPTypes.cc
+++ b/opencog/nlp/types/NLPTypes.cc
@@ -11,4 +11,4 @@
 #define INHERITANCE_FILE "opencog/nlp/types/atom_types.inheritance"
 #define INITNAME nlp_types_init
 
-#include <opencog/atoms/value/atom_types.cc>
+#include <opencog/atoms/atom_types/atom_types.cc>

--- a/opencog/nlp/wsd/ForeachWord.h
+++ b/opencog/nlp/wsd/ForeachWord.h
@@ -19,7 +19,7 @@
 #include <opencog/atomutils/FollowLink.h>
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atoms/base/Node.h>
-#include <opencog/atoms/value/atom_types.h>
+#include <opencog/atoms/atom_types/atom_types.h>
 #include <opencog/nlp/types/atom_types.h>
 
 namespace opencog {

--- a/opencog/nlp/wsd/NNAdjust.cc
+++ b/opencog/nlp/wsd/NNAdjust.cc
@@ -14,7 +14,7 @@
 #include <stdio.h>
 
 #include <opencog/util/platform.h>
-#include <opencog/atoms/value/NameServer.h>
+#include <opencog/atoms/atom_types/NameServer.h>
 #include <opencog/truthvalue/SimpleTruthValue.h>
 #include <opencog/nlp/wsd/ForeachWord.h>
 

--- a/opencog/nlp/wsd/ReportRank.cc
+++ b/opencog/nlp/wsd/ReportRank.cc
@@ -10,7 +10,7 @@
 
 #include <stdio.h>
 
-#include <opencog/atoms/value/types.h>
+#include <opencog/atoms/atom_types/types.h>
 #include <opencog/atoms/base/Node.h>
 #include <opencog/truthvalue/CountTruthValue.h>
 #include <opencog/truthvalue/TruthValue.h>

--- a/opencog/nlp/wsd/Sweep.h
+++ b/opencog/nlp/wsd/Sweep.h
@@ -14,7 +14,7 @@
 #include <set>
 
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/atoms/value/types.h>
+#include <opencog/atoms/atom_types/types.h>
 
 namespace opencog {
 

--- a/opencog/openpsi/OpenPsiImplicator.cc
+++ b/opencog/openpsi/OpenPsiImplicator.cc
@@ -19,7 +19,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/atoms/value/NameServer.h>
+#include <opencog/atoms/atom_types/NameServer.h>
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atoms/execution/Instantiator.h>
 

--- a/opencog/openpsi/OpenPsiRules.cc
+++ b/opencog/openpsi/OpenPsiRules.cc
@@ -19,7 +19,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/atoms/value/NameServer.h>
+#include <opencog/atoms/atom_types/NameServer.h>
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atoms/base/Node.h>
 

--- a/opencog/spacetime/atom-types/CMakeLists.txt
+++ b/opencog/spacetime/atom-types/CMakeLists.txt
@@ -14,6 +14,7 @@ TARGET_LINK_LIBRARIES(spacetime-types
 	${ATOMSPACE_atomcore_LIBRARY}
 	${ATOMSPACE_atombase_LIBRARY}
 	${ATOMSPACE_atomproto_LIBRARY}
+	${ATOMSPACE_atomtypes_LIBRARY}
 )
 
 ADD_DEPENDENCIES(spacetime-types spacetime_atom_types)

--- a/opencog/spacetime/atom-types/atom_types_init.cc
+++ b/opencog/spacetime/atom-types/atom_types_init.cc
@@ -26,4 +26,4 @@
 #define INHERITANCE_FILE "opencog/spacetime/atom-types/atom_types.inheritance"
 #define INITNAME spacetime_types_init
 
-#include <opencog/atoms/value/atom_types.cc>
+#include <opencog/atoms/atom_types/atom_types.cc>

--- a/opencog/visualization/dotty/DottyModule.cc
+++ b/opencog/visualization/dotty/DottyModule.cc
@@ -28,7 +28,7 @@
 
 #include <boost/pointer_cast.hpp>
 
-#include <opencog/atoms/value/NameServer.h>
+#include <opencog/atoms/atom_types/NameServer.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atoms/base/Node.h>

--- a/opencog/visualization/tulip/TulipWriter.cc
+++ b/opencog/visualization/tulip/TulipWriter.cc
@@ -21,7 +21,7 @@
 #include <time.h>
 #include <sstream>
 
-#include <opencog/atoms/value/NameServer.h>
+#include <opencog/atoms/atom_types/NameServer.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/cogserver/server/CogServer.h>
 

--- a/tests/persist/zmq/events/AtomSpacePublisherModuleUTest.cxxtest
+++ b/tests/persist/zmq/events/AtomSpacePublisherModuleUTest.cxxtest
@@ -34,7 +34,7 @@
 #include <opencog/util/Config.h>
 
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/atoms/value/types.h>
+#include <opencog/atoms/atom_types/types.h>
 #include <opencog/attention/atom_types.h>
 #include <opencog/truthvalue/TruthValue.h>
 #include <opencog/truthvalue/SimpleTruthValue.h>


### PR DESCRIPTION
Corresponding fix for [atomspace PR](https://github.com/opencog/atomspace/pull/1947). 
As per [https://github.com/opencog/atomspace/pull/1930](https://github.com/opencog/atomspace/pull/1930)