### PR TITLE
Re-enable the psi loop test in OpenPsiSCMUTest

### DIFF
--- a/tests/openpsi/OpenPsiSCMUTest.cxxtest
+++ b/tests/openpsi/OpenPsiSCMUTest.cxxtest
@@ -247,7 +247,7 @@ public:
     }
 
     // Check the scheme functions `psi-run` and `psi-halt`
-    void x_test_psi_run_and_psi_halt()
+    void test_psi_run_and_psi_halt()
     {
       logger().info("BEGIN TEST: %s", __FUNCTION__);
 

--- a/tests/openpsi/OpenPsiSCMUTest.cxxtest
+++ b/tests/openpsi/OpenPsiSCMUTest.cxxtest
@@ -252,9 +252,9 @@ public:
       logger().info("BEGIN TEST: %s", __FUNCTION__);
 
       // Common Setup
-      _scm->eval("(define d1 (component-1))");
+      _scm->eval("(define d1 (component-5))");
       CHKERR
-      _scm->eval("(define d2 (component-2))");
+      _scm->eval("(define d2 (component-6))");
       CHKERR
 
       // Tests

--- a/tests/openpsi/rules.scm
+++ b/tests/openpsi/rules.scm
@@ -289,8 +289,6 @@
   ; not be started at the same time.
   (sleep 1)
   (psi-run d2)
-  (groundable-content-1)
-  (groundable-content-2)
 
   (let ((l1 (psi-loop-count d1))
     (l2 (psi-loop-count d2)))

--- a/tests/openpsi/rules.scm
+++ b/tests/openpsi/rules.scm
@@ -277,6 +277,9 @@
 )
 
 ; --------------------------------------------------------------
+(define (component-5) (psi-component "component-5"))
+(define (component-6) (psi-component "component-6"))
+
 (define (test-psi-run)
 "
   If the loop-count is increasing then it means the loop is running


### PR DESCRIPTION
For testing `psi-run` and `psi-halt`