### PR TITLE
Change the formula used in inheritance-to-member

### DIFF
--- a/opencog/pln/rules/wip/inheritance-to-member.scm
+++ b/opencog/pln/rules/wip/inheritance-to-member.scm
@@ -40,7 +40,7 @@
 (define (inheritance-to-member-formula MBC IBC)
 	(cog-set-tv!
 		MBC
-		(member-to-inheritance-side-effect-free-formula
+		(inheritance-to-member-side-effect-free-formula
 			MBC
 			IBC)))
 


### PR DESCRIPTION
@ngeiswei I suppose it should be `inheritance-to-member-side-effect-free-formula` instead of `member-to-inheritance-side-effect-free-formula` in the `inheritance-to-member-formula` ?