### PR TITLE
Improve I-Surprisingness

### DIFF
--- a/opencog/learning/miner/MinerUtils.h
+++ b/opencog/learning/miner/MinerUtils.h
@@ -246,6 +246,18 @@ public:
 	                                    unsigned ms);
 
 	/**
+	 * Create a pattern body from clauses, introducing an AndLink if
+	 * necessary.
+	 */
+	static Handle mk_body(const HandleSeq& clauses);
+
+	/**
+	 * Given a sequence of clause create a LambdaLink of it without
+	 * variable declaration, introducing an AndLink if necessary.
+	 */
+	static Handle mk_pattern_without_vardecl(const HandleSeq& clauses);
+
+	/**
 	 * Given a vardecl and a body, filter the vardecl to contain only
 	 * variable of the body, and create a Lambda with them.
 	 */
@@ -256,6 +268,12 @@ public:
 	 * connected components.
 	 */
 	static HandleSeq get_component_patterns(const Handle& pattern);
+
+	/**
+	 * Like above but consider a sequence of clauses instead of a
+	 * pattern, and return a sequence of sequences of clauses.
+	 */
+	static HandleSeqSeq get_components(const HandleSeq& clauses);
 
 	/**
 	 * Given a pattern, split it into its disjuncts.
@@ -341,7 +359,7 @@ public:
 	 * Given a pattern, return its clause. If the pattern is not a
 	 * scope link (i.e. a constant/text), then behavior is undefined.
 	 */
