### PR TITLE
Remove temp hack - no longer needed.

### DIFF
--- a/opencog/nlp/lg-dict/LGDictEntry.cc
+++ b/opencog/nlp/lg-dict/LGDictEntry.cc
@@ -98,11 +98,6 @@ ValuePtr LGDictEntry::execute(AtomSpace* as, bool silent)
 	if (WORD_NODE != _outgoing[0]->get_type()) return Handle();
 	if (LG_DICT_NODE != _outgoing[1]->get_type()) return Handle();
 
-// Temp hack to pass circle-ci while waiting for pull reqs!
-as = this->getAtomSpace();
-if (nullptr == as) as = _outgoing[0]->getAtomSpace();
-if (nullptr == as) as = _outgoing[1]->getAtomSpace();
-
 	// Get the dictionary
 	LgDictNodePtr ldn(LgDictNodeCast(_outgoing[1]));
 	Dictionary dict = ldn->get_dictionary();

--- a/opencog/nlp/lg-parse/LGParseLink.cc
+++ b/opencog/nlp/lg-parse/LGParseLink.cc
@@ -145,11 +145,6 @@ ValuePtr LGParseLink::execute(AtomSpace* as, bool silent)
 	if (3 == _outgoing.size() and
 	   NUMBER_NODE != _outgoing[2]->get_type()) return Handle();
 
-// Temp hack, while waiting for pull req for circle-ci unit tests
-as = getAtomSpace();
-if (nullptr == as) as = _outgoing[0]->getAtomSpace();
-if (nullptr == as) as = _outgoing[1]->getAtomSpace();
-
 	// Link grammar, for some reason, has a different error handler
 	// per thread. Don't know why. So we have to set it every time,
 	// because we don't know what thread we are in.


### PR DESCRIPTION
This was required to pass unit tests during update; should not be needed any more.