### PR TITLE
Double+ iterations of MinerUTest::test_SodaDrinker_incremental()

### DIFF
--- a/tests/learning/miner/MinerUTest.cxxtest
+++ b/tests/learning/miner/MinerUTest.cxxtest
@@ -1313,7 +1313,7 @@ void MinerUTest::test_SodaDrinker_incremental()
 	int max_conjuncts = 3;
 	double complexity_penalty = 1;
 	int minsup = 5;
-	int max_iteration = 200;
+	int max_iteration = 500;
 	Handle ure_results = ure_pm(_tmp_as, minsup, max_iteration,
 	                            initpat,
 	                            incremental_expansion,


### PR DESCRIPTION
to garanty that it passes regardless of the random generator.