-	static const HandleSeq& get_clauses(const Handle& pattern);
+	static HandleSeq get_clauses(const Handle& pattern);
 
 	/**
 	 * Return the number of conjuncts in a pattern. That is, if the

--- a/opencog/learning/miner/Surprisingness.cc
+++ b/opencog/learning/miner/Surprisingness.cc
@@ -277,8 +277,9 @@ double Surprisingness::inner_product(const std::vector<HandleCounter>& dists)
 double Surprisingness::emp_prob(const Handle& pattern, const HandleSet& texts)
 {
 	double ucount = pow((double)texts.size(), MinerUtils::n_conjuncts(pattern));
-	double sup = MinerUtils::calc_support(pattern, texts, (unsigned)ucount);
-	// logger().debug() << "prob(" << oc_to_string(pattern) << ") = " << "sup = " << sup << ", ucount = " << ucount << ", res = " << sup/ucount;
+	unsigned ms = (unsigned)std::min((double)UINT_MAX, ucount);
+	double sup = MinerUtils::calc_support(pattern, texts, ms);
+	// logger().debug() << "emp_prob(" << oc_to_string(pattern) << ") = " << "sup = " << sup << ", ucount = " << ucount << ", res = " << sup/ucount;
 	return sup / ucount;
 }
 

--- a/opencog/learning/miner/Surprisingness.cc
+++ b/opencog/learning/miner/Surprisingness.cc
@@ -36,6 +36,7 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/algorithm/transform.hpp>
 #include <boost/range/algorithm/min_element.hpp>
+#include <boost/range/algorithm/sort.hpp>
 #include <boost/range/numeric.hpp>
 #include <boost/math/special_functions/binomial.hpp>
 
@@ -291,6 +292,7 @@ double Surprisingness::ji_prob(const HandleSeqSeq& partition,
 	                                        *pattern->getAtomSpace());
 
 	// Calculate the product of the probability over subpatterns
+	// without considering joint variables
 	double p = 1.0;
 	for (const Handle& subpattern : subpatterns)
 		p *= emp_prob(subpattern, texts);
@@ -305,21 +307,32 @@ double Surprisingness::ji_prob(const HandleSeqSeq& partition,
 	return p;
 }
 
+bool Surprisingness::has_same_index(const Handle& l_pat,
+                                    const Handle& r_pat,
+                                    const Handle& var)
+{
+	const Variables& lv = LambdaLinkCast(l_pat)->get_variables();
+	const Variables& rv = LambdaLinkCast(r_pat)->get_variables();
+	auto lv_it = lv.index.find(var);
+	auto rv_it = rv.index.find(var);
+	return lv_it != lv.index.end() and rv_it != lv.index.end()
+		and lv_it->second == rv_it->second;
+}
+
 bool Surprisingness::is_equivalent(const HandleSeq& l_blk,
                                    const HandleSeq& r_blk,
                                    const Handle& var)
 {
 	Handle l_pat = mk_pattern(l_blk);
 	Handle r_pat = mk_pattern(r_blk);
-	if (content_eq(l_pat, r_pat)) {
-		const Variables& lv = LambdaLinkCast(l_pat)->get_variables();
-		const Variables& rv = LambdaLinkCast(r_pat)->get_variables();
-		auto lvit = lv.index.find(var);
-		auto rvit = rv.index.find(var);
-		return lvit != lv.index.end() and rvit != lv.index.end()
-			and lvit->second == rvit->second;
-	}
-	return false;
+	return is_equivalent(l_pat, r_pat, var);
+}
+
+bool Surprisingness::is_equivalent(const Handle& l_pat,
+                                   const Handle& r_pat,
+                                   const Handle& var)
+{
+	return content_eq(l_pat, r_pat) and has_same_index(l_pat, r_pat, var);
 }
 
 HandleSeqUCounter::const_iterator Surprisingness::find_equivalent(
@@ -346,6 +359,94 @@ HandleSeqUCounter::iterator Surprisingness::find_equivalent(
 	return it;
 }
 
+bool Surprisingness::is_more_abstract(const HandleSeq& l_blk,
+                                      const HandleSeq& r_blk,
+                                      const Handle& var)
+{
+	Handle l_pat = mk_pattern(l_blk);
+	Handle r_pat = mk_pattern(r_blk);
+	return is_more_abstract(l_pat, r_pat, var);
+}
+
+bool Surprisingness::is_more_abstract(const Handle& l_pat,
+                                      const Handle& r_pat,
+                                      const Handle& var)
+{
+	Variables l_vars = MinerUtils::get_variables(l_pat);
+	Variables r_vars = MinerUtils::get_variables(r_pat);
+	Handle l_body = MinerUtils::get_body(l_pat);
+	Handle r_body = MinerUtils::get_body(r_pat);
+
+	// Let's first make sure that var is both in l_pat and r_pat
+	if (not l_vars.is_in_varset(var) or not r_vars.is_in_varset(var))
+		return false;
+
+	// Remove var from l_vars and r_vars to be considered as value
+	// rather than variable.
+	l_vars.erase(var);
+	r_vars.erase(var);
+
+	// Find all mappings from variables (except var) to terms
+	Unify unify(l_body, r_body, l_vars, r_vars);
+	// logger().debug() << "unify" << std::endl
+	//                  << "l_body:" << std::endl << oc_to_string(l_body)
+	//                  << "r_body:" << std::endl << oc_to_string(r_body)
+	//                  << "l_vars:" << std::endl << oc_to_string(l_vars)
+	//                  << "r_vars:" << std::endl << oc_to_string(r_vars);
+	Unify::SolutionSet sol = unify();
+
+	// If it is not satisfiable, l_pat is not an abstraction
+	//
+	// TODO: case of nary conjunctions additional care is needed
+	if (not sol.is_satisfiable())
+		return false;
+
+	Unify::TypedSubstitutions tsub = unify.typed_substitutions(sol, r_body);
+
+	// Check that for all mappings no variable in r_vars maps to a
+	// value (non-variable).
+	for (const auto& var2val_map : tsub)
+		for (const auto& var_val : var2val_map.first)
+			if (is_value(var_val, r_vars))
+				return false;
+	return true;
+}
+
+bool Surprisingness::is_strictly_more_abstract(const HandleSeq& l_blk,
+                                               const HandleSeq& r_blk,
+                                               const Handle& var)
+{
+	return not is_equivalent(l_blk, r_blk, var)
+		and is_more_abstract(l_blk, r_blk, var);
+}
+
+bool Surprisingness::is_value(const Unify::HandleCHandleMap::value_type& var_val,
+                              const Variables& vars)
+{
+	return vars.is_in_varset(var_val.first)
+		and not var_val.second.is_free_variable();
+}
+
+void Surprisingness::rank_by_abstraction(HandleSeqSeq& partition, const Handle& var)
+{
+	boost::sort(partition,
+	            [&](const HandleSeq& l_blk, const HandleSeq& r_blk) {
+		            // sort operates on strict weak order so is
+		            // compatible with is_strictly_more_abstract
+		            return is_strictly_more_abstract(l_blk, r_blk, var);
+	            });
+}
+
+HandleSeqSeq Surprisingness::copy_var_blocks(const HandleSeqSeq& partition,
+                                             const Handle& var)
+{
+	HandleSeqSeq var_partition;
+	for (const HandleSeq& blk : partition)
+		if (is_free_in_any_tree(blk, var))
+			var_partition.push_back(blk);
+	return var_partition;
+}
+
 HandleSeqUCounter Surprisingness::group_eq(const HandleSeqSeq& partition,
                                            const Handle& var)
 {
@@ -367,40 +468,59 @@ double Surprisingness::eq_prob(const HandleSeqSeq& partition,
                                const Handle& pattern,
                                const HandleSet& texts)
 {
+	// logger().debug() << "Surprisingness::eq_prob_alt partition:"
+	//                  << std::endl << oc_to_string(partition)
+	//                  << ", pattern:" << std::endl << oc_to_string(pattern)
+	//                  << ", texts.size() = " << texts.size();
+
 	double p = 1.0;
 	// Calculate the probability of a variable taking the same value
 	// across all blocks/subpatterns where that variable appears.
 	for (const Handle& var : joint_variables(pattern, partition)) {
 		// logger().debug() << "var = " << oc_to_string(var);
 
-		// Group subpatterns in equivalence blocks/subpatterns
-		// w.r.t. var. For each subpattern divide p by the number of
-		// values var can take (i.e. |texts| since each subpattern is
-		// independent), then within each subpattern, divide as many
-		// times as they are equivalent subpatterns by the number of
-		// values var actually takes, since all subpatterns are
-		// equivalent this restrict the universes where these
-		// subpatterns are only over these existing values.
-		double uc = texts.size();
-		for (const auto& blk_c : group_eq(partition, var)) {
-			// Take care of the independent part
-			p /= uc;
-			// logger().debug() << "divide p by " << uc
-			//                  << " for block:" << std::endl
-			//                  << oc_to_string(blk_c.first);
-			// Take care of the dependent (equivalent for now) part
-			if (1 < blk_c.second) {
-				double c = value_count(blk_c.first, var, texts);
-				p /= std::pow(c, blk_c.second - 1.0);
-				// logger().debug() << "divide p by " << std::pow(c, blk_c.second - 1.0)
-				//                  << " for " << blk_c.second - 1.0
-				//                  << " equivalent block(s)";
-			}
-		}
+		// Select all blocks containing var
+		HandleSeqSeq var_partition = copy_var_blocks(partition, var);
+		// logger().debug() << "var_partition = " << oc_to_string(var_partition);
 
-		// Finally multiple by the maximum number of values to normalize
-		// p, because P(equal) happens for each value.
-		p *= uc;
+		// For each variable, sort the partition so that abstract
+		// blocks, relative to var, appear first.
+		rank_by_abstraction(var_partition, var);
+		// logger().debug() << "var_partition (after ranking by abstraction) = "
+		//                  << oc_to_string(var_partition);
+
+		// For each block j_blk, but the first, look for the most
+		// specialized block that is more abstract or equivalent to that
+		// block relative to var, i_blk, and use the fact that var
+		// cannot take more values than its count in i_blk. If no such
+		// i_blk block exists, then use uc=|U| as count.
+		for (int j = 1; j < (int)var_partition.size(); j++) {
+			// logger().debug() << "var_partition[" << j << "]:" << std::endl
+			//                  << oc_to_string(var_partition[j]);
+
+			// Since abstraction relation is transitive, one can just go
+			// backward from j_blk and pick up the first i_blk that is
+			// either equivalent or more abstract, it will be the most
+			// specialized abstraction.
+			int i = j-1;
+			while (0 <= i)
+				if (is_more_abstract(var_partition[i], var_partition[j], var))
+					break;
+				else i--;
+
+			// if (0 <= i)
+			// 	logger().debug() << "var_partition[" << i
+			// 	                 << "] (most specialized abstraction):" << std::endl
+			// 	                 << oc_to_string(var_partition[j]);
+			// else
+			// 	logger().debug() << "no abstraction (i = " << i << ")";
+
+			double c = texts.size();
+			if (0 <= i)
+				c = value_count(var_partition[i], var, texts);
+			logger().debug() << "c = " << c;
+			p /= c;
+		}
 	}
 	return p;
 }

--- a/opencog/learning/miner/Surprisingness.cc
+++ b/opencog/learning/miner/Surprisingness.cc
@@ -186,7 +186,7 @@ HandleSeqSeqSeq Surprisingness::partitions(const Handle& pattern)
 	HandleSeqSeqSeq prtns = partitions(MinerUtils::get_clauses(pattern));
 	prtns.resize(prtns.size() - 1);
 	// prtns.resize(1); // comment this output to only consider
-	                    // singleton blocks (convenient for debugging)
+   //                  // singleton blocks (convenient for debugging)
 	return prtns;
 }
 
@@ -519,7 +519,7 @@ double Surprisingness::eq_prob(const HandleSeqSeq& partition,
 			double c = texts.size();
 			if (0 <= i)
 				c = value_count(var_partition[i], var, texts);
-			logger().debug() << "c = " << c;
+			// logger().debug() << "c = " << c;
 			p /= c;
 		}
 	}

--- a/opencog/learning/miner/Surprisingness.h
+++ b/opencog/learning/miner/Surprisingness.h
@@ -27,6 +27,7 @@
 #include <opencog/atoms/base/Handle.h>
 #include <opencog/atoms/core/LambdaLink.h>
 #include <opencog/atomspace/AtomSpace.h>
+#include <opencog/unify/Unify.h>
 
 namespace opencog
 {
@@ -134,10 +135,10 @@ public:
 	 * The problem is that, first, calculating such probability
 	 * distribution is expensive, and second, the resulting estimate is
 	 * too accurate and thus most pattern are measured as unsurprising
-	 * due to the inner product capturing the interactions, at the
-	 * point of contact of the variable, between the components.
-	 * Instead an estimate relying on the counts alone of values
-	 * associated to given variables in given components is derived.
+	 * due to the inner product capturing the interactions at the point
+	 * of contact of the variable, between the components.  Instead an
+	 * estimate relying on the counts alone of values associated to
+	 * given variables in given components is derived.
 	 *
 	 * Let's assume the same variable X appears in n difference
 	 * components. Let's call these variable appearences X1 to Xn. So
@@ -169,7 +170,9 @@ public:
 	 * adequatly discounts in the surprisingness measure the
 	 * surprisingness of the pattern alone.
 	 *
-	 * Example:
+	 * ## Examples
+	 *
+	 * ### First Example
 	 *
 	 * pattern
 	 * =
@@ -177,8 +180,8 @@ public:
 	 *   X Y
 	 *   And
 	 *     Inheritance X Y
-	 *     Inheritance H Y
-	 *     Inheritance F X
+	 *     Inheritance F Y
+	 *     Inheritance G X
 	 *
 	 * Let's consider a partition of 3 components/blocks, each clause
 	 * is a block.
@@ -189,8 +192,8 @@ public:
 	 *
 	 * All variables of this partition are joint (F and G are
 	 * constants). However relative to X components A and C are
-	 * independent, while relative to Y comomponent B is a
-	 * specialization of component A.
+	 * independent, while relative to Y component B is a specialization
+	 * of component A.
 	 *
 	 * Let's rewrite the component variables by explicitly showing
 	 * variable occurences in components
@@ -199,11 +202,12 @@ public:
 	 * B = Inheritance F Y2
 	 * C = Inheritance G X2
 	 *
-	 * The specialization relationship between A and B relative of Y
+	 * The specialization relationship between A and B relative to Y
 	 * allows us to infer that V(Y2) is a subset of V(Y1). Thus the
-	 * number of possible values that Y2 can take is bounded by S1.
+	 * number of possible values that Y2 can take is bounded by
+	 * |V(Y1)|.
 	 *
-	 * Let's calculate the P(X1=X2) and P(Y1=Y2) for this pattern.
+	 * Let's calculate P(X1=X2) and P(Y1=Y2) for this pattern.
 	 *
 	 * P(X1=X2) = 1/|U| * 1/|U| * |U|
 	 *          = 1/|U|
@@ -213,7 +217,7 @@ public:
 	 * are independent relative to X, each value of X2 can also be any
 	 * value of U. Then we multiple by |U| because the equality may
 	 * occur for each possible value of X1 or X2, so the probabilities
-	 * add up.
+	 * add up. Now for P(Y1=Y2)
 	 *
 	 * P(Y1=Y2) = 1/|U| * 1/|V(Y1)| * |U|
 	 *          = 1/|V(Y1)|
@@ -224,7 +228,7 @@ public:
 	 * Y. Then we multiple by |U| to add up all probabilities for each
 	 * values of the more abstract component A.
 	 *
-	 * Another example:
+	 * ### Second Example
 	 *
 	 * pattern
 	 * =
@@ -250,22 +254,61 @@ public:
 	 * Here A and B are actually equivalent relative to Y, meaning the
 	 * specialization relationship must not be strict.
 	 *
-	 * Without loss of generality let's assume that the variable
-	 * occurrences X1, ..., Xn are ordered such that for any i<j, Xi
-	 * occurs in a component that is either more abstract or equivalent
-	 * to the component where Xj occurs. Then the general formula is
+	 * ### Third Example
 	 *
-	 * P(X1=...=Xi=...=Xn) = Prod_{j=2}^n 1/|V(M(Xj))|
+	 * pattern
+	 * =
+	 * Lambda
+	 *   X Y Z W
+	 *   And
+	 *     List X Y X
+	 *     List Z W X
 	 *
-	 * where M(Xj) is the variable occurrence Xi of the most
-	 * specialized component with the component where Xj occurs
-	 * relative to X, such such that i<j.
+	 * Assuming a partition of the 2 components
+	 *
+	 * A = List X Y X
+	 * B = List Z W X
+	 *
+	 * Thus after explicitly showing variable occurences
+	 *
+	 * A = List X1 Y X1
+	 * B = List Z W X2
+	 *
+	 * P(X1=X2) = 1/|U| * 1/|V(X2)| * |U| = 1/|V(X2)|
+	 *
+	 * It doesn't matter that X1 appears twice in A, the number values
+	 * it can take is still bounded by its most specialized abstraction
+	 * relative to X, that is B.
+	 *
+	 * ## General formula
+	 *
+	 * Let X be a variable, with n variable occurences X1, ..., Xn in
+	 * the respective components C1, ..., Cn. Without loss of
+	 * generality let's assume that C1, ..., Cn are ordered such that
+	 * if Ci is strictly more abstract than Cj relative to X, then
+	 * i<j. This admits many orders as it doesn't impose restrictions
+	 * on components that are equivalent or independent.  But it
+	 * doesn't matter as it is only used to avoid cycles in the
+	 * calculation of the probability estimate. Then the general
+	 * formula is
+	 *
+	 * P(X1=...=Xn) = Prod_{j=2}^n 1/M(Xj)
+	 *
+	 * where M(Xj) is either
+	 *
+	 * 1. |V(Xi)|, the count of Xi in the most specialized component Ci
+	 * that is either more abstract than or equivalent to Cj relative
+	 * to X and such that i<j.
+	 *
+	 * 2. |U|, if no such more abstract or equivalent component exists
+	 * for Xj.
 	 *
 	 * A proof sketch of why it is a good estimate of P(X1=...=Xn)
 	 * (under independence assumption of the data) is that the
 	 * syntactic specialization relationship provides a prior to
-	 * discard distributions of values of variable occurences Xi using
-	 * subset relationships between V(Xi) and V(Xj).
+	 * discard distributions (i.e. set their prior probabilities to 0)
+	 * of values of variable occurences Xi using subset relationships
+	 * between V(Xi) and V(Xj).
 	 *
 	 * One last remark: The count |V(Xi)| can be exact or approximated.
 	 * Of course the estimate will be better if the count is exact.
@@ -467,7 +510,7 @@ public:
 	/**
 	 * Calculate probability estimate of a pattern given a partition,
 	 * assuming all blocks are independent, but takes into account the
-	 * joint variables.
+	 * joint variables (ji in ji_prob stands for joint-independent).
 	 *
 	 * An atomspace is provided to memoize the support of subpatterns.
 	 */
