### PR TITLE
Fix tense-matching in SuReal

### DIFF
--- a/opencog/nlp/sureal/SuRealPMCB.cc
+++ b/opencog/nlp/sureal/SuRealPMCB.cc
@@ -346,14 +346,13 @@ bool SuRealPMCB::grounding(const HandleMap &var_soln, const HandleMap &pred_soln
     HandleSeq qItprNode = getInterpretation(pred_soln.begin()->second);
     std::sort(qItprNode.begin(), qItprNode.end());
 
-    logger().debug("[SuReal] In grounding, trying to find a common interpretation between:\n%s",
-        (pred_soln.begin()->second)->to_short_string().c_str());
+    string debug_str = (pred_soln.begin()->second)->to_short_string();
 
     // try to find a common InterpretationNode to the solutions
     // i.e. all the solution-clauses have to come from the same interpretation (of a sentence)
     for (HandleMap::const_iterator it = ++pred_soln.begin(); it != pred_soln.end(); ++it)
     {
-        logger().debug("[SuReal] ...and:\n%s", it->second->to_short_string().c_str());
+        debug_str.append(it->second->to_short_string());
 
         HandleSeq thisSeq = getInterpretation(it->second);
         std::sort(thisSeq.begin(), thisSeq.end());
@@ -363,6 +362,9 @@ bool SuRealPMCB::grounding(const HandleMap &var_soln, const HandleMap &pred_soln
 
         qItprNode = overlapSeq;
     }
+
+    logger().debug("[SuReal] In grounding, trying to find a common interpretation between:\n%s",
+      debug_str.c_str());
 
     // no common InterpretationNode, ignore this grounding
     if (qItprNode.empty()) {
@@ -424,6 +426,9 @@ bool SuRealPMCB::grounding(const HandleMap &var_soln, const HandleMap &pred_soln
             // not a lemma, so just do a disjunct match for it
             if (qLemmaLinks.size() == 0)
             {
+                logger().debug("[SuReal] In grounding, this predicate is probably not a lemma: %s",
+                  hPatWord->to_short_string().c_str());
+
                 // reject it if disjuncts do not match
                 if (not disjunct_match(hPatWord, hSolnWordInst)) {
                     if (m_use_cache) {
@@ -445,6 +450,9 @@ bool SuRealPMCB::grounding(const HandleMap &var_soln, const HandleMap &pred_soln
             // and do a disjunct match for each of them
             else
             {
+                logger().debug("[SuReal] In grounding, this predicate is a lemma: %s",
+                  hPatWord->to_short_string().c_str());
+
                 bool found = false;
                 std::set<std::string> qChkWords;
 

--- a/opencog/nlp/sureal/SuRealPMCB.cc
+++ b/opencog/nlp/sureal/SuRealPMCB.cc
@@ -454,7 +454,6 @@ bool SuRealPMCB::grounding(const HandleMap &var_soln, const HandleMap &pred_soln
                   hPatWord->to_short_string().c_str());
 
                 bool found = false;
-                std::set<std::string> qChkWords;
 
                 for (LinkPtr lpll : qLemmaLinks)
                 {
@@ -466,11 +465,6 @@ bool SuRealPMCB::grounding(const HandleMap &var_soln, const HandleMap &pred_soln
 
                     std::string sName = qOS[0]->get_name();
                     std::string sWord = get_target_neighbors(qOS[0], REFERENCE_LINK)[0]->get_name();
-
-                    // Skip if we have seen it before
-                    if (std::find(qChkWords.begin(), qChkWords.end(), sWord) != qChkWords.end())
-                        continue;
-                    else qChkWords.insert(sWord);
 
                     // make sure the tense matches
                     // first get the tense of the solution instance node


### PR DESCRIPTION
One part of the code checks if a word with the corresponding tense exists by tracing LemmaLinks, and cache the result. But some words, e.g. "read", can be in present tense, past tense... etc, caching one result and skipping the rest could be problematic.