### PR TITLE
Revert a few cog-number changes in Ghost

### DIFF
--- a/opencog/ghost/procedures/predicates.scm
+++ b/opencog/ghost/procedures/predicates.scm
@@ -72,7 +72,7 @@
 
   An atomese wrapper of the function since-true-transition-occurred?
 "
-  (if (since-true-transition-occurred? model (cog-number secs))
+  (if (since-true-transition-occurred? model (string->number (cog-name secs)))
     (stv 1 1)
     (stv 0 1)
   )
@@ -84,7 +84,7 @@
 
   An atomese wrapper of the function since-false-transition-occurred?
 "
-  (if (since-false-transition-occurred? model (cog-number secs))
+  (if (since-false-transition-occurred? model (string->number (cog-name secs)))
     (stv 1 1)
     (stv 0 1)
   )
@@ -304,7 +304,7 @@
   (if (null? t)
     (stv 0 1)
     (if (>= (current-time-us)
-            (+ t (* (cog-number minutes) 60)))
+            (+ t (* (string->number (cog-name minutes)) 60)))
         (stv 1 1)
         (stv 0 1)))
 )

--- a/opencog/ghost/procedures/procedures.scm
+++ b/opencog/ghost/procedures/procedures.scm
@@ -755,7 +755,7 @@
   returns (stv 0 1). All times passed as argument should be in seconds.
 "
   (perceived? atom (current-time-us)
-    (cog-number time-interval))
+    (string->number (cog-name time-interval)))
 )
 
 ; --------------------------------------------------------------

--- a/opencog/ghost/procedures/schemas.scm
+++ b/opencog/ghost/procedures/schemas.scm
@@ -287,7 +287,7 @@
 
   Decrease the urge of GOAL by VALUE.
 "
-  (psi-decrease-urge (Concept (cog-name goal)) (cog-number value))
+  (psi-decrease-urge (Concept (cog-name goal)) (string->number (cog-name value)))
   fini
 )
 
@@ -301,7 +301,7 @@
   (define related-psi-rules
     (filter psi-rule? (cog-incoming-set goal-node)))
 
-  (psi-increase-urge goal-node (cog-number value))
+  (psi-increase-urge goal-node (string->number (cog-name value)))
 
   ; Stimulate the rules associate with this goal
   (for-each
@@ -466,7 +466,7 @@
 "
   (cog-set-sti!
     (get-rule-from-alias (cog-name rule-label))
-    (cog-number val))
+    (string->number (cog-name val)))
 )
 
 (define (max_sti_words . words)


### PR DESCRIPTION
Depending on the context, `NumberNode` may not be used (`TimeNode` / `ConceptNode` etc may be used instead), so revert a few of the previous `cog-number` related changes