@@ -476,8 +519,16 @@ public:
 	                      const HandleSet& texts);
 
 	/**
-	 * Tell whether 2 blocks/subpatterns are equivalent with respect to
-	 * a given variable. Basically, whether both block are semantically
+	 * Return true iff the given variable has the same position (same
+	 * index) in the variable declarations of both patterns.
+	 */
+	static bool has_same_index(const Handle& l_pat,
+	                           const Handle& r_pat,
+	                           const Handle& var);
+
+	/**
+	 * Tell whether 2 blocks/subpatterns are equivalent relatie to a
+	 * given variable. Basically, whether both block are semantically
 	 * equivalent and var is in the same position in both of them.
 	 *
 	 * For instance
@@ -485,12 +536,20 @@ public:
 	 * l_blk = { Inh X Y }
 	 * r_blk = { Inh Z Y }
 	 *
-	 * are equivalent w.r.t Y because are both are semantically
+	 * are equivalent relative to Y because are both are semantically
 	 * equivalent (up to an alpha-conversion) and Y is used in the same
 	 * place in both blocks.
 	 */
 	static bool is_equivalent(const HandleSeq& l_blk,
 	                          const HandleSeq& r_blk,
+	                          const Handle& var);
+
+	/**
+	 * List above but takes scope links instead of blocks (whether each
+	 * scope link has the conjunction of clauses of its block as body).
+	 */
+	static bool is_equivalent(const Handle& l_pat,
+	                          const Handle& r_pat,
 	                          const Handle& var);
 
 	static HandleSeqUCounter::const_iterator find_equivalent(
@@ -501,6 +560,64 @@ public:
 		HandleSeqUCounter& partition_c,
 		const HandleSeq& block,
 		const Handle& var);
