### PR TITLE
Fix broken usage of association list

### DIFF
--- a/opencog/ghost/matcher.scm
+++ b/opencog/ghost/matcher.scm
@@ -177,7 +177,7 @@
           (if (equal? (assoc-ref context-alist rc) #f)
             (set! context-alist
               (assoc-set! context-alist rc
-                (cdadr (cog-tv->alist (psi-satisfiable? r))))))
+                (cog-tv-mean (psi-satisfiable? r)))))
 
           ; Count the no. of rules that contain this action, and
           ; save it in action-cnt-alist

--- a/opencog/ghost/test.scm
+++ b/opencog/ghost/test.scm
@@ -205,7 +205,7 @@
       (map cog-av rule)
       (map cog-tv rule)
       (every
-        (lambda (x) (> (cog-tv-mean (cog-evaluate! x))) 0))
+        (lambda (x) (> (cog-tv-mean (cog-evaluate! x)) 0))
         (psi-get-context (car rule)))
       (if (null? (cog-value (car rule) ghost-time-last-executed))
         "N.A."

--- a/opencog/ghost/test.scm
+++ b/opencog/ghost/test.scm
@@ -205,7 +205,7 @@
       (map cog-av rule)
       (map cog-tv rule)
       (every
-        (lambda (x) (> (cdr (assoc 'mean (cog-tv->alist (cog-evaluate! x)))) 0))
+        (lambda (x) (> (cog-tv-mean (cog-evaluate! x))) 0))
         (psi-get-context (car rule)))
       (if (null? (cog-value (car rule) ghost-time-last-executed))
         "N.A."


### PR DESCRIPTION
A simple `(assoc-ref 'mean)` would have worked also, but this is faster/simpler/cleaner.