### PR TITLE
Double the number iterations in MinerUTest::test_InferenceControl()

### DIFF
--- a/tests/learning/miner/MinerUTest.cxxtest
+++ b/tests/learning/miner/MinerUTest.cxxtest
@@ -1378,7 +1378,7 @@ void MinerUTest::test_InferenceControl()
 	TS_ASSERT(content_is_in(expected, cpp_results));
 
 	// Run URE pattern miner
-	Handle ure_results = ure_pm(_tmp_as, 2, 50, initpat),
+	Handle ure_results = ure_pm(_tmp_as, 2, 100, initpat),
 		ure_expected = mk_minsup_eval(2, expected);
 
 	logger().debug() << "ure_results = " << oc_to_string(ure_results);


### PR DESCRIPTION
to minimize the odds of have a false negative unit test.