### PR TITLE
Convert to new execute() API.

### DIFF
--- a/opencog/nlp/lg-dict/LGDictEntry.cc
+++ b/opencog/nlp/lg-dict/LGDictEntry.cc
@@ -92,19 +92,10 @@ LGDictEntry::LGDictEntry(const Link& l)
 
 // =================================================================
 
-ValuePtr LGDictEntry::execute()
+ValuePtr LGDictEntry::execute(AtomSpace* as, bool silent)
 {
 	if (WORD_NODE != _outgoing[0]->get_type()) return Handle();
 	if (LG_DICT_NODE != _outgoing[1]->get_type()) return Handle();
-
-	AtomSpace* as = this->getAtomSpace();
-	if (nullptr == as)
-		as = _outgoing[0]->getAtomSpace();
-	if (nullptr == as)
-		as = _outgoing[1]->getAtomSpace();
-	if (nullptr == as)
-		throw InvalidParamException(TRACE_INFO,
-			"LgDictEntry requires an atomspace to work");
 
 	// Get the dictionary
 	LgDictNodePtr ldn(LgDictNodeCast(_outgoing[1]));

--- a/opencog/nlp/lg-dict/LGDictEntry.cc
+++ b/opencog/nlp/lg-dict/LGDictEntry.cc
@@ -94,8 +94,14 @@ LGDictEntry::LGDictEntry(const Link& l)
 
 ValuePtr LGDictEntry::execute(AtomSpace* as, bool silent)
 {
+	// XXX FIXME - these should throw, instead of returning null ptr!
 	if (WORD_NODE != _outgoing[0]->get_type()) return Handle();
 	if (LG_DICT_NODE != _outgoing[1]->get_type()) return Handle();
+
+// Temp hack to pass circle-ci while waiting for pull reqs!
+as = this->getAtomSpace();
+if (nullptr == as) as = _outgoing[0]->getAtomSpace();
+if (nullptr == as) as = _outgoing[1]->getAtomSpace();
 
 	// Get the dictionary
 	LgDictNodePtr ldn(LgDictNodeCast(_outgoing[1]));

--- a/opencog/nlp/lg-dict/LGDictEntry.h
+++ b/opencog/nlp/lg-dict/LGDictEntry.h
@@ -59,7 +59,7 @@ public:
 	LGDictEntry(const Link&);
 
 	// Return a pointer to the atom being specified.
-	virtual ValuePtr execute();
+	virtual ValuePtr execute(AtomSpace*, bool);
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/nlp/lg-parse/LGParseLink.cc
+++ b/opencog/nlp/lg-parse/LGParseLink.cc
@@ -145,6 +145,11 @@ ValuePtr LGParseLink::execute(AtomSpace* as, bool silent)
 	if (3 == _outgoing.size() and
 	   NUMBER_NODE != _outgoing[2]->get_type()) return Handle();
 
+// Temp hack, while waiting for pull req for circle-ci unit tests
+as = getAtomSpace();
+if (nullptr == as) as = _outgoing[0]->getAtomSpace();
+if (nullptr == as) as = _outgoing[1]->getAtomSpace();
+
 	// Link grammar, for some reason, has a different error handler
 	// per thread. Don't know why. So we have to set it every time,
 	// because we don't know what thread we are in.

--- a/opencog/nlp/lg-parse/LGParseLink.h
+++ b/opencog/nlp/lg-parse/LGParseLink.h
@@ -56,7 +56,7 @@ public:
 	LGParseLink(const Link&);
 
 	// Return a pointer to the atom being specified.
-	virtual ValuePtr execute();
+	virtual ValuePtr execute(AtomSpace*, bool);
 
 	static Handle factory(const Handle&);
 };


### PR DESCRIPTION
Pre-requisite for opencog/atomspace#2067