### PR TITLE
Rename the rule types in Ghost

### DIFF
--- a/opencog/ghost/README.md
+++ b/opencog/ghost/README.md
@@ -52,9 +52,9 @@ Here is a list of features that are fully supported in GHOST:
     - `set_used`, to set another rule as triggered, so that it will not be triggered again.
 - [Unordered Matching](https://github.com/bwilcox-1234/ChatScript/blob/master/WIKI/ChatScript-Basic-User-Manual.md#unordered-matching--)
 
-There are different types of rules in ChatScript -- responders (`u:` `s:` `?:`) and gambits (`r:` `t:`). Currently they are handled without distinction, except for questions (`?:`) which will only be triggered if the input is a question.
-
-[Rejoinder](https://github.com/bwilcox-1234/ChatScript/blob/master/WIKI/ChatScript-Basic-User-Manual.md#fast-overview-of-topic-files-top) (`a:` to `q:`) is also supported. Rejoinders have a higher priority than responders and gambits so it will always be selected if it satisfies the context. If more than one rejoinders satisfy the current context, the one that's defined first will always be selected.
+There are different types of rules in ChatScript -- responders, rejoinders, and gambits. Note, here in GHOST, responders are called reactive rules and gambits are called proactive rules.
+Use `r:` to define a reactive rule, `j1:` `j2:` `j3:`... etc to define a rejoinder (on different levels), and `p:` to define a gambit. Currently `s:`, `?:`, and `u:` can still be used to define a reactive rule, `a:` up to `e:` can still be used to define a rejoinder, and `t:` can still be used to define a gambit, but these are for backward compability ONLY.
+Rejoinders have a higher priority than reactive rules and proactive rules so it will always be selected if it satisfies the context. If more than one rejoinders satisfy the current context, the one that's defined first will always be selected.
 
 Simple comparisons (`=` `!=` `<` `<=` `>` `>=`) can be done in the context of a rule, for variables, user variables, and functions, e.g.
 ```

--- a/opencog/ghost/cs-parse.scm
+++ b/opencog/ghost/cs-parse.scm
@@ -93,27 +93,30 @@
     ; Starts with "r:"; "s:", "?:" and "u:" are for backward compatibility
     ((has-match? "[rs?u]:" str)
       (result:suffix 'REACTIVE-RULES location
-        (substring (string-trim-both
-          (match:substring current-match)) 0 1)))
+        (string-trim-both
+          (match:substring current-match)
+            (lambda (c) (or (eqv? c #\space) (eqv? c #\:))))))
     ; Rejoinders
     ; Starts with "j" follow by a number to denote the level
     ((has-match? "j[0-9]+:" str)
       (result:suffix 'REJOINDERS location
-        (substring (string-trim-both
-          (match:substring current-match)) 0
-            (- (string-length (match:substring current-match)) 1))))
+        (string-trim-both
+          (match:substring current-match)
+            (lambda (c) (or (eqv? c #\space) (eqv? c #\:))))))
     ; Rejoinders again, for backward compatibility, but limit the support
     ; up to the letter "e" instead of "q" as in ChatScript
     ((has-match? "[a-e]:" str)
       (result:suffix 'REJOINDERS location
-        (substring (string-trim-both
-          (match:substring current-match)) 0 1)))
+        (string-trim-both
+          (match:substring current-match)
+            (lambda (c) (or (eqv? c #\space) (eqv? c #\:))))))
     ; Proactive rules (aka Gambits)
     ; Starts with "p:"; "t:" is for backward compatibility
     ((has-match? "[pt]:" str)
       (result:suffix 'PROACTIVE-RULES location
-        (substring (string-trim-both
-          (match:substring current-match)) 0 1)))
+        (string-trim-both
+          (match:substring current-match)
+            (lambda (c) (or (eqv? c #\space) (eqv? c #\:))))))
     ((has-match? "[{][%] set delay=[0-9]+ [%][}]" str)
       (result:suffix 'SET_DELAY location
         (string-trim-both (match:substring current-match))))

--- a/opencog/ghost/cs-parse.scm
+++ b/opencog/ghost/cs-parse.scm
@@ -332,7 +332,7 @@
 
     ; Rule grammar
     (rule
-      ; ----- Responders ----- ;
+      ; ----- Reactive Rules ----- ;
       (rule-goal rule-lconcept REACTIVE-RULES str context action) :
         (create-rule
           (eval-string (string-append "(list " $5 ")"))
@@ -446,9 +446,9 @@
           (eval-string (string-append "(list " $2 ")"))
           (eval-string (string-append "(list " $3 ")"))
           (list) "" $1 (list))
-      ; ----- Gambits ----- ;
-      ; Note, do not support a gambit that has a label
-      ; but no context -- it's ambiguous to determine
+      ; ----- Proactive Rules ----- ;
+      ; Note, do not support a proactive rule that has a
+      ; label but no context -- it's ambiguous to determine
       ; whether it's really a label or just the first
       ; word of the "action"
       (rule-goal rule-lconcept PROACTIVE-RULES str context action) :
@@ -521,7 +521,7 @@
           (eval-string (string-append "(list " $3 ")"))
           (list) "" $2 $1)
       ; Same as the above, context is needed for a
-      ; labeled gambit
+      ; labeled proactive rule
       (PROACTIVE-RULES str context action) :
         (create-rule
           (eval-string (string-append "(list " $3 ")"))

--- a/opencog/ghost/cs-parse.scm
+++ b/opencog/ghost/cs-parse.scm
@@ -95,7 +95,15 @@
       (result:suffix 'REACTIVE-RULES location
         (car (string->list (substring (string-trim-both
           (match:substring current-match)) 0 1)))))
-    ((has-match? "[a-q]:" str)
+    ; Rejoinders
+    ; Starts with "j" follow by a number to denote the level
+    ((has-match? "j[0-9]+:" str)
+      (result:suffix 'REJOINDERS location
+        (car (string->list (substring (string-trim-both
+          (match:substring current-match)) 0 1)))))
+    ; Rejoinders again, for backward compatibility, but limit the support
+    ; up to the letter "e" instead of "q" as in ChatScript
+    ((has-match? "[a-e]:" str)
       (result:suffix 'REJOINDERS location
         (car (string->list (substring (string-trim-both
           (match:substring current-match)) 0 1)))))

--- a/opencog/ghost/cs-parse.scm
+++ b/opencog/ghost/cs-parse.scm
@@ -89,17 +89,20 @@
       (cons (make-lexical-token 'SAMPLE_INPUT location #f) ""))
     ((has-match? "*#" str)
       (cons (make-lexical-token 'COMMENT location #f) ""))
-    ; Chatscript rules
-    ((has-match? "[s?u]:" str)
-      (result:suffix 'RESPONDERS location
+    ; Reactive rules (aka Responders)
+    ; Starts with "r:"; "s:", "?:" and "u:" are for backward compatibility
+    ((has-match? "[rs?u]:" str)
+      (result:suffix 'REACTIVE-RULES location
         (car (string->list (substring (string-trim-both
           (match:substring current-match)) 0 1)))))
     ((has-match? "[a-q]:" str)
       (result:suffix 'REJOINDERS location
         (car (string->list (substring (string-trim-both
           (match:substring current-match)) 0 1)))))
-    ((has-match? "[rt]:" str)
-      (result:suffix 'GAMBIT location
+    ; Proactive rules (aka Gambits)
+    ; Starts with "p:"; "r:" and "t:" are for backward compatibility
+    ((has-match? "[prt]:" str)
+      (result:suffix 'PROACTIVE-RULES location
         (car (string->list (substring (string-trim-both
           (match:substring current-match)) 0 1)))))
     ((has-match? "[{][%] set delay=[0-9]+ [%][}]" str)
@@ -248,7 +251,7 @@
     ; MOVAR = Match Variables grounded in their original words
     ; ? = Comparison tests
     ; VLINE = Vertical Line |
-    (CONCEPT RESPONDERS REJOINDERS GAMBIT URGE ORD-GOAL GOAL RGOAL COMMENT
+    (CONCEPT REACTIVE-RULES REJOINDERS PROACTIVE-RULES URGE ORD-GOAL GOAL RGOAL COMMENT
      SAMPLE_INPUT PARALLEL-RULES LINK-CONCEPT RLINK-CONCEPT
       (right: LPAREN LSBRACKET << ID VAR * ^ < LEMMA LITERAL LITERAL_APOS NUM DICTKEY
               STRING *~n *n UVAR MVAR MOVAR EQUAL NOT RESTART LBRACE VLINE COMMA
@@ -318,58 +321,58 @@
     ; Rule grammar
     (rule
       ; ----- Responders ----- ;
-      (rule-goal rule-lconcept RESPONDERS str context action) :
+      (rule-goal rule-lconcept REACTIVE-RULES str context action) :
         (create-rule
           (eval-string (string-append "(list " $5 ")"))
           (eval-string (string-append "(list " $6 ")"))
           (eval-string (string-append "(list " $1 ")"))
           $4 $3 $2)
-      (rule-lconcept rule-goal RESPONDERS str context action) :
+      (rule-lconcept rule-goal REACTIVE-RULES str context action) :
         (create-rule
           (eval-string (string-append "(list " $5 ")"))
           (eval-string (string-append "(list " $6 ")"))
           (eval-string (string-append "(list " $2 ")"))
           $4 $3 $1)
-      (rule-goal RESPONDERS str context action) :
+      (rule-goal REACTIVE-RULES str context action) :
         (create-rule
           (eval-string (string-append "(list " $4 ")"))
           (eval-string (string-append "(list " $5 ")"))
           (eval-string (string-append "(list " $1 ")"))
           $3 $2 (list))
-      (rule-lconcept RESPONDERS str context action) :
+      (rule-lconcept REACTIVE-RULES str context action) :
         (create-rule
           (eval-string (string-append "(list " $4 ")"))
           (eval-string (string-append "(list " $5 ")"))
           (list) $3 $2 $1)
-      (rule-goal rule-lconcept RESPONDERS context action) :
+      (rule-goal rule-lconcept REACTIVE-RULES context action) :
         (create-rule
           (eval-string (string-append "(list " $4 ")"))
           (eval-string (string-append "(list " $5 ")"))
           (eval-string (string-append "(list " $1 ")"))
           "" $3 $2)
-      (rule-lconcept rule-goal RESPONDERS context action) :
+      (rule-lconcept rule-goal REACTIVE-RULES context action) :
         (create-rule
           (eval-string (string-append "(list " $4 ")"))
           (eval-string (string-append "(list " $5 ")"))
           (eval-string (string-append "(list " $2 ")"))
           "" $3 $1)
-      (rule-goal RESPONDERS context action) :
+      (rule-goal REACTIVE-RULES context action) :
         (create-rule
           (eval-string (string-append "(list " $3 ")"))
           (eval-string (string-append "(list " $4 ")"))
           (eval-string (string-append "(list " $1 ")"))
           "" $2 (list))
-      (rule-lconcept RESPONDERS context action) :
+      (rule-lconcept REACTIVE-RULES context action) :
         (create-rule
           (eval-string (string-append "(list " $3 ")"))
           (eval-string (string-append "(list " $4 ")"))
           (list) "" $2 $1)
-      (RESPONDERS str context action) :
+      (REACTIVE-RULES str context action) :
         (create-rule
           (eval-string (string-append "(list " $3 ")"))
           (eval-string (string-append "(list " $4 ")"))
           (list) $2 $1 (list))
-      (RESPONDERS context action) :
+      (REACTIVE-RULES context action) :
         (create-rule
           (eval-string (string-append "(list " $2 ")"))
           (eval-string (string-append "(list " $3 ")"))
@@ -436,88 +439,88 @@
       ; but no context -- it's ambiguous to determine
       ; whether it's really a label or just the first
       ; word of the "action"
-      (rule-goal rule-lconcept GAMBIT str context action) :
+      (rule-goal rule-lconcept PROACTIVE-RULES str context action) :
         (create-rule
           (eval-string (string-append "(list " $5 ")"))
           (eval-string (string-append "(list " $6 ")"))
           (eval-string (string-append "(list " $1 ")"))
           $4 $3 $2)
-      (rule-lconcept rule-goal GAMBIT str context action) :
+      (rule-lconcept rule-goal PROACTIVE-RULES str context action) :
         (create-rule
           (eval-string (string-append "(list " $5 ")"))
           (eval-string (string-append "(list " $6 ")"))
           (eval-string (string-append "(list " $2 ")"))
           $4 $3 $1)
-      (rule-goal GAMBIT str context action) :
+      (rule-goal PROACTIVE-RULES str context action) :
         (create-rule
           (eval-string (string-append "(list " $4 ")"))
           (eval-string (string-append "(list " $5 ")"))
           (eval-string (string-append "(list " $1 ")"))
           $3 $2 (list))
-      (rule-lconcept GAMBIT str context action) :
+      (rule-lconcept PROACTIVE-RULES str context action) :
         (create-rule
           (eval-string (string-append "(list " $4 ")"))
           (eval-string (string-append "(list " $5 ")"))
           (list) $3 $2 $1)
-      (rule-goal rule-lconcept GAMBIT context action) :
+      (rule-goal rule-lconcept PROACTIVE-RULES context action) :
         (create-rule
           (eval-string (string-append "(list " $4 ")"))
           (eval-string (string-append "(list " $5 ")"))
           (eval-string (string-append "(list " $1 ")"))
           "" $3 $2)
-      (rule-lconcept rule-goal GAMBIT context action) :
+      (rule-lconcept rule-goal PROACTIVE-RULES context action) :
         (create-rule
           (eval-string (string-append "(list " $4 ")"))
           (eval-string (string-append "(list " $5 ")"))
           (eval-string (string-append "(list " $2 ")"))
           "" $3 $1)
-      (rule-goal GAMBIT context action) :
+      (rule-goal PROACTIVE-RULES context action) :
         (create-rule
           (eval-string (string-append "(list " $3 ")"))
           (eval-string (string-append "(list " $4 ")"))
           (eval-string (string-append "(list " $1 ")"))
           "" $2 (list))
-      (rule-lconcept GAMBIT context action) :
+      (rule-lconcept PROACTIVE-RULES context action) :
         (create-rule
           (eval-string (string-append "(list " $3 ")"))
           (eval-string (string-append "(list " $4 ")"))
           (list) "" $2 $1)
-      (rule-goal rule-lconcept GAMBIT action) :
+      (rule-goal rule-lconcept PROACTIVE-RULES action) :
         (create-rule
           (list)
           (eval-string (string-append "(list " $4 ")"))
           (eval-string (string-append "(list " $1 ")"))
           "" $3 $2)
-      (rule-lconcept rule-goal GAMBIT action) :
+      (rule-lconcept rule-goal PROACTIVE-RULES action) :
         (create-rule
           (list)
           (eval-string (string-append "(list " $4 ")"))
           (eval-string (string-append "(list " $2 ")"))
           "" $3 $1)
-      (rule-goal GAMBIT action) :
+      (rule-goal PROACTIVE-RULES action) :
         (create-rule
           (list)
           (eval-string (string-append "(list " $3 ")"))
           (eval-string (string-append "(list " $1 ")"))
           "" $2 (list))
-      (rule-lconcept GAMBIT action) :
+      (rule-lconcept PROACTIVE-RULES action) :
         (create-rule
           (list)
           (eval-string (string-append "(list " $3 ")"))
           (list) "" $2 $1)
       ; Same as the above, context is needed for a
       ; labeled gambit
-      (GAMBIT str context action) :
+      (PROACTIVE-RULES str context action) :
         (create-rule
           (eval-string (string-append "(list " $3 ")"))
           (eval-string (string-append "(list " $4 ")"))
           (list) $2 $1 (list))
-      (GAMBIT context action) :
+      (PROACTIVE-RULES context action) :
         (create-rule
           (eval-string (string-append "(list " $2 ")"))
           (eval-string (string-append "(list " $3 ")"))
           (list) "" $1 (list))
-      (GAMBIT action) :
+      (PROACTIVE-RULES action) :
         (create-rule
           (list)
           (eval-string (string-append "(list " $2 ")"))

--- a/opencog/ghost/cs-parse.scm
+++ b/opencog/ghost/cs-parse.scm
@@ -93,26 +93,27 @@
     ; Starts with "r:"; "s:", "?:" and "u:" are for backward compatibility
     ((has-match? "[rs?u]:" str)
       (result:suffix 'REACTIVE-RULES location
-        (car (string->list (substring (string-trim-both
-          (match:substring current-match)) 0 1)))))
+        (substring (string-trim-both
+          (match:substring current-match)) 0 1)))
     ; Rejoinders
     ; Starts with "j" follow by a number to denote the level
     ((has-match? "j[0-9]+:" str)
       (result:suffix 'REJOINDERS location
-        (car (string->list (substring (string-trim-both
-          (match:substring current-match)) 0 1)))))
+        (substring (string-trim-both
+          (match:substring current-match)) 0
+            (- (string-length (match:substring current-match)) 1))))
     ; Rejoinders again, for backward compatibility, but limit the support
     ; up to the letter "e" instead of "q" as in ChatScript
     ((has-match? "[a-e]:" str)
       (result:suffix 'REJOINDERS location
-        (car (string->list (substring (string-trim-both
-          (match:substring current-match)) 0 1)))))
+        (substring (string-trim-both
+          (match:substring current-match)) 0 1)))
     ; Proactive rules (aka Gambits)
     ; Starts with "p:"; "r:" and "t:" are for backward compatibility
     ((has-match? "[prt]:" str)
       (result:suffix 'PROACTIVE-RULES location
-        (car (string->list (substring (string-trim-both
-          (match:substring current-match)) 0 1)))))
+        (substring (string-trim-both
+          (match:substring current-match)) 0 1)))
     ((has-match? "[{][%] set delay=[0-9]+ [%][}]" str)
       (result:suffix 'SET_DELAY location
         (string-trim-both (match:substring current-match))))

--- a/opencog/ghost/cs-parse.scm
+++ b/opencog/ghost/cs-parse.scm
@@ -109,8 +109,8 @@
         (substring (string-trim-both
           (match:substring current-match)) 0 1)))
     ; Proactive rules (aka Gambits)
-    ; Starts with "p:"; "r:" and "t:" are for backward compatibility
-    ((has-match? "[prt]:" str)
+    ; Starts with "p:"; "t:" is for backward compatibility
+    ((has-match? "[pt]:" str)
       (result:suffix 'PROACTIVE-RULES location
         (substring (string-trim-both
           (match:substring current-match)) 0 1)))

--- a/opencog/ghost/ghost.scm
+++ b/opencog/ghost/ghost.scm
@@ -71,14 +71,13 @@
 (define ghost-time-last-executed (Predicate (ghost-prefix "Time Last Executed")))
 (define ghost-word-seq (Predicate (ghost-prefix "Word Sequence")))
 (define ghost-rule-type (Predicate (ghost-prefix "Rule Type")))
-(define ghost-next-responder (Predicate (ghost-prefix "Next Responder")))
+(define ghost-next-reactive-rule (Predicate (ghost-prefix "Next Reactive Rule")))
 (define ghost-next-rejoinder (Predicate (ghost-prefix "Next Rejoinder")))
 (define ghost-rej-seq-num (Predicate (ghost-prefix "Rejoinder Sequence Number")))
 (define ghost-context-specificity (Predicate (ghost-prefix "Context Specificity")))
 (define strval-rejoinder (StringValue "rejoinder"))
-(define strval-responder (StringValue "responder"))
-(define strval-random-gambit (StringValue "random gambit"))
-(define strval-gambit (StringValue "gambit"))
+(define strval-reactive-rule (StringValue "reactive-rule"))
+(define strval-proactive-rule (StringValue "proactive-rule"))
 
 ;; --------------------
 (define-public (ghost-word-seq-pred)
@@ -120,7 +119,7 @@
 ; A list of all the labels of the rules we have seen
 (define rule-label-list '())
 
-; An association list of the types (responders, rejoinders etc)
+; An association list of the types (reactive rules, rejoinders etc)
 ; of the rules
 (define rule-type-alist '())
 
@@ -179,7 +178,7 @@
 (define context-weight 1)
 (define sti-weight 1)
 (define urge-weight 1)
-(define responder-sti-boost 1)
+(define reactive-rule-sti-boost 1)
 (define rejoinder-sti-boost 10)
 (define refractory-period 1)
 (define specificity-based-action-selection #t)

--- a/opencog/ghost/matcher.scm
+++ b/opencog/ghost/matcher.scm
@@ -17,16 +17,16 @@
   if applicable, and de-stimulate the selected rule.
 "
   ; Keep a record of which rule got executed, just for rejoinders
-  (let ((next-responder (cog-value RULE ghost-next-responder))
+  (let ((next-reactive-rule (cog-value RULE ghost-next-reactive-rule))
         (next-rejoinder (cog-value RULE ghost-next-rejoinder))
         (av-alist (cog-av->alist (cog-av RULE))))
     ; Stimulate the next rules in the sequence and lower the STI of
     ; the current one
-    ; Rejoinders will have a bigger boost than responders by default
-    (if (not (null? next-responder))
+    ; Rejoinders will have a bigger boost than reactive rules by default
+    (if (not (null? next-reactive-rule))
       (for-each
-        (lambda (r) (cog-stimulate r (* default-stimulus responder-sti-boost)))
-        (cog-value->list next-responder)))
+        (lambda (r) (cog-stimulate r (* default-stimulus reactive-rule-sti-boost)))
+        (cog-value->list next-reactive-rule)))
     (if (not (null? next-rejoinder))
       (for-each
         (lambda (r) (cog-stimulate r (* default-stimulus rejoinder-sti-boost)))
@@ -243,7 +243,7 @@
               (list)
               (map (lambda (a) (assoc-ref action-rule-alist (car a))) action-weight-alist))))
       (if (null? rejoinder)
-        ; If there is no rejoinder that safisfy the current context, try the responders
+        ; If there is no rejoinder that safisfy the current context, try the reactive rules
         (begin
           (if specificity-based-action-selection
             ; Specificity-based action selection (experimental)

--- a/opencog/ghost/test.scm
+++ b/opencog/ghost/test.scm
@@ -200,7 +200,7 @@
       "TV = ~a\n"
       "Satisfiability: ~a\n"
       "Time last executed: ~a\n"
-      "Next responder: ~a\n"
+      "Next reactive rule: ~a\n"
       "Next rejoinder: ~a\n")
       (map cog-av rule)
       (map cog-tv rule)
@@ -211,10 +211,10 @@
         "N.A."
         (strftime "%D %T" (localtime (inexact->exact
           (car (cog-value->list (cog-value (car rule) ghost-time-last-executed)))))))
-      (if (null? (cog-value (car rule) ghost-next-responder))
+      (if (null? (cog-value (car rule) ghost-next-reactive-rule))
         (list)
         (append-map psi-rule-alias
-          (cog-value->list (cog-value (car rule) ghost-next-responder))))
+          (cog-value->list (cog-value (car rule) ghost-next-reactive-rule))))
       (if (null? (cog-value (car rule) ghost-next-rejoinder))
         (list)
         (append-map psi-rule-alias
@@ -321,13 +321,13 @@
   ghost-set-rep-sti-boost VAL
 
   Set how much of a default stimulus will be given to
-  the next responder after triggering the previous
+  the next reactive rule after triggering the previous
   one in the sequence.
 "
   (if (number? VAL)
-    (set! responder-sti-boost VAL)
+    (set! reactive-rule-sti-boost VAL)
     (cog-logger-warn ghost-logger
-      "The responder STI boost has to be a numberic value!"))
+      "The reactive rule STI boost has to be a numberic value!"))
 )
 
 ; ----------

--- a/opencog/ghost/translator.scm
+++ b/opencog/ghost/translator.scm
@@ -629,12 +629,12 @@
              (string=? "u" TYPE)
              (string=? "s" TYPE))
          (set! rule-type-alist
-           (assoc-set! rule-type-alist NAME strval-responder))
+           (assoc-set! rule-type-alist NAME strval-reactive-rule))
          (list '() '()))
         ; For backward compatibility
         ((equal? "?" TYPE)
          (set! rule-type-alist
-           (assoc-set! rule-type-alist NAME strval-responder))
+           (assoc-set! rule-type-alist NAME strval-reactive-rule))
          (let ((var (Variable (gen-var "Interpretation" #f))))
            (list
              (list (TypedVariable var (Type "InterpretationNode")))
@@ -649,15 +649,15 @@
              ; For backward compatibility
              (string=? "t" TYPE))
          (set! rule-type-alist
-           (assoc-set! rule-type-alist NAME strval-gambit))
+           (assoc-set! rule-type-alist NAME strval-proactive-rule))
          (list '() '()))
         ((null? rule-hierarchy)
          (clear-parsing-states)
          ; If we are here, it has to be a rejoinder, so make sure
-         ; rule-hierarchy is not empty, i.e. a responder should
+         ; rule-hierarchy is not empty, i.e. a reactive rule should
          ; be defined in advance
          (throw (ghost-prefix
-           "Please define a responder first before defining a rejoinder.")))
+           "Please define a reactive rule first before defining a rejoinder.")))
         ((equal? "Parallel-Rules"
            (cog-name (psi-get-goal (car (get-rules-from-label
              (last (list-ref rule-hierarchy (- (get-rejoinder-level TYPE) 1))))))))
@@ -731,8 +731,9 @@
   NAME is like a label of a rule, so that one can reference this rule
   by using it.
 
-  TYPE is a grouping idea from ChatScript, e.g. responders, rejoinders,
-  gambits etc.
+  TYPE is a grouping idea from ChatScript, i.e. responders, rejoinders,
+  and gambits. Note, here in GHOST, responders are called reactive rules
+  and gambits are called proactive rules.
 "
   ; Label the rule with NAME, if given, generate one otherwise
   (define rule-name
@@ -897,8 +898,8 @@
         (if is-rejoinder?
           ; If it's a rejoinder, its parent rule should be the
           ; last rule one level up in rule-hierarchy
-          ; 'process-type' will make sure there is a responder
-          ; defined beforehand so rule-hierarchy is not empty
+          ; 'process-type' will make sure there is a reactive
+          ; rule defined beforehand so rule-hierarchy is not empty
           (begin
             (set-next-rule
               (car (get-rules-from-label
@@ -924,7 +925,7 @@
                     (lambda (r)
                       (set-next-rule
                         (car (get-rules-from-label r))
-                          a-rule ghost-next-responder))
+                          a-rule ghost-next-reactive-rule))
                     lv))
                 rule-hierarchy))
             (add-to-rule-hierarchy 0 NAME)))

--- a/opencog/ghost/translator.scm
+++ b/opencog/ghost/translator.scm
@@ -624,12 +624,15 @@
   Figure out what the type of the rule is, generate the needed atomese, and
   return the type as a StringValue.
 "
-  (cond ((or (equal? #\u TYPE)
-             (equal? #\s TYPE))
+  (cond ((or (string=? "r" TYPE)
+             ; For backward compatibility
+             (string=? "u" TYPE)
+             (string=? "s" TYPE))
          (set! rule-type-alist
            (assoc-set! rule-type-alist NAME strval-responder))
          (list '() '()))
-        ((equal? #\? TYPE)
+        ; For backward compatibility
+        ((equal? "?" TYPE)
          (set! rule-type-alist
            (assoc-set! rule-type-alist NAME strval-responder))
          (let ((var (Variable (gen-var "Interpretation" #f))))
@@ -642,11 +645,9 @@
                    (DefinedLinguisticConcept "InterrogativeSpeechAct"))
                  (InheritanceLink var
                    (DefinedLinguisticConcept "TruthQuerySpeechAct")))))))
-        ((equal? #\r TYPE)
-         (set! rule-type-alist
-           (assoc-set! rule-type-alist NAME strval-random-gambit))
-         (list '() '()))
-        ((equal? #\t TYPE)
+        ((or (string=? "p" TYPE)
+             ; For backward compatibility
+             (string=? "t" TYPE))
          (set! rule-type-alist
            (assoc-set! rule-type-alist NAME strval-gambit))
          (list '() '()))

--- a/opencog/ghost/utils.scm
+++ b/opencog/ghost/utils.scm
@@ -284,9 +284,13 @@
 ; ----------
 (define (get-rejoinder-level TYPE)
 "
-  Return the rejoinder level, e.g. a = level 1, b = level 2, and so on...
+  Return the rejoinder level, e.g. j1 = level 1, j2 = level 2, and so on...
 "
-  (- (char->integer TYPE) 96))
+  (if (string-prefix? "j" TYPE)
+    (string->number (string-trim TYPE (lambda (c) (eqv? c #\j))))
+    ; For backward compatibility,
+    ; e.g. a = level 1, b = level 2, and so on...
+    (- (char->integer (string-ref TYPE 0)) 96)))
 
 ; ----------
 (define (get-related-psi-rules ATOM)


### PR DESCRIPTION
Changing `responders` to `reactive rules` and `gambits` to `proactive rules`, as well as the prefix/syntax for defining them as discussed, but still backward compatible with the old ones.