### PR TITLE
Revert some of the changes in opencog/opencog#3383

### DIFF
--- a/opencog/ghost/procedures/pln-reasoner.scm
+++ b/opencog/ghost/procedures/pln-reasoner.scm
@@ -35,6 +35,147 @@
 ; Since this file isn't loaded when ghost-procedures is loaded, import required
 ; modules. It is not loaded with the module it is an experimental feature.
 (use-modules (opencog nlp sureal))
+(use-modules (ice-9 receive))
+
+; ----------------------------------------------------------------------------
+(define-public (filter-for-pln a-list)
+"
+  Takes a list of atoms and return a SetLink containing atoms that pln can
+  reason on. Some of the patterns that make the returned SetLink are,
+          (Inheritance
+              (TypeChoice
+                  (Type \"ConceptNode\")
+                  (Type \"SatisfyingSetLink\")
+                  (Type \"SatisfyingSetScopeLink\"))
+              (TypeChoice
+                  (Type \"ConceptNode\")
+                  (Type \"SatisfyingSetLink\")
+                  (Type \"SatisfyingSetScopeLink\")))
+          (Evaluation
+              (Type \"PredicateNode\")
+              (ListLink
+                  (Type \"ConceptNode\")
+                  (Type \"ConceptNode\")))
+          (Evaluation
+              (Type \"PredicateNode\")
+              (ListLink
+                  (Type \"ConceptNode\")))
+          (Member
+              (TypeChoice
+                  (Type \"ConceptNode\")
+                  (Type \"SatisfyingSetLink\")
+                  (Type \"SatisfyingSetScopeLink\"))
+              (TypeChoice
+                  (Type \"ConceptNode\")
+                  (Type \"SatisfyingSetLink\")
+                  (Type \"SatisfyingSetScopeLink\")))
+          (Implication
+              (Type \"PredicateNode\")
+              (Type \"PredicateNode\"))
+   a-list:
+  - This is a list of atoms, for example a list of r2l outputs
+"
+; TODO: Move this to an (opencog pln) module, when there is one.
+    (define filter-in-pattern
+        (ScopeLink
+            (TypedVariable
+                (Variable "$x")
+                (TypeChoice
+                    (Signature
+                        (Inheritance
+                            (TypeChoice
+                                (Type "ConceptNode")
+                                (Type "SatisfyingSetLink")
+                                (Type "SatisfyingSetScopeLink"))
+                            (TypeChoice
+                                (Type "ConceptNode")
+                                (Type "SatisfyingSetLink")
+                                (Type "SatisfyingSetScopeLink"))))
+                    (Signature
+                        (Implication
+                            (Type "PredicateNode")
+                            (Type "PredicateNode")))
+                    (Signature
+                        (Member
+                            (TypeChoice
+                                (Type "ConceptNode")
+                                (Type "SatisfyingSetLink")
+                                (Type "SatisfyingSetScopeLink"))
+                            (TypeChoice
+                                (Type "ConceptNode")
+                                (Type "SatisfyingSetLink")
+                                (Type "SatisfyingSetScopeLink"))))
+                    (Signature
+                        (Evaluation
+                            (Type "PredicateNode")
+                            (ListLink
+                                (Type "ConceptNode")
+                                (Type "ConceptNode"))))
+                    (Signature
+                        (Evaluation
+                            (Type "PredicateNode")
+                            (ListLink
+                                (Type "ConceptNode"))))
+                ))
+            ; Return atoms with the given signatures
+            (Variable "$x")
+        ))
+     (define filter-from (SetLink  a-list))
+     ; Do the filtering
+    (define result (cog-execute! (MapLink filter-in-pattern filter-from)))
+     ; Delete the filter-from SetLink and its encompasing MapLink.
+    (cog-delete-recursive filter-from)
+     result
+)
+; ----------------------------------------------------------------------------
+(define (simple-forward-step RB-NODE FOCUS-SET)
+"
+  Makes a single forward step using the rules in rulebase RB-NODE over the
+  whole FOCUS-SET.
+"
+; NOTE: It is simple b/c it doesn't try to restrict inference over a
+; certain source atoms.
+; TODO: Move logic to ForwardChainer.
+    (let* ((result (cog-fc RB-NODE (Set) #:focus-set (Set FOCUS-SET)))
+           (result-list (cog-outgoing-set result)))
+        ; Cleanup
+        (cog-delete result)
+         ; If there are multiple results for application of a rule, the
+        ; result will have a ListLink of the results. Get the results out
+        ; of the ListLinks helps in debugging and filtering-for-pln/sureal
+        (receive (list-links other)
+            (partition
+                (lambda (x) (equal? 'ListLink (cog-type x))) result-list)
+             (let ((partial-results (append-map cog-outgoing-set list-links)))
+                ; Cleanup. NOTE: Cleanup is not done on `other` b/c, it might
+                ; contain atoms which are part of r2l outputs, which if deleted
+                ; recursively might affect the nlp pipline.
+                (map cog-delete-recursive list-links)
+                (delete-duplicates (append partial-results other))
+            )
+        )
+    )
+)
+
+; ----------------------------------------------------------------------------
+(define-public (simple-forward-chain RB-NODE FOCUS-SET STEPS)
+"
+  Applys the rules in rulebase RB-NODE over the whole FOCUS-SET, STEPS times.
+  Before each recursive step occurs, the FOCUS-SET and outputs of current-step
+  are merged and passed as the new FOCUS-SET.
+   Returns a list containing both the FOCUS-SET and the inference results.
+"
+    ; TODO: Add an optional argument for filtering results b/n steps using.
+    ; Create the next focus-set.
+    (define (create-next-fs prev-fs chaining-result)
+            (delete-duplicates (append chaining-result prev-fs)))
+     (if (equal? 1 STEPS)
+        (create-next-fs  FOCUS-SET (simple-forward-step RB-NODE FOCUS-SET))
+        (simple-forward-chain RB-NODE
+            (create-next-fs FOCUS-SET (simple-forward-step RB-NODE FOCUS-SET))
+            (- STEPS 1))
+    )
+)
 
 ;-------------------------------------------------------------------------------
 (define (infer-on-r2l rule-base r2l-outputs steps)


### PR DESCRIPTION
The removal was a mistake made as there are no tests that use the function. These functions
are needed for some of the previous pln-trails and also for pln->sureal.