### PR TITLE
Allow to call Python methods from GHOST

### DIFF
--- a/opencog/ghost/terms.scm
+++ b/opencog/ghost/terms.scm
@@ -254,13 +254,29 @@
 )
 
 ; ----------
+(define (parse-method-name method-name)
+"
+  Checks if the method-name has a prefix 'scm_' or 'py_'
+  and converts it to the corresponding name 'scm:name' or 'py:name'
+  to be used as GroundedPredicate name.
+  By default scm is used if the method-name does not have the prefix.
+"
+ (cond
+  ((string-prefix? "scm_" method-name)
+   (string-append "scm:" (substring method-name 4)))
+  ((string-prefix? "py_" method-name)
+   (string-append "py:" (substring method-name 3)))
+  (else (string-append "scm:" method-name))))
+
+; ----------
 (define (context-function NAME ARGS)
 "
   Occurrence of a function in the context of a rule.
-  The Scheme function named NAME should have already been defined.
+  The Scheme or Python function named NAME should have already been defined.
+  The Python name has 'py_' prefix and Scheme name has 'scm_' or no prefix.
 "
   ; TODO: Check to make sure the function has been defined
-  (Evaluation (GroundedPredicate (string-append "scm: " NAME))
+  (Evaluation (GroundedPredicate (parse-method-name NAME))
               (List (map (lambda (a) (if (equal? 'GlobNode (cog-type a))
                                          (List a) a))
                          ARGS))))
@@ -269,10 +285,11 @@
 (define (action-function NAME ARGS)
 "
   Occurrence of a function in the action of a rule.
-  The Scheme function named NAME should have already been defined.
+  The Scheme or Python function named NAME should have already been defined.
+  The Python name has 'py_' prefix and Scheme name has 'scm_' or no prefix.
 "
   ; TODO: Check to make sure the function has been defined
-  (ExecutionOutput (GroundedSchema (string-append "scm: " NAME))
+  (ExecutionOutput (GroundedSchema (parse-method-name NAME))
                    (List (map (lambda (a) (if (equal? 'GlobNode (cog-type a))
                                               (List a) a))
                               ARGS))))

--- a/tests/ghost/test-ghost-syntax.scm
+++ b/tests/ghost/test-ghost-syntax.scm
@@ -196,10 +196,35 @@
 (define-public (get-weather-info) (List (Word "sunny")))
 (define-public (check-name name) (if (string=? "Bob" (cog-name name)) (stv 1 1) (stv 0 1)))
 (ghost-parse "r: (tell me the weather) test function - ^get-weather-info")
+(ghost-parse "r: (what is the weather) test function - ^scm_get-weather-info")
 (ghost-parse "r: (who am I ^check-name(Bob)) test function - predicate")
+(ghost-parse "r: (who are you ^scm_check-name(Bob)) test function - scm predicate")
+
+
+(python-eval "
+from opencog.type_constructors import *
+from opencog.scheme_wrapper import scheme_eval_as
+from opencog.cogserver_type_constructors import *
+
+atomspace = scheme_eval_as('(cog-atomspace)')
+set_type_ctor_atomspace(atomspace)
+
+def get_weather_info():
+    return ListLink(WordLink('cloudy'))
+
+def check_name(word):
+    return TruthValue(1, 1) if word.name == 'Bob' else TruthValue(0, 0)
+")
+
+(ghost-parse "r: (what was the weather yesterday) test function - ^py_get_weather_info")
+(ghost-parse "r: (who were you ^py_check_name(Bob)) test function - py predicate")
 
 (test-equal ghost-function "test function - sunny" (get-result "tell me the weather"))
+(test-equal ghost-function "test function - sunny" (get-result "what is the weather"))
+(test-equal ghost-function "test function - cloudy" (get-result "what was the weather yesterday"))
 (test-equal ghost-function "test function - predicate" (get-result "who am I"))
+(test-equal ghost-function "test function - scm predicate" (get-result "who are you"))
+(test-equal ghost-function "test function - py predicate" (get-result "who were you"))
 
 ; --- Comparison --- ;
 (define ghost-comparison "GHOST comparison")

--- a/tests/ghost/test-ghost-syntax.scm
+++ b/tests/ghost/test-ghost-syntax.scm
@@ -211,7 +211,7 @@ atomspace = scheme_eval_as('(cog-atomspace)')
 set_type_ctor_atomspace(atomspace)
 
 def get_weather_info():
-    return ListLink(WordLink('cloudy'))
+    return ListLink(WordNode('cloudy'))
 
 def check_name(word):
     return TruthValue(1, 1) if word.name == 'Bob' else TruthValue(0, 0)

--- a/tests/ghost/test-ghost-syntax.scm
+++ b/tests/ghost/test-ghost-syntax.scm
@@ -15,7 +15,8 @@
   (opencog nlp chatbot)
   (opencog openpsi)
   (opencog ghost)
-  (opencog ghost procedures))
+  (opencog ghost procedures)
+  (opencog python))
 
 ; Set the address for relex server
 (set-relex-server-host)


### PR DESCRIPTION
This is a proposal to allow use Python methods from GHOST rules.
The prefix 'py_' can be used to mark a function or a predicate as defined in Python.
For example:
```scheme
; Function get_weather_info has 'py_' prefix
(ghost-parse "r: (what was the weather yesterday) ^py_get_weather_info")

; Predicate check_name(name) has 'py_' prefix
(ghost-parse "r: (who were you ^py_check_name(Bob)) I was Bob")
```

The full example:
```scheme
(python-eval "
from opencog.type_constructors import *
from opencog.scheme_wrapper import scheme_eval_as
from opencog.cogserver_type_constructors import *

atomspace = scheme_eval_as('(cog-atomspace)')
set_type_ctor_atomspace(atomspace)

def get_weather_info():
    return ListLink(WordNode('cloudy'))

def check_name(word):
    print('[python] check name:', word)
    return TruthValue(1, 1) if word.name == 'Bob' else TruthValue(0, 0)
")

(ghost-parse "r: (what was the weather yesterday)  ^py_get_weather_info")
(ghost-parse "r: (who were you ^py_check_name(Bob)) I was Bob")

(test-ghost "what was the weather yesterday")
(test-ghost "who were you")
``` 

If a function or a predicate are defined in Scheme the prefix 'scm_' or none can be used.

For example:
```scheme
(define-public (get-weather-info) (List (Word "sunny")))
(define-public (check-name name) (if (string=? "Bob" (cog-name name)) (stv 1 1) (stv 0 1)))

; Function without prefix is used
(ghost-parse "r: (tell me the weather)  ^get-weather-info")
; Function with prefix 'scm_' is used
(ghost-parse "r: (what is the weather)  ^scm_get-weather-info")

; Predicate without prefix is used
(ghost-parse "r: (who am I ^check-name(Bob)) I am Bob")
; Predicate with prefix 'scm_' is used
(ghost-parse "r: (who are you ^scm_check-name(Bob)) I am Bob")

(test-ghost "tell me the weather")
(test-ghost "what is the weather")

(test-ghost "who am I")
(test-ghost "who are you")
```

