### PR TITLE
Double iteration to MinerUTest::test_evaluation() to avoid false negative

### DIFF
--- a/tests/learning/miner/MinerUTest.cxxtest
+++ b/tests/learning/miner/MinerUTest.cxxtest
@@ -1025,7 +1025,7 @@ void MinerUTest::test_evaluation()
 	TS_ASSERT(content_is_in(cpp_expected, cpp_results));
 
 	// Run URE pattern miner
-	Handle ure_results = ure_pm(texts, 2, 2),
+	Handle ure_results = ure_pm(texts, 2, 5),
 		ure_expected = mk_minsup_eval(2, cpp_expected);
 
 	logger().debug() << "ure_results = " << oc_to_string(ure_results);


### PR DESCRIPTION
Fix `MinerUTest::test_evaluation()` in response to #1998