### PR TITLE
Fix bug in pattern miner + some tweaking for debugging

### DIFF
--- a/opencog/learning/miner/MinerSCM.cc
+++ b/opencog/learning/miner/MinerSCM.cc
@@ -25,6 +25,7 @@
 
 #include <cmath>
 
+#include <opencog/util/Logger.h>
 #include <opencog/guile/SchemeModule.h>
 #include <opencog/atoms/core/NumberNode.h>
 

--- a/opencog/learning/miner/MinerUtils.cc
+++ b/opencog/learning/miner/MinerUtils.cc
@@ -205,7 +205,9 @@ Handle MinerUtils::val_shallow_abstract(const Handle& value)
 	Handle vardecl = variable_list(rnd_vars);
 
 	// Links wrapped with LocalQuoteLink
-	if (tt == AND_LINK) {
+	if (tt == AND_LINK or
+	    tt == OR_LINK or
+	    tt == NOT_LINK) {
 		return lambda(vardecl, local_quote(createLink(rnd_vars, tt)));
 	}
 

--- a/opencog/learning/miner/miner-utils.scm
+++ b/opencog/learning/miner/miner-utils.scm
@@ -70,6 +70,8 @@
 
 (define (fill-texts-cpt texts-cpt texts)
 "
+  Usage: (fill-texts-cpt texts-cpt texts)
+
   For each element text of texts create
 
   MemberLink

--- a/opencog/learning/miner/miner-utils.scm
+++ b/opencog/learning/miner/miner-utils.scm
@@ -18,6 +18,7 @@
 (use-modules (opencog))
 (use-modules (opencog exec))
 (use-modules (opencog ure))
+(use-modules (opencog logger))
 (use-modules (srfi srfi-1))
 
 (define (iota-plus-one x)

--- a/tests/learning/miner/MinerUTest.cxxtest
+++ b/tests/learning/miner/MinerUTest.cxxtest
@@ -143,6 +143,7 @@ public:
 	void test_compose_1();
 	void test_compose_2();
 	void test_compose_3();
+	void test_compose_4();
 	void test_expand_conjunction_disconnect();
 	void test_expand_conjunction_1();
 	void test_expand_conjunction_2();
@@ -302,10 +303,9 @@ void MinerUTest::test_remove_useless_clauses()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-	Handle X = an(VARIABLE_NODE, "$X"),
-		pattern = al(LAMBDA_LINK,
-		             X,
-		             al(AND_LINK, X, X)),
+	Handle pattern = al(LAMBDA_LINK,
+	                    X,
+	                    al(AND_LINK, X, X)),
 		result = MinerUtils::remove_useless_clauses(pattern),
 		expected = al(LAMBDA_LINK, X, X);
 
@@ -316,15 +316,10 @@ void MinerUTest::test_match()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-	Handle X = an(VARIABLE_NODE, "$X"),
-		Y = an(VARIABLE_NODE, "$Y"),
-		A = an(CONCEPT_NODE, "A"),
-		B = an(CONCEPT_NODE, "B"),
-		C = an(CONCEPT_NODE, "C"),
-		pattern = al(LAMBDA_LINK,
-		             al(VARIABLE_LIST, X, Y),
-		             al(LOCAL_QUOTE_LINK,
-		                al(AND_LINK, X, Y))),
+	Handle pattern = al(LAMBDA_LINK,
+	                    al(VARIABLE_LIST, X, Y),
+	                    al(LOCAL_QUOTE_LINK,
+	                       al(AND_LINK, X, Y))),
 		text = al(INHERITANCE_LINK, A, al(AND_LINK, B, C));
 
 	TS_ASSERT(not Miner().match(pattern, text));
@@ -334,13 +329,9 @@ void MinerUTest::test_compose_1()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-	Handle X = an(VARIABLE_NODE, "$X"),
-		Y = an(VARIABLE_NODE, "$Y"),
-		A = an(CONCEPT_NODE, "A"),
-		B = an(CONCEPT_NODE, "B"),
-		pattern = al(LAMBDA_LINK,
-		             al(VARIABLE_LIST, X, Y),
-		             al(AND_LINK, X, al(INHERITANCE_LINK, Y, B))),
+	Handle pattern = al(LAMBDA_LINK,
+	                    al(VARIABLE_LIST, X, Y),
+	                    al(AND_LINK, X, al(INHERITANCE_LINK, Y, B))),
 		subpat = A;
 
 	Handle npat = MinerUtils::compose(pattern, {{Y, subpat}}),
@@ -356,9 +347,7 @@ void MinerUTest::test_compose_2()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-	Handle X = an(VARIABLE_NODE, "$X"),
-		Y = an(VARIABLE_NODE, "$Y"),
-		VarXY = al(VARIABLE_LIST, X, Y),
+	Handle VarXY = al(VARIABLE_LIST, X, Y),
 		pattern = al(LAMBDA_LINK,
 		             VarXY,
 		             al(QUOTE_LINK,
@@ -386,9 +375,7 @@ void MinerUTest::test_compose_3()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-	Handle X = an(VARIABLE_NODE, "$X"),
-		Y = an(VARIABLE_NODE, "$Y"),
-		VarXY = al(VARIABLE_LIST, X, Y),
+	Handle VarXY = al(VARIABLE_LIST, X, Y),
 		pattern = al(LAMBDA_LINK,
 		             al(IMPLICATION_LINK, X, Y));
 
@@ -396,6 +383,20 @@ void MinerUTest::test_compose_3()
 		expected = al(LAMBDA_LINK,
 		              VarXY,
 		              al(IMPLICATION_LINK, X, Y));
+
+	logger().debug() << "npat = " << oc_to_string(npat);
+	logger().debug() << "expected = " << oc_to_string(expected);
+
+	TS_ASSERT(content_eq(npat, expected));
+}
+
+void MinerUTest::test_compose_4()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle sa = al(LAMBDA_LINK, X, al(LOCAL_QUOTE_LINK, al(NOT_LINK, X))),
+		npat = MinerUtils::compose(top, {{X, sa}}),
+		expected = sa;
 
 	logger().debug() << "npat = " << oc_to_string(npat);
 	logger().debug() << "expected = " << oc_to_string(expected);

--- a/tests/learning/miner/MinerUTestUtils.cc
+++ b/tests/learning/miner/MinerUTestUtils.cc
@@ -45,9 +45,9 @@ Handle MinerUTestUtils::add_minsup_prd(AtomSpace& as)
 	return an(PREDICATE_NODE, "minsup");
 }
 
-Handle MinerUTestUtils::add_isurp_prd(AtomSpace& as)
+Handle MinerUTestUtils::add_isurp_prd(AtomSpace& as, const std::string& mode)
 {
-	return an(PREDICATE_NODE, "isurp");
+	return an(PREDICATE_NODE, mode);
 }
 
 Handle MinerUTestUtils::add_top(AtomSpace& as)
@@ -84,10 +84,11 @@ Handle MinerUTestUtils::add_minsup_evals(AtomSpace& as,
 }
 
 Handle MinerUTestUtils::add_isurp_eval(AtomSpace& as,
+                                       const std::string& mode,
                                        const Handle& pattern)
 {
 	Handle isurp_eval_h = al(EVALUATION_LINK,
-	                         add_isurp_prd(as),
+	                         add_isurp_prd(as, mode),
 	                         al(LIST_LINK,
 	                            pattern,
 	                            add_texts_cpt(as)));
@@ -326,7 +327,7 @@ HandleSeq MinerUTestUtils::ure_isurp(AtomSpace& as,
 {
 	configure_ISurprisingness(scm, isurp_rb, mode, max_conjuncts);
 	Handle X = an(VARIABLE_NODE, "$X"),
-		target = add_isurp_eval(as, X),
+		target = add_isurp_eval(as, mode, X),
 		vardecl = al(TYPED_VARIABLE_LINK, X, an(TYPE_NODE, "LambdaLink"));
 	BackwardChainer bc(as, isurp_rb, target, vardecl);
 	bc.do_chain();

--- a/tests/learning/miner/MinerUTestUtils.h
+++ b/tests/learning/miner/MinerUTestUtils.h
@@ -54,11 +54,11 @@ public:
 	/**
 	 * Add
 	 *
-	 * (Predicate "isurp")
+	 * (Predicate <mode>)
 	 *
 	 * to as.
 	 */
-	static Handle add_isurp_prd(AtomSpace& as);
+	static Handle add_isurp_prd(AtomSpace& as, const std::string& mode);
 
 	/**
 	 * Add
@@ -98,12 +98,14 @@ public:
 	 * Insert
 	 *
 	 * (Evaluation
-	 *   (Predicate "isurp")
+	 *   (Predicate <mode>)
 	 *   (List pattern (Concept "texts")))
 	 *
 	 * to as.
 	 */
-	static Handle add_isurp_eval(AtomSpace& as, const Handle& pattern);
+	static Handle add_isurp_eval(AtomSpace& as,
+	                             const std::string& mode,
+	                             const Handle& pattern);
 
 	/**
 	 * Given

--- a/tests/learning/miner/SurprisingnessUTest.cxxtest
+++ b/tests/learning/miner/SurprisingnessUTest.cxxtest
@@ -387,7 +387,7 @@ void SurprisingnessUTest::test_nisurp_old_ugly_man()
 	std::string mode = "nisurp-old";
 	unsigned max_conjuncts = 2;
 	HandleSeq isurp_results = ure_isurp(mode, max_conjuncts);
-	Handle expected = MinerUTestUtils::add_isurp_eval(_as, ugly_man_pattern);
+	Handle expected = MinerUTestUtils::add_isurp_eval(_as, mode, ugly_man_pattern);
 
 	logger().debug() << "isurp_results = " << oc_to_string(isurp_results);
 
@@ -441,7 +441,7 @@ void SurprisingnessUTest::test_nisurp_old_ugly_man_soda_drinker()
 	std::string mode = "nisurp-old";
 	unsigned max_conjuncts = 3;
 	HandleSeq isurp_results = ure_isurp(mode, max_conjuncts);
-	Handle expected = MinerUTestUtils::add_isurp_eval(_as, umsd_pattern);
+	Handle expected = MinerUTestUtils::add_isurp_eval(_as, mode, umsd_pattern);
 
 	logger().debug() << "isurp_results = " << oc_to_string(isurp_results);
 
@@ -499,8 +499,9 @@ void SurprisingnessUTest::test_nisurp_no_linkage_synthetic_1()
 	MinerUTestUtils::add_minsup_eval(_as, pattern, 5, TruthValue::TRUE_TV());
 
 	// Test normalized I-Surprisingness
-	HandleSeq isurp_results = ure_isurp("nisurp", 2);
-	Handle expected = MinerUTestUtils::add_isurp_eval(_as, pattern);
+	std::string mode = "nisurp";
+	HandleSeq isurp_results = ure_isurp(mode, 2);
+	Handle expected = MinerUTestUtils::add_isurp_eval(_as, mode, pattern);
 
 	logger().debug() << "isurp_results = " << oc_to_string(isurp_results);
 
@@ -550,8 +551,9 @@ void SurprisingnessUTest::test_nisurp_no_linkage_synthetic_2()
 	MinerUTestUtils::add_minsup_eval(_as, pattern, 5, TruthValue::TRUE_TV());
 
 	// Test normalized I-Surprisingness
-	HandleSeq isurp_results = ure_isurp("nisurp", 2);
-	Handle expected = MinerUTestUtils::add_isurp_eval(_as, pattern);
+	std::string mode = "nisurp";
+	HandleSeq isurp_results = ure_isurp(mode, 2);
+	Handle expected = MinerUTestUtils::add_isurp_eval(_as, mode, pattern);
 
 	logger().debug() << "isurp_results = " << oc_to_string(isurp_results);
 
@@ -605,8 +607,9 @@ void SurprisingnessUTest::xtest_nisurp_linkage_synthetic_1()
 	MinerUTestUtils::add_minsup_eval(_as, pattern, 5, TruthValue::TRUE_TV());
 
 	// Test normalized I-Surprisingness
-	HandleSeq isurp_results = ure_isurp("nisurp", 2);
-	Handle expected = MinerUTestUtils::add_isurp_eval(_as, pattern);
+	std::string mode = "nisurp";
+	HandleSeq isurp_results = ure_isurp(mode, 2);
+	Handle expected = MinerUTestUtils::add_isurp_eval(_as, mode, pattern);
 
 	logger().debug() << "isurp_results = " << oc_to_string(isurp_results);
 
@@ -656,8 +659,9 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_2()
 	MinerUTestUtils::add_minsup_eval(_as, pattern, 5, TruthValue::TRUE_TV());
 
 	// Test normalized I-Surprisingness
-	HandleSeq isurp_results = ure_isurp("nisurp", 2);
-	Handle expected = MinerUTestUtils::add_isurp_eval(_as, pattern);
+	std::string mode = "nisurp";
+	HandleSeq isurp_results = ure_isurp(mode, 2);
+	Handle expected = MinerUTestUtils::add_isurp_eval(_as, mode, pattern);
 
 	logger().debug() << "isurp_results = " << oc_to_string(isurp_results);
 
@@ -707,8 +711,9 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_3()
 	MinerUTestUtils::add_minsup_eval(_as, pattern, 5, TruthValue::TRUE_TV());
 
 	// Test normalized I-Surprisingness
-	HandleSeq isurp_results = ure_isurp("nisurp", 2);
-	Handle expected = MinerUTestUtils::add_isurp_eval(_as, pattern);
+	std::string mode = "nisurp";
+	HandleSeq isurp_results = ure_isurp(mode, 2);
+	Handle expected = MinerUTestUtils::add_isurp_eval(_as, mode, pattern);
 
 	logger().debug() << "isurp_results = " << oc_to_string(isurp_results);
 
@@ -771,8 +776,9 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_4()
 	MinerUTestUtils::add_minsup_eval(_as, pattern, 5, TruthValue::TRUE_TV());
 
 	// Test normalized I-Surprisingness
-	HandleSeq isurp_results = ure_isurp("nisurp", 2);
-	Handle expected = MinerUTestUtils::add_isurp_eval(_as, pattern);
+	std::string mode = "nisurp";
+	HandleSeq isurp_results = ure_isurp(mode, 2);
+	Handle expected = MinerUTestUtils::add_isurp_eval(_as, mode, pattern);
 
 	logger().debug() << "isurp_results = " << oc_to_string(isurp_results);
 
@@ -833,8 +839,9 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_5()
 	MinerUTestUtils::add_minsup_eval(_as, pattern, 5, TruthValue::TRUE_TV());
 
 	// Test normalized I-Surprisingness
-	HandleSeq isurp_results = ure_isurp("nisurp", 2);
-	Handle expected = MinerUTestUtils::add_isurp_eval(_as, pattern);
+	std::string mode = "nisurp";
+	HandleSeq isurp_results = ure_isurp(mode, 2);
+	Handle expected = MinerUTestUtils::add_isurp_eval(_as, mode, pattern);
 
 	logger().debug() << "isurp_results = " << oc_to_string(isurp_results);
 
@@ -898,8 +905,9 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_6()
 	MinerUTestUtils::add_minsup_eval(_as, pattern, 5, TruthValue::TRUE_TV());
 
 	// Test normalized I-Surprisingness
-	HandleSeq isurp_results = ure_isurp("nisurp", 3);
-	Handle expected = MinerUTestUtils::add_isurp_eval(_as, pattern);
+	std::string mode = "nisurp";
+	HandleSeq isurp_results = ure_isurp(mode, 3);
+	Handle expected = MinerUTestUtils::add_isurp_eval(_as, mode, pattern);
 
 	logger().debug() << "isurp_results = " << oc_to_string(isurp_results);
 
@@ -973,8 +981,9 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_7()
 	MinerUTestUtils::add_minsup_eval(_as, pattern, 5, TruthValue::TRUE_TV());
 
 	// Test normalized I-Surprisingness
-	HandleSeq isurp_results = ure_isurp("nisurp", 4);
-	Handle expected = MinerUTestUtils::add_isurp_eval(_as, pattern);
+	std::string mode = "nisurp";
+	HandleSeq isurp_results = ure_isurp(mode, 4);
+	Handle expected = MinerUTestUtils::add_isurp_eval(_as, mode, pattern);
 
 	logger().debug() << "isurp_results = " << oc_to_string(isurp_results);
 
@@ -1036,8 +1045,9 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_8()
 	MinerUTestUtils::add_minsup_eval(_as, pattern, 5, TruthValue::TRUE_TV());
 
 	// Test normalized I-Surprisingness
-	HandleSeq isurp_results = ure_isurp("nisurp", 2);
-	Handle expected = MinerUTestUtils::add_isurp_eval(_as, pattern);
+	std::string mode = "nisurp";
+	HandleSeq isurp_results = ure_isurp(mode, 2);
+	Handle expected = MinerUTestUtils::add_isurp_eval(_as, mode, pattern);
 
 	logger().debug() << "isurp_results = " << oc_to_string(isurp_results);
 
@@ -1099,8 +1109,9 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_9()
 	MinerUTestUtils::add_minsup_eval(_as, pattern, 5, TruthValue::TRUE_TV());
 
 	// Test normalized I-Surprisingness
-	HandleSeq isurp_results = ure_isurp("nisurp", 2);
-	Handle expected = MinerUTestUtils::add_isurp_eval(_as, pattern);
+	std::string mode = "nisurp";
+	HandleSeq isurp_results = ure_isurp(mode, 2);
+	Handle expected = MinerUTestUtils::add_isurp_eval(_as, mode, pattern);
 
 	logger().debug() << "isurp_results = " << oc_to_string(isurp_results);
 
@@ -1178,7 +1189,7 @@ void SurprisingnessUTest::test_nisurp_ugly_man_soda_drinker()
 	std::string mode("nisurp");
 	unsigned max_conjuncts = 3;
 	HandleSeq isurp_results = ure_isurp(mode, max_conjuncts);
-	Handle expected = MinerUTestUtils::add_isurp_eval(_as, umsd_pattern);
+	Handle expected = MinerUTestUtils::add_isurp_eval(_as, mode, umsd_pattern);
 
 	logger().debug() << "isurp_results = " << oc_to_string(isurp_results);
 


### PR DESCRIPTION
That fix doesn't address the RAM explosion, which is unfortunately not a bug. Surprisingess requires to run the pattern to its full extend in order to get its support and estimate its empirical probability. The number of matches for some patterns grow polynomially with the size of the atomspace, thus the RAM explosion.

I see 2 options to address that problem

1. Write a callback to the pattern matcher to only count matches without instantiating them (would take less CPU and considerably less RAM, however special care is required to not count duplicates multiple times).
2. Subsample the atomspace before estimating the empirical probability (using statistical bootstrapping, as suggested by Matt, to improve the estimate).

Maybe we ultimately need a combination of both...