### PR TITLE
Fix cog-number applied to TimeNodes

### DIFF
--- a/opencog/nlp/chatbot/chat-utils.scm
+++ b/opencog/nlp/chatbot/chat-utils.scm
@@ -48,7 +48,7 @@
 
   Returns the time, in seconds, at which the SentenceNode SENT was parsed.
 "
-  (cog-number (car (cog-chase-link 'AtTimeLink 'TimeNode sent)))
+  (string->number (cog-name (car (cog-chase-link 'AtTimeLink 'TimeNode sent))))
 )
 
 (define-public (get-last-said-sent)
@@ -72,7 +72,7 @@
     (define last-time 0)
     (define result '())
     (define (last-sent sent)
-        (let ((sent-time (cog-number (gar sent))))
+      (let ((sent-time (string->number (cog-name (gar sent)))))
             (if (>= sent-time last-time)
                 (begin
                     (set! last-time sent-time)


### PR DESCRIPTION
(cog-number (TimeNode "12345")) leads to an error.
```
ERROR: In procedure cog-number:
In procedure cog-number: Wrong type (expecting NumberNode): (TimeNode "12345")
```