### PR TITLE
Fix pattern miner

### DIFF
--- a/examples/learning/miner/simple/simple.scm
+++ b/examples/learning/miner/simple/simple.scm
@@ -21,8 +21,12 @@
 ;;   (Inheritance
 ;;     (Concept "A")
 ;;     (Variable "$X")))
-(define results (cog-mine (cog-atomspace) #:minsup 2))
+;;
+;; Since the pattern has no conjunction the surprisingness measure is
+;; none (as the current surprisingness measures consider the
+;; surprisingness of conjunctions of components)
+(define results (cog-mine (cog-atomspace) #:minsup 2 #:surprisingness 'none))
 
 ;; Call the miner on the text set of interest instead, should yield
 ;; the same results.
-(cog-mine (list AB AC) #:minsup 2)
+(cog-mine (list AB AC) #:minsup 2 #:surprisingness 'none)

--- a/examples/learning/miner/ugly-male-soda-drinker/ugly-male-soda-drinker.scm
+++ b/examples/learning/miner/ugly-male-soda-drinker/ugly-male-soda-drinker.scm
@@ -34,9 +34,39 @@
 ;;     (Inheritance
 ;;       (Variable "$X")
 ;;       (Concept "soda drinker"))))
+;;
+;; Because surprisingness is used the output is gonna be a sorted List
+;; where the following
+;;
+;; (EvaluationLink (stv 0.88636364 1)
+;;    (PredicateNode "isurp")
+;;    (ListLink
+;;       (LambdaLink
+;;          (VariableNode "$PM-294b9483")
+;;          (AndLink
+;;             (InheritanceLink
+;;                (VariableNode "$PM-294b9483")
+;;                (ConceptNode "man")
+;;             )
+;;             (InheritanceLink
+;;                (VariableNode "$PM-294b9483")
+;;                (ConceptNode "ugly")
+;;             )
+;;             (InheritanceLink
+;;                (VariableNode "$PM-294b9483")
+;;                (ConceptNode "soda drinker")
+;;             )
+;;          )
+;;       )
+;;       (ConceptNode "texts-471337883-0XMuFQrSAV2O3H48")
+;;    )
+;; )
+;;
+;; appears on top as it is the most surprising pattern according to
+;; the nisurp (I-Surprisingness) measure.
 (define results (cog-mine (cog-atomspace)
                           #:minsup 5
                           #:maximum-iterations 100
                           #:incremental-expansion #t
                           #:max-conjuncts 3
-                          #:surprisingness 'nisurp-old))
+                          #:surprisingness 'nisurp))


### PR DESCRIPTION
Fix #3454 + add `none` surprisingness measure, as surprisingness is currently only defined for conjunctions of components.