+
+	/**
+	 * Tell whether the left block/subpattern is is syntactically more
+	 * abstract than the right block/subpattern relative to a given
+	 * variable.
+	 *
+	 * For instance
+	 *
+	 * l_blk = { List X Y Z }
+	 * r_blk = { List W A Z }
+	 *
+	 * l_blk is more abstract than r_blk relative to Z because the
+	 * matching values of Z in l_blk is a subset of the matching values
+	 * of Z in l_blk.
+	 */
+	static bool is_more_abstract(const HandleSeq& l_blk,
+	                             const HandleSeq& r_blk,
+	                             const Handle& var);
+
+	/**
+	 * List above but takes scope links instead of blocks (whether each
+	 * scope link has the conjunction of clauses of its block as body).
+	 *
+	 * TODO: for now, this code relies on unification. However it can
+	 * certainly be optimized by not relying on unification and being
+	 * re-implemented instead, and perhaps it could then be merged to
+	 * the unification code.
+	 */
+	static bool is_more_abstract(const Handle& l_pat,
+	                             const Handle& r_pat,
+	                             const Handle& var);
+
+	/**
+	 * Return true iff l_blk is strictly more abstract than r_blk
+	 * relative to var. That is more abstract and not equivalent.
+	 */
+	static bool is_strictly_more_abstract(const HandleSeq& l_blk,
+	                                      const HandleSeq& r_blk,
+	                                      const Handle& var);
+
+	/**
+	 * Return true iff var_val is a pair with the first element a
+	 * variable in vars, and the second element a value (non-variable).
+	 */
+	static bool is_value(const Unify::HandleCHandleMap::value_type& var_val,
+	                     const Variables& vars);
+
+	/**
+	 * Sort the partition such that if block A is strictly more
+	 * abstract than block B relative var, then A occurs before B.
+	 */
+	static void rank_by_abstraction(HandleSeqSeq& partition, const Handle& var);
+
+	/**
+	 * Copy all blocks where var appears
+	 */
+	static HandleSeqSeq copy_var_blocks(const HandleSeqSeq& partition,
+	                                    const Handle& var);
 
 	/**
 	 * Given subpatterns linked by a variable, count how many
@@ -531,11 +648,20 @@ public:
 	/**
 	 * For each joint variable of pattern (variable that appears in
 	 * more than one partition block) calculate the probability
-	 * estimate of being assigned the same value across all block.
+	 * estimate of being assigned the same value across all blocks.
 	 */
 	static double eq_prob(const HandleSeqSeq& partition,
 	                      const Handle& pattern,
 	                      const HandleSet& texts);
+
+	/**
+	 * Alternate implementation of eq_prob. Takes into syntactical
+	 * abstraction between blocks in order to better estimate variable
+	 * occurance equality (see the comment above isurp).
+	 */
+	static double eq_prob_alt(const HandleSeqSeq& partition,
+	                          const Handle& pattern,
+	                          const HandleSet& texts);
 };
 
 /**

--- a/tests/learning/miner/SurprisingnessUTest.cxxtest
+++ b/tests/learning/miner/SurprisingnessUTest.cxxtest
@@ -67,10 +67,17 @@ private:
 	// inheritance links to _texts_cpt.
 	void load_ugly_male_soda_drinker_corpus();
 
-	// Generate Inheritance betwee n_cpts concept nodes with a
+	// Populate the atomspace with n_cpts concept nodes
+	HandleSeq populate_concepts(unsigned n_cpts);
+
+	// Populate Inheritance between n_cpts concept nodes with a
 	// probability ip to have an inheritance between 2 concept nodes,
-	// and associate all created atoms to _texts_cpt.
-	void mk_uniform_inheritance_links(unsigned n_cpts, double ip);
+	// and associate all created atoms to _texts_cpt. The semantics of
+	// Inheritance is not taken into account.
+	void populate_uniform_inheritance_links(unsigned n_cpts, double ip);
+
+	// Generate Lists of ari concepts among n_cpts
+	void populate_uniform_list_links(unsigned n_cpts, unsigned ari, double ip);
 
 public:
 	SurprisingnessUTest();
@@ -81,6 +88,8 @@ public:
 
 	// Test auxilary methods
 	void test_partitions();
+	void test_is_more_abstract();
+	void test_is_strictly_more_abstract();
 
 	// Test surprisingness measures
 	void test_nisurp_old_ugly_man();
@@ -99,6 +108,8 @@ public:
 	void test_nisurp_linkage_synthetic_6();
 	// TODO: re-enable when specialized subpattern are supported
 	void xtest_nisurp_linkage_synthetic_7();
+	void test_nisurp_linkage_synthetic_8();
+	void test_nisurp_linkage_synthetic_9();
 	void test_nisurp_ugly_man_soda_drinker();
 };
 
@@ -119,7 +130,7 @@ void SurprisingnessUTest::load_ugly_male_soda_drinker_corpus()
 		al(MEMBER_LINK, text, _texts_cpt);
 }
 
-void SurprisingnessUTest::mk_uniform_inheritance_links(unsigned n_cpts, double ip)
+HandleSeq SurprisingnessUTest::populate_concepts(unsigned n_cpts)
 {
 	// Create concepts Ci for i in [0, n_cpts)
 	HandleSeq cpts(n_cpts);
@@ -127,6 +138,14 @@ void SurprisingnessUTest::mk_uniform_inheritance_links(unsigned n_cpts, double i
 		cpts[i] = an(CONCEPT_NODE, std::string("C") + std::to_string(i));
 		al(MEMBER_LINK, cpts[i], _texts_cpt);
 	}
+	return cpts;
+}
+
+void SurprisingnessUTest::populate_uniform_inheritance_links(unsigned n_cpts,
+                                                             double ip)
+{
+	// Create concepts Ci for i in [0, n_cpts)
+	HandleSeq cpts = populate_concepts(n_cpts);
 
 	// For any Ci Cj pair create a Inheritance Link between them with
 	// probability ip and add it to the data base.
@@ -135,6 +154,29 @@ void SurprisingnessUTest::mk_uniform_inheritance_links(unsigned n_cpts, double i
 			if (biased_randbool(ip)) {
 				Handle InhCiCj = al(INHERITANCE_LINK, Ci, Cj);
 				al(MEMBER_LINK, InhCiCj, _texts_cpt);
+			}
+		}
+	}
+
+	// logger().debug() << "AtomSpace:" << std::endl << _as;
+}
+
+void SurprisingnessUTest::populate_uniform_list_links(unsigned n_cpts,
+                                                      unsigned ari,
+                                                      double ip)
+{
+	// Create concepts Ci for i in [0, n_cpts)
+	HandleSeq cpts = populate_concepts(n_cpts);
+
+	// For any Ci Cj Ck triple create a List Link between them with
+	// probability ip and add it to the data base.
+	for (const Handle& Ci : cpts) {
+		for (const Handle& Cj : cpts) {
+			for (const Handle& Ck : cpts) {
+				if (biased_randbool(ip)) {
+					Handle ListCiCjCk = al(LIST_LINK, Ci, Cj, Ck);
+					al(MEMBER_LINK, ListCiCjCk, _texts_cpt);
+				}
 			}
 		}
 	}
@@ -206,6 +248,34 @@ void SurprisingnessUTest::test_partitions()
 	logger().debug() << "expect = " << oc_to_string(expect);
 
 	TS_ASSERT_EQUALS(result, expect);
+}
+
+void SurprisingnessUTest::test_is_more_abstract()
+{
+	HandleSeq l_blk{al(LIST_LINK, Z, W, X)};
+	HandleSeq r_blk{al(LIST_LINK, X, Y, X)};
+
+	// Left block/subpattern is more abstract than right
+	// block/subpattern, relative to Z.
+	TS_ASSERT(Surprisingness::is_more_abstract(l_blk, r_blk, X));
+}
+
+void SurprisingnessUTest::test_is_strictly_more_abstract()
+{
+	HandleSeq l_blk{al(LIST_LINK, X, Y, Z)};
+	HandleSeq r_blk{al(LIST_LINK, W, C0, Z)};
+
+	// Left block/subpattern is strictly more abstract than right
+	// block/subpattern, relative to Z.
+	TS_ASSERT(Surprisingness::is_strictly_more_abstract(l_blk, r_blk, Z));
+
+	// Left block/subpattern is not more abstract than right
+	// block/subpattern, relative to X.
+	TS_ASSERT(not Surprisingness::is_strictly_more_abstract(l_blk, r_blk, X));
+
+	// Left block/subpattern is not more abstract than itself relative
+	// to Z, since it is equivalent.
+	TS_ASSERT(not Surprisingness::is_strictly_more_abstract(l_blk, l_blk, Z));
 }
 
 // Test old normalized I-Surprisingess for the ugly male
@@ -341,7 +411,7 @@ void SurprisingnessUTest::test_nisurp_old_ugly_man_soda_drinker()
 void SurprisingnessUTest::test_nisurp_no_linkage_synthetic_1()
 {
 	// Create data base
-	mk_uniform_inheritance_links(1000, 0.01);
+	populate_uniform_inheritance_links(1000, 0.01);
 
 	// Create pattern to measure surprisingness of
 	//
@@ -392,7 +462,7 @@ void SurprisingnessUTest::test_nisurp_no_linkage_synthetic_1()
 void SurprisingnessUTest::test_nisurp_no_linkage_synthetic_2()
 {
 	// Create data base
-	mk_uniform_inheritance_links(1000, 0.5);
+	populate_uniform_inheritance_links(1000, 0.5);
 
 	// Create pattern to measure surprisingness of
 	//
@@ -447,7 +517,7 @@ void SurprisingnessUTest::test_nisurp_no_linkage_synthetic_2()
 void SurprisingnessUTest::xtest_nisurp_linkage_synthetic_1()
 {
 	// Create data base
-	mk_uniform_inheritance_links(1000, 0.1);
+	populate_uniform_inheritance_links(1000, 0.1);
 
 	// Create pattern to measure surprisingness of
 	//
@@ -498,7 +568,7 @@ void SurprisingnessUTest::xtest_nisurp_linkage_synthetic_1()
 void SurprisingnessUTest::test_nisurp_linkage_synthetic_2()
 {
 	// Create data base
-	mk_uniform_inheritance_links(1000, 0.1);
+	populate_uniform_inheritance_links(1000, 0.1);
 
 	// Create pattern to measure surprisingness of
 	//
@@ -549,7 +619,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_2()
 void SurprisingnessUTest::test_nisurp_linkage_synthetic_3()
 {
 	// Create data base
-	mk_uniform_inheritance_links(1000, 0.001);
+	populate_uniform_inheritance_links(10000, 0.001);
 
 	// Create pattern to measure surprisingness of
 	//
@@ -583,7 +653,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_3()
 	// Since the pattern is composed of 2 independent patterns, it
 	// should be completely unsurprising, thus have a nearly null
 	// nisurp measure.
-	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 0.6);
+	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 1e-3);
 }
 
 // Similar to above for pattern
@@ -609,7 +679,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_3()
 void SurprisingnessUTest::test_nisurp_linkage_synthetic_4()
 {
 	// Create data base
-	mk_uniform_inheritance_links(1000, 0.01);
+	populate_uniform_inheritance_links(1000, 0.01);
 
 	// Create pattern to measure surprisingness of
 	//
@@ -671,7 +741,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_4()
 void SurprisingnessUTest::xtest_nisurp_linkage_synthetic_5()
 {
 	// Create data base
-	mk_uniform_inheritance_links(1000, 0.1);
+	populate_uniform_inheritance_links(1000, 0.1);
 
 	// Create pattern to measure surprisingness of
 	//
@@ -732,7 +802,7 @@ void SurprisingnessUTest::xtest_nisurp_linkage_synthetic_5()
 void SurprisingnessUTest::test_nisurp_linkage_synthetic_6()
 {
 	// Create data base
-	mk_uniform_inheritance_links(1000, 0.01);
+	populate_uniform_inheritance_links(1000, 0.01);
 
 	// Create pattern to measure surprisingness of
 	//
@@ -800,7 +870,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_6()
 void SurprisingnessUTest::xtest_nisurp_linkage_synthetic_7()
 {
 	// Create data base
-	mk_uniform_inheritance_links(1000, 0.01);
+	populate_uniform_inheritance_links(1000, 0.01);
 
 	// Create pattern to measure surprisingness of
 	//
@@ -850,6 +920,132 @@ void SurprisingnessUTest::xtest_nisurp_linkage_synthetic_7()
 	// should be completely unsurprising, thus have a nearly null
 	// nisurp measure.
 	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 1e-9);
+}
+
+// Similar to above for pattern
+//
+// LambdaLink
+//   VariableList
+//     X
+//     Y
+//     Z
+//     W
+//   AndLink
+//     List
+//       X
+//       Y
+//       Z
+//     List
+//       W
+//       Y
+//       Z
+void SurprisingnessUTest::test_nisurp_linkage_synthetic_8()
+{
+	// Create data base
+	populate_uniform_list_links(50, 3, 0.1);
+
+	// Create pattern to measure surprisingness of
+	//
+	// LambdaLink
+	//   X Y Z W
+	//   AndLink
+	//     List
+	//       X
+	//       Y
+	//       Z
+	//     List
+	//       W
+	//       Y
+	//       Z
+	Handle pattern = al(LAMBDA_LINK,
+	                    al(VARIABLE_LIST, X, Y, Z, W),
+	                    al(AND_LINK,
+	                       al(LIST_LINK, X, Y, Z),
+	                       al(LIST_LINK, W, Y, Z)));
+	MinerUTestUtils::add_minsup_eval(_as, pattern, 5, TruthValue::TRUE_TV());
+
+	// Test normalized I-Surprisingness
+	HandleSeq isurp_results = ure_isurp("nisurp", 2);
+	Handle expected = MinerUTestUtils::add_isurp_eval(_as, pattern);
+
+	logger().debug() << "isurp_results = " << oc_to_string(isurp_results);
+
+	TS_ASSERT(not isurp_results.empty());
+
+	Handle isurp_front = isurp_results.front();
+
+	logger().debug() << "expected = " << oc_to_string(expected);
+	logger().debug() << "isurp_front = " << oc_to_string(isurp_front);
+
+	TS_ASSERT(content_eq(expected, isurp_front));
+
+	// Since the pattern is composed of 2 independent patterns, it
+	// should be completely unsurprising, thus have a nearly null
+	// nisurp measure.
+	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 0.3);
+}
+
+// Similar to above for pattern
+//
+// LambdaLink
+//   VariableList
+//     X
+//     Y
+//     Z
+//     W
+//   AndLink
+//     List
+//       X
+//       Y
+//       X
+//     List
+//       Z
+//       W
+//       X
+void SurprisingnessUTest::test_nisurp_linkage_synthetic_9()
+{
+	// Create data base
+	populate_uniform_list_links(50, 3, 0.1);
+
+	// Create pattern to measure surprisingness of
+	//
+	// LambdaLink
+	//   X Y Z W
+	//   AndLink
+	//     List
+	//       X
+	//       Y
+	//       X
+	//     List
+	//       Z
+	//       W
+	//       X
+	Handle pattern = al(LAMBDA_LINK,
+	                    al(VARIABLE_LIST, X, Y, Z, W),
+	                    al(AND_LINK,
+	                       al(LIST_LINK, X, Y, X),
+	                       al(LIST_LINK, Z, W, X)));
+	MinerUTestUtils::add_minsup_eval(_as, pattern, 5, TruthValue::TRUE_TV());
+
+	// Test normalized I-Surprisingness
+	HandleSeq isurp_results = ure_isurp("nisurp", 2);
+	Handle expected = MinerUTestUtils::add_isurp_eval(_as, pattern);
+
+	logger().debug() << "isurp_results = " << oc_to_string(isurp_results);
+
+	TS_ASSERT(not isurp_results.empty());
+
+	Handle isurp_front = isurp_results.front();
+
+	logger().debug() << "expected = " << oc_to_string(expected);
+	logger().debug() << "isurp_front = " << oc_to_string(isurp_front);
+
+	TS_ASSERT(content_eq(expected, isurp_front));
+
+	// Since the pattern is composed of 2 independent patterns, it
+	// should be completely unsurprising, thus have a nearly null
+	// nisurp measure.
+	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 0.3);
 }
 
 // Test normalized I-Surprisingess for the ugly male soda drinker

--- a/tests/learning/miner/SurprisingnessUTest.cxxtest
+++ b/tests/learning/miner/SurprisingnessUTest.cxxtest
@@ -103,11 +103,9 @@ public:
 	void test_nisurp_linkage_synthetic_2();
 	void test_nisurp_linkage_synthetic_3();
 	void test_nisurp_linkage_synthetic_4();
-	// TODO: re-enable when specialized subpattern are supported
-	void xtest_nisurp_linkage_synthetic_5();
+	void test_nisurp_linkage_synthetic_5();
 	void test_nisurp_linkage_synthetic_6();
-	// TODO: re-enable when specialized subpattern are supported
-	void xtest_nisurp_linkage_synthetic_7();
+	void test_nisurp_linkage_synthetic_7();
 	void test_nisurp_linkage_synthetic_8();
 	void test_nisurp_linkage_synthetic_9();
 	void test_nisurp_ugly_man_soda_drinker();
@@ -195,7 +193,7 @@ SurprisingnessUTest::SurprisingnessUTest() : _scm(&_as)
 	logger().set_print_to_stdout_flag(true);
 
 	// URE logger
-	ure_logger().set_level(Logger::DEBUG);
+	ure_logger().set_level(Logger::INFO);
 	ure_logger().set_timestamp_flag(false);
 	ure_logger().set_sync_flag(true);
 	ure_logger().set_print_to_stdout_flag(true);
@@ -738,7 +736,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_4()
 // closes, however in the second clauses it is a subset of the
 // possible values of the first clause, so again not completely
 // independent like in test_nisurp_linkage_synthetic_3
-void SurprisingnessUTest::xtest_nisurp_linkage_synthetic_5()
+void SurprisingnessUTest::test_nisurp_linkage_synthetic_5()
 {
 	// Create data base
 	populate_uniform_inheritance_links(1000, 0.1);
@@ -779,7 +777,7 @@ void SurprisingnessUTest::xtest_nisurp_linkage_synthetic_5()
 	// Since the pattern is composed of 2 independent patterns, it
 	// should be completely unsurprising, thus have a nearly null
 	// nisurp measure.
-	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 1e-9);
+	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 1e-2);
 }
 
 // Similar to above for pattern
@@ -867,7 +865,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_6()
 //     InheritanceLink
 //       Z
 //       C1
-void SurprisingnessUTest::xtest_nisurp_linkage_synthetic_7()
+void SurprisingnessUTest::test_nisurp_linkage_synthetic_7()
 {
 	// Create data base
 	populate_uniform_inheritance_links(1000, 0.01);
@@ -919,7 +917,7 @@ void SurprisingnessUTest::xtest_nisurp_linkage_synthetic_7()
 	// Since the pattern is composed of 2 independent patterns, it
 	// should be completely unsurprising, thus have a nearly null
 	// nisurp measure.
-	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 1e-9);
+	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 0.5);
 }
 
 // Similar to above for pattern

--- a/tests/learning/miner/SurprisingnessUTest.cxxtest
+++ b/tests/learning/miner/SurprisingnessUTest.cxxtest
@@ -88,7 +88,12 @@ public:
 
 	// Test auxilary methods
 	void test_partitions();
-	void test_is_more_abstract();
+	void test_is_syntax_more_abstract();
+	void test_is_more_abstract_1();
+	void test_is_more_abstract_2();
+	void test_is_more_abstract_3();
+	// TODO: fix is_more_abstract to support that case
+	void xtest_is_more_abstract_4();
 	void test_is_strictly_more_abstract();
 
 	// Test surprisingness measures
@@ -248,14 +253,82 @@ void SurprisingnessUTest::test_partitions()
 	TS_ASSERT_EQUALS(result, expect);
 }
 
-void SurprisingnessUTest::test_is_more_abstract()
+void SurprisingnessUTest::test_is_syntax_more_abstract()
 {
 	HandleSeq l_blk{al(LIST_LINK, Z, W, X)};
 	HandleSeq r_blk{al(LIST_LINK, X, Y, X)};
 
-	// Left block/subpattern is more abstract than right
-	// block/subpattern, relative to Z.
-	TS_ASSERT(Surprisingness::is_more_abstract(l_blk, r_blk, X));
+	// Left block/subpattern is syntactically more abstract than
+	// right block/subpattern, relative to X.
+	TS_ASSERT(Surprisingness::is_more_abstract(l_blk, r_blk, X)); }
+
+void SurprisingnessUTest::test_is_more_abstract_1()
+{
+	Handle l_pat = al(LAMBDA_LINK,
+	                  al(VARIABLE_LIST, X, Y, Z),
+	                  al(AND_LINK,
+	                     al(INHERITANCE_LINK, X, Z),
+	                     al(INHERITANCE_LINK, Y, Z)));
+	Handle r_pat = al(LAMBDA_LINK,
+	                  Z,
+	                  al(INHERITANCE_LINK, C0, Z));
+
+	// Left pattern is more abstract than right pattern, relative to Z.
+	TS_ASSERT(Surprisingness::is_more_abstract(l_pat, r_pat, Z));
+}
+
+void SurprisingnessUTest::test_is_more_abstract_2()
+{
+	Handle l_pat = al(LAMBDA_LINK,
+	                  al(VARIABLE_LIST, X, Y),
+	                  al(INHERITANCE_LINK, X, Z));
+	Handle r_pat = al(LAMBDA_LINK,
+	                  al(VARIABLE_LIST, X, Y, Z),
+	                  al(AND_LINK,
+	                     al(INHERITANCE_LINK, X, C0),
+	                     al(INHERITANCE_LINK, Z, Y),
+	                     al(INHERITANCE_LINK, Z, C1)));
+
+	// Left pattern is more abstract than right pattern, relative to X.
+	TS_ASSERT(Surprisingness::is_more_abstract(l_pat, r_pat, X));
+}
+
+void SurprisingnessUTest::test_is_more_abstract_3()
+{
+	Handle l_pat = al(LAMBDA_LINK,
+	                  al(VARIABLE_LIST, X, Y, Z),
+	                  al(AND_LINK,
+	                     al(INHERITANCE_LINK, X, Y),
+	                     al(INHERITANCE_LINK, Z, C1)));
+	Handle r_pat = al(LAMBDA_LINK,
+	                  al(VARIABLE_LIST, X, Z),
+	                  al(AND_LINK,
+	                     al(INHERITANCE_LINK, X, C0),
+	                     al(INHERITANCE_LINK, Z, Y)));
+
+	// Left pattern is more abstract than right pattern, relative to X.
+	TS_ASSERT(Surprisingness::is_more_abstract(l_pat, r_pat, X));
+
+	// Left pattern is more abstract than right pattern, relative to Y.
+	TS_ASSERT(Surprisingness::is_more_abstract(l_pat, r_pat, Y));
+}
+
+void SurprisingnessUTest::xtest_is_more_abstract_4()
+{
+	Handle l_pat = al(LAMBDA_LINK,
+	                  al(VARIABLE_LIST, X, Y, Z),
+	                  al(AND_LINK,
+	                     al(INHERITANCE_LINK, X, Y),
+	                     al(INHERITANCE_LINK, Z, Y)));
+	Handle r_pat = al(LAMBDA_LINK,
+	                  al(VARIABLE_LIST, X, Z),
+	                  al(INHERITANCE_LINK, Z, C0));
+
+	// Left pattern is more abstract than right pattern, relative to X.
+	TS_ASSERT(Surprisingness::is_more_abstract(l_pat, r_pat, X));
+
+	// Left pattern is more abstract than right pattern, relative to Y.
+	TS_ASSERT(Surprisingness::is_more_abstract(l_pat, r_pat, Y));
 }
 
 void SurprisingnessUTest::test_is_strictly_more_abstract()


### PR DESCRIPTION
Improve static analysis on the components of a pattern to avoid attributing dependence within the pattern structure as dependence within the data.

For instance in pattern
```
Lambda
  X Y Z W
  And
    List X Y Z
    List X C W
```
the second clause is a syntactic specialization of the first clause relative to variable X, meaning the domain of X in the second clause is necessarily a subset of the domain of X in the first clause, taking this knowledge into account improves the probability estimate that values are the same across occurrences of X.