### PR TITLE
ECAN config file cleanup

### DIFF
--- a/lib/cogserver.conf
+++ b/lib/cogserver.conf
@@ -6,57 +6,16 @@
 #    (start-cogserver)
 #
 # It can be treated as an example configuration for a production OpenCog
-# server. Particularly noteworthy is the list of automatically loaded
-# modules.
+# server.
 #
-SERVER_PORT           = 17001
+# SERVER_PORT           = 17001
 LOG_FILE              = /tmp/cogserver.log
 
 # Other possible log levels are "error", "warn", "info", "debug" and "fine"
 # LOG_LEVEL             = debug
 LOG_LEVEL             = info
 LOG_TO_STDOUT         = false
-SERVER_CYCLE_DURATION = 100
-
-# Economic Attention Allocation parameters
-STARTING_STI_FUNDS    = 10000
-STARTING_LTI_FUNDS    = 10000
-STI_FUNDS_BUFFER      = 10000
-LTI_FUNDS_BUFFER      = 10000
-MIN_STI               = -400
-
-ECAN_MAX_ATOM_STI_RENT      = 15
-ECAN_STARTING_ATOM_STI_RENT = 10
-ECAN_STARTING_ATOM_LTI_RENT = 0
-ECAN_STARTING_ATOM_STI_WAGE = 2
-ECAN_STARTING_ATOM_LTI_WAGE = 2
-
-#Used by ImportanceDiffusionAgent class
-#0 => flat rent, 1 => exp rent, 2 => log rent, 3 => linear rent
-ECAN_RENT_TYPE              = 0
-ECAN_RENT_AMNESTY           = 5
-ECAN_RENT_EQUATION_PARAMETER_0 = 0.05
-ECAN_RENT_EQUATION_PARAMETER_1 = 0.0
-
-#End of ImportanceDiffusionAgent class
-
-#Used by SimpleImportanceDiffusionAgent class
-#Maximum percentage of STI that is spread from an atom
-ECAN_MAX_SPREAD_PERCENTAGE = 0.6
-
-# If false, will diffuse along hebbian links only. If true,
-# will also diffuse to all non-hebbian incident atoms in the
-# incoming and outgoing sets
-ECAN_SPREAD_HEBBIAN_ONLY = false
-
-# Maximum percentage that will be available for diffusion to hebbian links
-HEBBIAN_MAX_ALLOCATION_PERCENTAGE = 0.5
-
-# spread deciding function type (HPERBOLIC = 0 and STEP = 1 )
-SPREAD_DECIDER_TYPE = 1
-
-#END of SimpleImportanceDiffusionAgent params
-#END of Economic Attention Allocation parameters
+# SERVER_CYCLE_DURATION = 100
 
 # Use this command PROMPT when telnet/terminal doesn't support ANSI
 # PROMPT                = "opencog> "
@@ -86,10 +45,10 @@ SPREAD_DECIDER_TYPE = 1
 # a persistent opencog table of sense similarities. For now, they remain
 # in use.
 #
-SENSE_SIMILARITY_DB_NAME          = "lexat"
-SENSE_SIMILARITY_DB_USERNAME      = "linas"
-SENSE_SIMILARITY_DB_PASSWD        = "asdf"
+# SENSE_SIMILARITY_DB_NAME          = "lexat"
+# SENSE_SIMILARITY_DB_USERNAME      = "linas"
+# SENSE_SIMILARITY_DB_PASSWD        = "asdf"
 
 # Parameters for ZeroMQ AtomSpace Event Publisher
-ZMQ_EVENT_USE_PUBLIC_IP = TRUE
-ZMQ_EVENT_PORT = 5563
+# ZMQ_EVENT_USE_PUBLIC_IP = TRUE
+# ZMQ_EVENT_PORT = 5563

--- a/lib/development.conf
+++ b/lib/development.conf
@@ -3,82 +3,38 @@
 # server. Particularly noteworthy is the list of automatically loaded
 # modules.
 #
-SERVER_PORT           = 17001
+# SERVER_PORT           = 17001
 LOG_FILE              = /tmp/cogserver.log
 
 # Other possible log levels are "error", "warn", "info", "debug" and "fine"
 # LOG_LEVEL             = debug
 LOG_LEVEL             = info
 LOG_TO_STDOUT         = false
-SERVER_CYCLE_DURATION = 100
-
-# Economic Attention Allocation parameters
-STARTING_STI_FUNDS    = 10000
-STARTING_LTI_FUNDS    = 10000
-STI_FUNDS_BUFFER      = 10000
-LTI_FUNDS_BUFFER      = 10000
-MIN_STI               = -400
-
-ECAN_MAX_ATOM_STI_RENT      = 15
-ECAN_STARTING_ATOM_STI_RENT = 10
-ECAN_STARTING_ATOM_LTI_RENT = 0
-ECAN_STARTING_ATOM_STI_WAGE = 2
-ECAN_STARTING_ATOM_LTI_WAGE = 2
-
-#Used by ImportanceDiffusionAgent class
-#0 => flat rent, 1 => exp rent, 2 => log rent, 3 => linear rent
-ECAN_RENT_TYPE              = 0
-ECAN_RENT_AMNESTY           = 5
-ECAN_RENT_EQUATION_PARAMETER_0 = 0.05
-ECAN_RENT_EQUATION_PARAMETER_1 = 0.0
-
-#End of ImportanceDiffusionAgent class
-
-#Used by SimpleImportanceDiffusionAgent class
-#Maximum percentage of STI that is spread from an atom
-ECAN_MAX_SPREAD_PERCENTAGE = 0.6
-
-# If false, will diffuse along hebbian links only. If true,
-# will also diffuse to all non-hebbian incident atoms in the
-# incoming and outgoing sets
-ECAN_SPREAD_HEBBIAN_ONLY = false
-
-# Maximum percentage that will be available for diffusion to hebbian links
-HEBBIAN_MAX_ALLOCATION_PERCENTAGE = 0.5
-ECAN_CONVERT_LINKS = false
-ECAN_CONVERSION_THRESHOLD = 15
-
-# spread deciding function type (HPERBOLIC = 0 and STEP = 1 )
-SPREAD_DECIDER_TYPE = 1
-#END of SimpleImportanceDiffusionAgent params
-
-#ForgettingAgent params
-ECAN_FORGET_PERCENTAGE = 0.001
-
-#END of Economic Attention Allocation parameters
+# SERVER_CYCLE_DURATION = 100
 
 # Use this command PROMPT when telnet/terminal doesn't support ANSI
-PROMPT                = "opencog> "
+# PROMPT                = "opencog> "
 # Prompt with ANSI color codes
-ANSI_PROMPT           = "[0;32mopencog[1;32m> [0m"
+# ANSI_PROMPT           = "[0;32mopencog[1;32m> [0m"
 # Use this guile PROMPT when telnet/terminal doesn't support ANSI
-SCM_PROMPT            = "guile> "
+# SCM_PROMPT            = "guile> "
 # Prompt with ANSI color codes
-ANSI_SCM_PROMPT       = "[0;34mguile[1;34m> [0m"
+# ANSI_SCM_PROMPT       = "[0;34mguile[1;34m> [0m"
 # Global option so that modules know whether they should output ANSI color
 # codes
-ANSI_ENABLED	       = true
+# ANSI_ENABLED	       = true
 
+# These modules are already loaded by default.
 # Cogserver in OSX will automatically change .so extension to .dylib
 # if .so exists.
-MODULES               = opencog/cogserver/server/libbuiltinreqs.so,
-                        opencog/cogserver/shell/libscheme-shell.so,
-                        opencog/cogserver/shell/libpy-shell.so
-
+# MODULES               = opencog/cogserver/server/libbuiltinreqs.so,
+#                         opencog/cogserver/shell/libscheme-shell.so,
+#                         opencog/cogserver/shell/libpy-shell.so
+#
 # Optional modules, not enabled by default
 #                        opencog/modules/events/libatomspacepublishermodule.so
 #                        opencog/learning/dimensionalembedding/libdimensionalembedding.so
 
 # Parameters for ZeroMQ AtomSpace Event Publisher
-ZMQ_EVENT_USE_PUBLIC_IP = TRUE
-ZMQ_EVENT_PORT = 5563
+# ZMQ_EVENT_USE_PUBLIC_IP = TRUE
+# ZMQ_EVENT_PORT = 5563

--- a/lib/lojban.conf
+++ b/lib/lojban.conf
@@ -3,71 +3,25 @@
 # server. Particularly noteworthy is the list of automatically loaded
 # modules.
 #
-SERVER_PORT           = 17001
+# SERVER_PORT           = 17001
 LOG_FILE              = /tmp/cogserver.log
 
 # Other possible log levels are "error", "warn", "info", "debug" and "fine"
 # LOG_LEVEL             = debug
 LOG_LEVEL             = info
 LOG_TO_STDOUT         = false
-SERVER_CYCLE_DURATION = 100
-
-# Economic Attention Allocation parameters
-STARTING_STI_FUNDS    = 10000
-STARTING_LTI_FUNDS    = 10000
-STI_FUNDS_BUFFER      = 10000
-LTI_FUNDS_BUFFER      = 10000
-MIN_STI               = -400
-
-ECAN_MAX_ATOM_STI_RENT      = 15
-ECAN_STARTING_ATOM_STI_RENT = 10
-ECAN_STARTING_ATOM_LTI_RENT = 0
-ECAN_STARTING_ATOM_STI_WAGE = 2
-ECAN_STARTING_ATOM_LTI_WAGE = 2
-
-#Used by ImportanceDiffusionAgent class
-#0 => flat rent, 1 => exp rent, 2 => log rent, 3 => linear rent
-ECAN_RENT_TYPE              = 0
-ECAN_RENT_AMNESTY           = 5
-ECAN_RENT_EQUATION_PARAMETER_0 = 0.05
-ECAN_RENT_EQUATION_PARAMETER_1 = 0.0
-
-#End of ImportanceDiffusionAgent class
-
-#Used by SimpleImportanceDiffusionAgent class
-#Maximum percentage of STI that is spread from an atom
-ECAN_MAX_SPREAD_PERCENTAGE = 0.6
-
-# If false, will diffuse along hebbian links only. If true,
-# will also diffuse to all non-hebbian incident atoms in the
-# incoming and outgoing sets
-ECAN_SPREAD_HEBBIAN_ONLY = false
-
-# Maximum percentage that will be available for diffusion to hebbian links
-HEBBIAN_MAX_ALLOCATION_PERCENTAGE = 0.5
-ECAN_CONVERT_LINKS = false
-ECAN_CONVERSION_THRESHOLD = 15
-
-# spread deciding function type (HPERBOLIC = 0 and STEP = 1 )
-SPREAD_DECIDER_TYPE = 1
-#END of SimpleImportanceDiffusionAgent params
-
-#ForgettingAgent params
-ECAN_FORGET_PERCENTAGE = 0.001
-
-#END of Economic Attention Allocation parameters
 
 # Use this command PROMPT when telnet/terminal doesn't support ANSI
-PROMPT                = "opencog> "
+# PROMPT                = "opencog> "
 # Prompt with ANSI color codes
-ANSI_PROMPT           = "[0;32mopencog[1;32m> [0m"
+# ANSI_PROMPT           = "[0;32mopencog[1;32m> [0m"
 # Use this guile PROMPT when telnet/terminal doesn't support ANSI
-SCM_PROMPT            = "guile> "
+# SCM_PROMPT            = "guile> "
 # Prompt with ANSI color codes
-ANSI_SCM_PROMPT       = "[0;34mguile[1;34m> [0m"
+# ANSI_SCM_PROMPT       = "[0;34mguile[1;34m> [0m"
 # Global option so that modules know whether they should output ANSI color
 # codes
-ANSI_ENABLED	       = true
+# ANSI_ENABLED	       = true
 
 # Cogserver in OSX will automatically change .so extension to .dylib
 # if .so exists.
@@ -77,9 +31,5 @@ MODULES               = opencog/cogserver/server/libbuiltinreqs.so,
                         opencog/nlp/lojban/libLojbanModule.so
 
 # Optional modules, not enabled by default
-#                        opencog/modules/events/libatomspacepublishermodule.so
-#                        opencog/learning/dimensionalembedding/libdimensionalembedding.so
-
-# Parameters for ZeroMQ AtomSpace Event Publisher
-ZMQ_EVENT_USE_PUBLIC_IP = TRUE
-ZMQ_EVENT_PORT = 5563
+#                       opencog/modules/events/libatomspacepublishermodule.so
+#                       opencog/learning/dimensionalembedding/libdimensionalembedding.so

--- a/lib/opencog-chatbot.conf
+++ b/lib/opencog-chatbot.conf
@@ -9,19 +9,7 @@ SERVER_PORT           = 17004
 LOG_FILE              = /tmp/cog-chatbot.log
 LOG_LEVEL             = info
 LOG_TO_STDOUT         = false
-SERVER_CYCLE_DURATION = 100
-STARTING_STI_FUNDS    = 10000
-STARTING_LTI_FUNDS    = 10000
-STI_FUNDS_BUFFER      = 10000
-LTI_FUNDS_BUFFER      = 10000
-MIN_STI               = -400
 #
 # Blank out the prompt, otherwise it is echoed to the IRC channel.
 ANSI_PROMPT           = ""
 PROMPT                = ""
-
-# These file paths assume that you have done `make install` after
-# compiling; these modules are found in `/usr/local/lib/opencog`.
-MODULES               = opencog/modules/libbuiltinreqs.so,
-                        opencog/modules/libscheme-shell.so,
-                        opencog/modules/libpy-shell.so

--- a/lib/opencog-test.conf
+++ b/lib/opencog-test.conf
@@ -1,24 +1,16 @@
 #
 # This config file is used by various opencog unit tests.
 #
-# Pick a port number that doesn't conflict!
-SERVER_PORT           = 18001
+# Pick a port number that doesn't conflict with a running server!
+SERVER_PORT           = 18123
 LOG_FILE              = opencog-test.log
 
 LOG_LEVEL             = debug
 LOG_TO_STDOUT         = true
-SERVER_CYCLE_DURATION = 100
-STARTING_STI_FUNDS    = 10000
-STARTING_LTI_FUNDS    = 10000
-STI_FUNDS_BUFFER      = 10000
-LTI_FUNDS_BUFFER      = 10000
-MIN_STI               = -400
-PROMPT                = "opencog> "
 MODULES               = opencog/server/libbuiltinreqs.so,
                         opencog/shell/libscheme-shell.so
 
 # Parameters for ZeroMQ AtomSpace Event Publisher
-# Use a non-stanard port number, so that the test doesn't conflict
+# Use a non-standard port number, so that the test doesn't conflict
 # with a running server!
-ZMQ_EVENT_USE_PUBLIC_IP = TRUE
 ZMQ_EVENT_PORT = 6563

--- a/lib/opencog.conf
+++ b/lib/opencog.conf
@@ -1,43 +1,15 @@
 #
 # This file provides an example configuration for a production OpenCog
-# server. Particularly noteworthy is the list of automatically loaded
-# modules.
+# server.
 #
-SERVER_PORT           = 17001
+# SERVER_PORT           = 17001
 LOG_FILE              = /tmp/cogserver.log
 
 # Other possible log levels are "error", "warn", "info", "debug" and "fine"
 # LOG_LEVEL             = debug
 LOG_LEVEL             = info
 LOG_TO_STDOUT         = false
-SERVER_CYCLE_DURATION = 100
-
-# Economic Attention Allocation parameters
-STARTING_STI_FUNDS    = 100000
-STARTING_LTI_FUNDS    = 100000
-TARGET_STI_FUNDS      = 10000
-TARGET_LTI_FUNDS      = 10000
-STI_FUNDS_BUFFER      = 10000
-LTI_FUNDS_BUFFER      = 10000
-
-ECAN_STARTING_ATOM_STI_RENT = 10
-ECAN_STARTING_ATOM_STI_WAGE = 10
-
-ECAN_STARTING_ATOM_LTI_RENT = 1
-ECAN_STARTING_ATOM_LTI_WAGE = 10
-
-#For FocusBoundaryUpdatingAgent
-ECAN_AFB_SIZE = 0.2
-ECAN_AFB_DECAY = 0.1
-ECAN_AFB_BOTTOM = 50
-ECAN_MIN_AF_SIZE = 100
-ECAN_MAX_AF_SIZE = 500
-
-#For ForgettingAgent
-ECAN_ATOMSPACE_MAXSIZE = 100000
-ECAN_ATOMSPACE_ACCEPTABLE_SIZE_SPREAD = 100
-
-#END of Economic Attention Allocation parameters
+# SERVER_CYCLE_DURATION = 100
 
 # Use this command PROMPT when telnet/terminal doesn't support ANSI
 # PROMPT                = "opencog> "
@@ -69,10 +41,10 @@ ECAN_ATOMSPACE_ACCEPTABLE_SIZE_SPREAD = 100
 # a persistent opencog table of sense similarities. For now, they remain
 # in use.
 #
-SENSE_SIMILARITY_DB_NAME          = "lexat"
-SENSE_SIMILARITY_DB_USERNAME      = "linas"
-SENSE_SIMILARITY_DB_PASSWD        = "asdf"
+# SENSE_SIMILARITY_DB_NAME          = "lexat"
+# SENSE_SIMILARITY_DB_USERNAME      = "linas"
+# SENSE_SIMILARITY_DB_PASSWD        = "asdf"
 
 # Parameters for ZeroMQ AtomSpace Event Publisher
-ZMQ_EVENT_USE_PUBLIC_IP = TRUE
-ZMQ_EVENT_PORT = 5563
+# ZMQ_EVENT_USE_PUBLIC_IP = TRUE
+# ZMQ_EVENT_PORT = 5563

--- a/lib/opencog2.conf
+++ b/lib/opencog2.conf
@@ -10,12 +10,5 @@ LOG_FILE              = /tmp/cogserver2.log
 # LOG_LEVEL             = debug
 LOG_LEVEL             = info
 LOG_TO_STDOUT         = false
-SERVER_CYCLE_DURATION = 100
-STARTING_STI_FUNDS    = 10000
-STARTING_LTI_FUNDS    = 10000
-STI_FUNDS_BUFFER      = 10000
-LTI_FUNDS_BUFFER      = 10000
-MIN_STI               = -400
-PROMPT                = "opencog> "
 MODULES               = libbuiltinreqs.so,
                         libscheme-shell.so

--- a/lib/opencog3.conf
+++ b/lib/opencog3.conf
@@ -10,12 +10,5 @@ LOG_FILE              = /tmp/cogserver3.log
 # LOG_LEVEL             = debug
 LOG_LEVEL             = info
 LOG_TO_STDOUT         = false
-SERVER_CYCLE_DURATION = 100
-STARTING_STI_FUNDS    = 10000
-STARTING_LTI_FUNDS    = 10000
-STI_FUNDS_BUFFER      = 10000
-LTI_FUNDS_BUFFER      = 10000
-MIN_STI               = -400
-PROMPT                = "opencog> "
 MODULES               = libbuiltinreqs.so,
                         libscheme-shell.so

--- a/lib/opencog_patternminer.conf
+++ b/lib/opencog_patternminer.conf
@@ -3,114 +3,27 @@
 # server. Particularly noteworthy is the list of automatically loaded
 # modules.
 #
-SERVER_PORT           = 17001
+# SERVER_PORT           = 17001
 LOG_FILE              = /tmp/cogserver.log
 
 # Other possible log levels are "error", "warn", "info", "debug" and "fine"
 # LOG_LEVEL             = debug
 LOG_LEVEL             = info
 LOG_TO_STDOUT         = false
-SERVER_CYCLE_DURATION = 100
-
-# Economic Attention Allocation parameters
-STARTING_STI_FUNDS    = 100000
-STARTING_LTI_FUNDS    = 100000
-TARGET_STI_FUNDS      = 10000
-TARGET_LTI_FUNDS      = 10000
-STI_FUNDS_BUFFER      = 10000
-LTI_FUNDS_BUFFER      = 10000
-MIN_STI               = 0
-
-ECAN_MAX_ATOM_STI_RENT      = 15
-
-ECAN_STARTING_ATOM_STI_RENT = 10
-ECAN_STARTING_ATOM_STI_WAGE = 10
-
-ECAN_STARTING_ATOM_LTI_RENT = 1
-ECAN_STARTING_ATOM_LTI_WAGE = 10
-
-ECAN_AF_RENT_FREQUENCY = 2
-
-#For FocusBoundaryUpdatingAgent
-ECAN_AFB_SIZE = 0.2
-ECAN_AFB_DECAY = 0.1
-ECAN_AFB_BOTTOM = 50
-ECAN_MIN_AF_SIZE = 100
-ECAN_MAX_AF_SIZE = 500
-
-#For ForgettingAgent
-ECAN_ATOMSPACE_MAXSIZE = 100000
-ECAN_ATOMSPACE_ACCEPTABLE_SIZE_SPREAD = 100
-
-#For HebbianLinkCreationAgent
-ECAN_MAXLINKS = 300
-ECAN_LOCAL_FAR_LINK_RATIO = 10
-
-#For WARent/DiffusionAgent
-ECAN_DIFFUSION_TOURNAMENT_SIZE = 5
-ECAN_RENT_TOURNAMENT_SIZE = 5
-
-#Used by ImportanceDiffusionAgent class
-#0 => flat rent, 1 => exp rent, 2 => log rent, 3 => linear rent
-ECAN_RENT_TYPE              = 0
-ECAN_RENT_AMNESTY           = 5
-ECAN_RENT_EQUATION_PARAMETER_0 = 0.05
-ECAN_RENT_EQUATION_PARAMETER_1 = 0.0
-
-#End of ImportanceDiffusionAgent class
-
-#Used by SimpleImportanceDiffusionAgent class
-#Maximum percentage of STI that is spread from an atom
-ECAN_MAX_SPREAD_PERCENTAGE = 0.2
-
-# If false, will diffuse along hebbian links only. If true,
-# will also diffuse to all non-hebbian incident atoms in the
-# incoming and outgoing sets
-ECAN_SPREAD_HEBBIAN_ONLY = false
-
-# Maximum percentage that will be available for diffusion to hebbian links
-HEBBIAN_MAX_ALLOCATION_PERCENTAGE = 0.5
-ECAN_CONVERT_LINKS = false
-ECAN_CONVERSION_THRESHOLD = 15
-
-# spread deciding function type (HPERBOLIC = 0 and STEP = 1 )
-SPREAD_DECIDER_TYPE = 1
-#END of SimpleImportanceDiffusionAgent params
-
-#ForgettingAgent params
-ECAN_FORGET_PERCENTAGE = 0.001
-
-#END of Economic Attention Allocation parameters
 
 # Use this command PROMPT when telnet/terminal doesn't support ANSI
-PROMPT                = "opencog> "
+# PROMPT                = "opencog> "
 # Prompt with ANSI color codes
-ANSI_PROMPT           = "[0;32mopencog[1;32m> [0m"
+# ANSI_PROMPT           = "[0;32mopencog[1;32m> [0m"
 # Use this guile PROMPT when telnet/terminal doesn't support ANSI
-SCM_PROMPT            = "guile> "
+# SCM_PROMPT            = "guile> "
 # Prompt with ANSI color codes
-ANSI_SCM_PROMPT       = "[0;34mguile[1;34m> [0m"
+# ANSI_SCM_PROMPT       = "[0;34mguile[1;34m> [0m"
 # Global option so that modules know whether they should output ANSI color
 # codes
-ANSI_ENABLED	       = true
+# ANSI_ENABLED	       = true
 
-# Cogserver in OSX will automatically change .so extension to .dylib
-# if .so exists.
-MODULES               = libbuiltinreqs.so,
-                        libscheme-shell.so,
-                        libpy-shell.so,
-			
-
-# Optional modules, not enabled by default
-#                        libatomspacepublishermodule.so
-#                        libdimensionalembedding.so
-
-
-# Parameters for ZeroMQ AtomSpace Event Publisher
-ZMQ_EVENT_USE_PUBLIC_IP = TRUE
-ZMQ_EVENT_PORT = 5563
-
-
+# -------------------------------------------------------------
 # Parameters for RuleEngine
 # RULE_ENGINE_TRIGGERED_ON = [1 ,2 ,3]
 # 1-when atom added 2-when atom enters to AF 3-both on 1 and 2

--- a/lib/opencog_patternminer_common.conf
+++ b/lib/opencog_patternminer_common.conf
@@ -5,114 +5,28 @@
 # server. Particularly noteworthy is the list of automatically loaded
 # modules.
 #
-SERVER_PORT           = 17001
+# SERVER_PORT           = 17001
 LOG_FILE              = /tmp/cogserver.log
 
 # Other possible log levels are "error", "warn", "info", "debug" and "fine"
 # LOG_LEVEL             = debug
 LOG_LEVEL             = info
 LOG_TO_STDOUT         = false
-SERVER_CYCLE_DURATION = 100
-
-# Economic Attention Allocation parameters
-STARTING_STI_FUNDS    = 100000
-STARTING_LTI_FUNDS    = 100000
-TARGET_STI_FUNDS      = 10000
-TARGET_LTI_FUNDS      = 10000
-STI_FUNDS_BUFFER      = 10000
-LTI_FUNDS_BUFFER      = 10000
-MIN_STI               = 0
-
-ECAN_MAX_ATOM_STI_RENT      = 15
-
-ECAN_STARTING_ATOM_STI_RENT = 10
-ECAN_STARTING_ATOM_STI_WAGE = 10
-
-ECAN_STARTING_ATOM_LTI_RENT = 1
-ECAN_STARTING_ATOM_LTI_WAGE = 10
-
-ECAN_AF_RENT_FREQUENCY = 2
-
-#For FocusBoundaryUpdatingAgent
-ECAN_AFB_SIZE = 0.2
-ECAN_AFB_DECAY = 0.1
-ECAN_AFB_BOTTOM = 50
-ECAN_MIN_AF_SIZE = 100
-ECAN_MAX_AF_SIZE = 500
-
-#For ForgettingAgent
-ECAN_ATOMSPACE_MAXSIZE = 100000
-ECAN_ATOMSPACE_ACCEPTABLE_SIZE_SPREAD = 100
-
-#For HebbianLinkCreationAgent
-ECAN_MAXLINKS = 300
-ECAN_LOCAL_FAR_LINK_RATIO = 10
-
-#For WARent/DiffusionAgent
-ECAN_DIFFUSION_TOURNAMENT_SIZE = 5
-ECAN_RENT_TOURNAMENT_SIZE = 5
-
-#Used by ImportanceDiffusionAgent class
-#0 => flat rent, 1 => exp rent, 2 => log rent, 3 => linear rent
-ECAN_RENT_TYPE              = 0
-ECAN_RENT_AMNESTY           = 5
-ECAN_RENT_EQUATION_PARAMETER_0 = 0.05
-ECAN_RENT_EQUATION_PARAMETER_1 = 0.0
-
-#End of ImportanceDiffusionAgent class
-
-#Used by SimpleImportanceDiffusionAgent class
-#Maximum percentage of STI that is spread from an atom
-ECAN_MAX_SPREAD_PERCENTAGE = 0.2
-
-# If false, will diffuse along hebbian links only. If true,
-# will also diffuse to all non-hebbian incident atoms in the
-# incoming and outgoing sets
-ECAN_SPREAD_HEBBIAN_ONLY = false
-
-# Maximum percentage that will be available for diffusion to hebbian links
-HEBBIAN_MAX_ALLOCATION_PERCENTAGE = 0.5
-ECAN_CONVERT_LINKS = false
-ECAN_CONVERSION_THRESHOLD = 15
-
-# spread deciding function type (HPERBOLIC = 0 and STEP = 1 )
-SPREAD_DECIDER_TYPE = 1
-#END of SimpleImportanceDiffusionAgent params
-
-#ForgettingAgent params
-ECAN_FORGET_PERCENTAGE = 0.001
-
-#END of Economic Attention Allocation parameters
 
 # Use this command PROMPT when telnet/terminal doesn't support ANSI
-PROMPT                = "opencog> "
+# PROMPT                = "opencog> "
 # Prompt with ANSI color codes
-ANSI_PROMPT           = "[0;32mopencog[1;32m> [0m"
+# ANSI_PROMPT           = "[0;32mopencog[1;32m> [0m"
 # Use this guile PROMPT when telnet/terminal doesn't support ANSI
-SCM_PROMPT            = "guile> "
+# SCM_PROMPT            = "guile> "
 # Prompt with ANSI color codes
-ANSI_SCM_PROMPT       = "[0;34mguile[1;34m> [0m"
+# ANSI_SCM_PROMPT       = "[0;34mguile[1;34m> [0m"
 # Global option so that modules know whether they should output ANSI color
 # codes
-ANSI_ENABLED	       = true
-
-# Cogserver in OSX will automatically change .so extension to .dylib
-# if .so exists.
-MODULES               = libbuiltinreqs.so,
-                        libscheme-shell.so,
-                        libpy-shell.so,
-			
-
-# Optional modules, not enabled by default
-#                        libatomspacepublishermodule.so
-#                        libdimensionalembedding.so
+# ANSI_ENABLED	       = true
 
 
-# Parameters for ZeroMQ AtomSpace Event Publisher
-ZMQ_EVENT_USE_PUBLIC_IP = TRUE
-ZMQ_EVENT_PORT = 5563
-
-
+# --------------------------------------------------------------
 # Parameters for RuleEngine
 # RULE_ENGINE_TRIGGERED_ON = [1 ,2 ,3]
 # 1-when atom added 2-when atom enters to AF 3-both on 1 and 2

--- a/lib/opencog_patternminer_nlp.conf
+++ b/lib/opencog_patternminer_nlp.conf
@@ -4,114 +4,27 @@
 # server. Particularly noteworthy is the list of automatically loaded
 # modules.
 #
-SERVER_PORT           = 17001
+# SERVER_PORT           = 17001
 LOG_FILE              = /tmp/cogserver.log
 
 # Other possible log levels are "error", "warn", "info", "debug" and "fine"
 # LOG_LEVEL             = debug
 LOG_LEVEL             = info
 LOG_TO_STDOUT         = false
-SERVER_CYCLE_DURATION = 100
-
-# Economic Attention Allocation parameters
-STARTING_STI_FUNDS    = 100000
-STARTING_LTI_FUNDS    = 100000
-TARGET_STI_FUNDS      = 10000
-TARGET_LTI_FUNDS      = 10000
-STI_FUNDS_BUFFER      = 10000
-LTI_FUNDS_BUFFER      = 10000
-MIN_STI               = 0
-
-ECAN_MAX_ATOM_STI_RENT      = 15
-
-ECAN_STARTING_ATOM_STI_RENT = 10
-ECAN_STARTING_ATOM_STI_WAGE = 10
-
-ECAN_STARTING_ATOM_LTI_RENT = 1
-ECAN_STARTING_ATOM_LTI_WAGE = 10
-
-ECAN_AF_RENT_FREQUENCY = 2
-
-#For FocusBoundaryUpdatingAgent
-ECAN_AFB_SIZE = 0.2
-ECAN_AFB_DECAY = 0.1
-ECAN_AFB_BOTTOM = 50
-ECAN_MIN_AF_SIZE = 100
-ECAN_MAX_AF_SIZE = 500
-
-#For ForgettingAgent
-ECAN_ATOMSPACE_MAXSIZE = 100000
-ECAN_ATOMSPACE_ACCEPTABLE_SIZE_SPREAD = 100
-
-#For HebbianLinkCreationAgent
-ECAN_MAXLINKS = 300
-ECAN_LOCAL_FAR_LINK_RATIO = 10
-
-#For WARent/DiffusionAgent
-ECAN_DIFFUSION_TOURNAMENT_SIZE = 5
-ECAN_RENT_TOURNAMENT_SIZE = 5
-
-#Used by ImportanceDiffusionAgent class
-#0 => flat rent, 1 => exp rent, 2 => log rent, 3 => linear rent
-ECAN_RENT_TYPE              = 0
-ECAN_RENT_AMNESTY           = 5
-ECAN_RENT_EQUATION_PARAMETER_0 = 0.05
-ECAN_RENT_EQUATION_PARAMETER_1 = 0.0
-
-#End of ImportanceDiffusionAgent class
-
-#Used by SimpleImportanceDiffusionAgent class
-#Maximum percentage of STI that is spread from an atom
-ECAN_MAX_SPREAD_PERCENTAGE = 0.2
-
-# If false, will diffuse along hebbian links only. If true,
-# will also diffuse to all non-hebbian incident atoms in the
-# incoming and outgoing sets
-ECAN_SPREAD_HEBBIAN_ONLY = false
-
-# Maximum percentage that will be available for diffusion to hebbian links
-HEBBIAN_MAX_ALLOCATION_PERCENTAGE = 0.5
-ECAN_CONVERT_LINKS = false
-ECAN_CONVERSION_THRESHOLD = 15
-
-# spread deciding function type (HPERBOLIC = 0 and STEP = 1 )
-SPREAD_DECIDER_TYPE = 1
-#END of SimpleImportanceDiffusionAgent params
-
-#ForgettingAgent params
-ECAN_FORGET_PERCENTAGE = 0.001
-
-#END of Economic Attention Allocation parameters
 
 # Use this command PROMPT when telnet/terminal doesn't support ANSI
-PROMPT                = "opencog> "
+# PROMPT                = "opencog> "
 # Prompt with ANSI color codes
-ANSI_PROMPT           = "[0;32mopencog[1;32m> [0m"
+# ANSI_PROMPT           = "[0;32mopencog[1;32m> [0m"
 # Use this guile PROMPT when telnet/terminal doesn't support ANSI
-SCM_PROMPT            = "guile> "
+# SCM_PROMPT            = "guile> "
 # Prompt with ANSI color codes
-ANSI_SCM_PROMPT       = "[0;34mguile[1;34m> [0m"
+# ANSI_SCM_PROMPT       = "[0;34mguile[1;34m> [0m"
 # Global option so that modules know whether they should output ANSI color
 # codes
-ANSI_ENABLED	       = true
+# ANSI_ENABLED	       = true
 
-# Cogserver in OSX will automatically change .so extension to .dylib
-# if .so exists.
-MODULES               = libbuiltinreqs.so,
-                        libscheme-shell.so,
-                        libpy-shell.so,
-			
-
-# Optional modules, not enabled by default
-#                        libatomspacepublishermodule.so
-#                        libdimensionalembedding.so
-
-
-# Parameters for ZeroMQ AtomSpace Event Publisher
-ZMQ_EVENT_USE_PUBLIC_IP = TRUE
-ZMQ_EVENT_PORT = 5563
-
-
+# -------------------------------------------------------------------
 # Parameters for RuleEngine
 # RULE_ENGINE_TRIGGERED_ON = [1 ,2 ,3]
 # 1-when atom added 2-when atom enters to AF 3-both on 1 and 2

--- a/lib/opencog_patternminer_pln.conf
+++ b/lib/opencog_patternminer_pln.conf
@@ -4,114 +4,27 @@
 # server. Particularly noteworthy is the list of automatically loaded
 # modules.
 #
-SERVER_PORT           = 17001
+# SERVER_PORT           = 17001
 LOG_FILE              = /tmp/cogserver.log
 
 # Other possible log levels are "error", "warn", "info", "debug" and "fine"
 # LOG_LEVEL             = debug
 LOG_LEVEL             = info
 LOG_TO_STDOUT         = false
-SERVER_CYCLE_DURATION = 100
-
-# Economic Attention Allocation parameters
-STARTING_STI_FUNDS    = 100000
-STARTING_LTI_FUNDS    = 100000
-TARGET_STI_FUNDS      = 10000
-TARGET_LTI_FUNDS      = 10000
-STI_FUNDS_BUFFER      = 10000
-LTI_FUNDS_BUFFER      = 10000
-MIN_STI               = 0
-
-ECAN_MAX_ATOM_STI_RENT      = 15
-
-ECAN_STARTING_ATOM_STI_RENT = 10
-ECAN_STARTING_ATOM_STI_WAGE = 10
-
-ECAN_STARTING_ATOM_LTI_RENT = 1
-ECAN_STARTING_ATOM_LTI_WAGE = 10
-
-ECAN_AF_RENT_FREQUENCY = 2
-
-#For FocusBoundaryUpdatingAgent
-ECAN_AFB_SIZE = 0.2
-ECAN_AFB_DECAY = 0.1
-ECAN_AFB_BOTTOM = 50
-ECAN_MIN_AF_SIZE = 100
-ECAN_MAX_AF_SIZE = 500
-
-#For ForgettingAgent
-ECAN_ATOMSPACE_MAXSIZE = 100000
-ECAN_ATOMSPACE_ACCEPTABLE_SIZE_SPREAD = 100
-
-#For HebbianLinkCreationAgent
-ECAN_MAXLINKS = 300
-ECAN_LOCAL_FAR_LINK_RATIO = 10
-
-#For WARent/DiffusionAgent
-ECAN_DIFFUSION_TOURNAMENT_SIZE = 5
-ECAN_RENT_TOURNAMENT_SIZE = 5
-
-#Used by ImportanceDiffusionAgent class
-#0 => flat rent, 1 => exp rent, 2 => log rent, 3 => linear rent
-ECAN_RENT_TYPE              = 0
-ECAN_RENT_AMNESTY           = 5
-ECAN_RENT_EQUATION_PARAMETER_0 = 0.05
-ECAN_RENT_EQUATION_PARAMETER_1 = 0.0
-
-#End of ImportanceDiffusionAgent class
-
-#Used by SimpleImportanceDiffusionAgent class
-#Maximum percentage of STI that is spread from an atom
-ECAN_MAX_SPREAD_PERCENTAGE = 0.2
-
-# If false, will diffuse along hebbian links only. If true,
-# will also diffuse to all non-hebbian incident atoms in the
-# incoming and outgoing sets
-ECAN_SPREAD_HEBBIAN_ONLY = false
-
-# Maximum percentage that will be available for diffusion to hebbian links
-HEBBIAN_MAX_ALLOCATION_PERCENTAGE = 0.5
-ECAN_CONVERT_LINKS = false
-ECAN_CONVERSION_THRESHOLD = 15
-
-# spread deciding function type (HPERBOLIC = 0 and STEP = 1 )
-SPREAD_DECIDER_TYPE = 1
-#END of SimpleImportanceDiffusionAgent params
-
-#ForgettingAgent params
-ECAN_FORGET_PERCENTAGE = 0.001
-
-#END of Economic Attention Allocation parameters
 
 # Use this command PROMPT when telnet/terminal doesn't support ANSI
-PROMPT                = "opencog> "
+# PROMPT                = "opencog> "
 # Prompt with ANSI color codes
-ANSI_PROMPT           = "[0;32mopencog[1;32m> [0m"
+# ANSI_PROMPT           = "[0;32mopencog[1;32m> [0m"
 # Use this guile PROMPT when telnet/terminal doesn't support ANSI
-SCM_PROMPT            = "guile> "
+# SCM_PROMPT            = "guile> "
 # Prompt with ANSI color codes
-ANSI_SCM_PROMPT       = "[0;34mguile[1;34m> [0m"
+# ANSI_SCM_PROMPT       = "[0;34mguile[1;34m> [0m"
 # Global option so that modules know whether they should output ANSI color
 # codes
-ANSI_ENABLED	       = true
+# ANSI_ENABLED	       = true
 
-# Cogserver in OSX will automatically change .so extension to .dylib
-# if .so exists.
-MODULES               = libbuiltinreqs.so,
-                        libscheme-shell.so,
-                        libpy-shell.so,
-			
-
-# Optional modules, not enabled by default
-#                        libatomspacepublishermodule.so
-#                        libdimensionalembedding.so
-
-
-# Parameters for ZeroMQ AtomSpace Event Publisher
-ZMQ_EVENT_USE_PUBLIC_IP = TRUE
-ZMQ_EVENT_PORT = 5563
-
-
+# ---------------------------------------------------------------------
 # Parameters for RuleEngine
 # RULE_ENGINE_TRIGGERED_ON = [1 ,2 ,3]
 # 1-when atom added 2-when atom enters to AF 3-both on 1 and 2

--- a/opencog/attention/default-param-values.scm
+++ b/opencog/attention/default-param-values.scm
@@ -1,213 +1,75 @@
-
+;
+; ECAN paramters.
+;
 (use-modules (opencog))
 
-(define AF_RENT_FREQUENCY  (ConceptNode "AF_RENT_FREQUENCY"))
-(define MAX_AF_SIZE (ConceptNode "MAX_AF_SIZE"))
-(define MIN_AF_SIZE (ConceptNode "MIN_AF_SIZE"))
-(define AF_SIZE (ConceptNode "AF_SIZE"))
-(define AFB_BOTTOM  (ConceptNode "AFB_BOTTOM"))
-(define AFB_DECAY (ConceptNode "AFB_DECAY"))
-(define ECAN_PARAM (ConceptNode "ECAN_PARAMS"))
-(define FORGET_THRESHOLD (ConceptNode "FORGET_THRESHOLD") ) 
-(define MAX_LINKS (ConceptNode "MAX_LINKS")   ) 
-(define HEBBIAN_MAX_ALLOCATION_PERCENTAGE (ConceptNode "HEBBIAN_MAX_ALLOCATION_PERCENTAGE") )  
-(define LOCAL_FAR_LINK_RATIO (ConceptNode "LOCAL_FAR_LINK_RATIO") )
-(define MAX_SPREAD_PERCENTAGE  (ConceptNode "MAX_SPREAD_PERCENTAGE"))
-(define SPREAD_HEBBIAN_ONLY (ConceptNode "SPREAD_HEBBIAN_ONLY"))
-(define DIFFUSION_TOURNAMENT_SIZE(ConceptNode "DIFFUSION_TOURNAMENT_SIZE"))
-(define STARTING_ATOM_STI_RENT (ConceptNode "STARTING_ATOM_STI_RENT"))
-(define STARTING_ATOM_LTI_RENT (ConceptNode "STARTING_ATOM_LTI_RENT"))
-(define TARGET_STI_FUNDS (ConceptNode "TARGET_STI_FUNDS"))
-(define TARGET_LTI_FUNDS (ConceptNode "TARGET_LTI_FUNDS"))
-(define STI_FUNDS_BUFFER (ConceptNode "STI_FUNDS_BUFFER"))
-(define LTI_FUNDS_BUFFER (ConceptNode "LTI_FUNDS_BUFFER"))
-(define TARGET_LTI_FUNDS_BUFFER (ConceptNode "TARGET_LTI_FUNDS_BUFFER"))
-(define RENT_TOURNAMENT_SIZE (ConceptNode "RENT_TOURNAMENT_SIZE"))
-(define SPREADING_FILTER (ConceptNode "SPREADING_FILTER"))
+(define AF_RENT_FREQUENCY         (Concept "AF_RENT_FREQUENCY"))
+(define MAX_AF_SIZE               (Concept "MAX_AF_SIZE"))
+(define MIN_AF_SIZE               (Concept "MIN_AF_SIZE"))
+(define AF_SIZE                   (Concept "AF_SIZE"))
+(define AFB_BOTTOM                (Concept "AFB_BOTTOM"))
+(define AFB_DECAY                 (Concept "AFB_DECAY"))
+(define ECAN_PARAM                (Concept "ECAN_PARAMS"))
+(define FORGET_THRESHOLD          (Concept "FORGET_THRESHOLD"))
+(define MAX_LINKS                 (Concept "MAX_LINKS"))
+(define HEBBIAN_MAX_ALLOCATION_PERCENTAGE (Concept "HEBBIAN_MAX_ALLOCATION_PERCENTAGE"))
+(define LOCAL_FAR_LINK_RATIO      (Concept "LOCAL_FAR_LINK_RATIO") )
+(define MAX_SPREAD_PERCENTAGE     (Concept "MAX_SPREAD_PERCENTAGE"))
+(define SPREAD_HEBBIAN_ONLY       (Concept "SPREAD_HEBBIAN_ONLY"))
+(define DIFFUSION_TOURNAMENT_SIZE (Concept "DIFFUSION_TOURNAMENT_SIZE"))
+(define STARTING_ATOM_STI_RENT    (Concept "STARTING_ATOM_STI_RENT"))
+(define STARTING_ATOM_LTI_RENT    (Concept "STARTING_ATOM_LTI_RENT"))
+(define TARGET_STI_FUNDS          (Concept "TARGET_STI_FUNDS"))
+(define TARGET_LTI_FUNDS          (Concept "TARGET_LTI_FUNDS"))
+(define STI_FUNDS_BUFFER          (Concept "STI_FUNDS_BUFFER"))
+(define LTI_FUNDS_BUFFER          (Concept "LTI_FUNDS_BUFFER"))
+(define TARGET_LTI_FUNDS_BUFFER   (Concept "TARGET_LTI_FUNDS_BUFFER"))
+(define RENT_TOURNAMENT_SIZE      (Concept "RENT_TOURNAMENT_SIZE"))
+(define SPREADING_FILTER          (Concept "SPREADING_FILTER"))
 
-(MemberLink 
-  AF_SIZE
-  ECAN_PARAM  
-)
-(MemberLink
-  MAX_AF_SIZE
-  ECAN_PARAM
-)
-(MemberLink 
-  MIN_AF_SIZE
-  ECAN_PARAM  
-)
-(MemberLink 
-  AFB_DECAY
-  ECAN_PARAM
-)
-(MemberLink
-  AFB_BOTTOM
-  ECAN_PARAM
-)
-(MemberLink
-  MAX_AF_SIZE
-  ECAN_PARAM
-)
-(MemberLink 
-  AF_RENT_FREQUENCY 
-  ECAN_PARAM  
-)
-(MemberLink 
-  FORGET_THRESHOLD
-  ECAN_PARAM  
-)
-(MemberLink 
-  MAX_LINKS
-  ECAN_PARAM  
-)
-(MemberLink 
-  HEBBIAN_MAX_ALLOCATION_PERCENTAGE
-  ECAN_PARAM  
-)
-(MemberLink 
-  LOCAL_FAR_LINK_RATIO
-  ECAN_PARAM  
-)
-(MemberLink 
-  MAX_SPREAD_PERCENTAGE
-  ECAN_PARAM  
-)
-(MemberLink
-  SPREADING_FILTER
-  ECAN_PARAM
-)
-(MemberLink 
-  SPREAD_HEBBIAN_ONLY
-  ECAN_PARAM  
-)
-(MemberLink 
-  DIFFUSION_TOURNAMENT_SIZE
-  ECAN_PARAM  
-)
-(MemberLink 
-  STARTING_ATOM_STI_RENT
-  ECAN_PARAM  
-)
-(MemberLink 
-  STARTING_ATOM_LTI_RENT
-  ECAN_PARAM  
-)
-(MemberLink 
-  TARGET_STI_FUNDS
-  ECAN_PARAM  
-)
-(MemberLink
-  TARGET_LTI_FUNDS
-  ECAN_PARAM
-)
-(MemberLink 
-  STI_FUNDS_BUFFER
-  ECAN_PARAM
-)
-(MemberLink 
-  LTI_FUNDS_BUFFER
-  ECAN_PARAM
-)
-(MemberLink 
-  TARGET_LTI_FUNDS_BUFFER
-  ECAN_PARAM
-)
-(MemberLink 
-  RENT_TOURNAMENT_SIZE
-  ECAN_PARAM
-)
-(StateLink
-  AF_SIZE
-  (NumberNode "0.2")  
-)
-(StateLink
-  MIN_AF_SIZE
-  (NumberNode "500")
-)
-(StateLink 
-  AFB_DECAY
-  (NumberNode "0.05")
-)
-(StateLink 
-  AFB_BOTTOM
-  (NumberNode "50")
-)
-(StateLink 
-  MAX_AF_SIZE
-  (NumberNode "1000")
-)
-(StateLink 
-  AF_RENT_FREQUENCY 
-  (NumberNode "5")
-)
-(StateLink 
-  FORGET_THRESHOLD
-  (NumberNode "0.05")
-)
-(StateLink 
-  MAX_LINKS
-  (NumberNode "300")
-)
-(StateLink 
-  HEBBIAN_MAX_ALLOCATION_PERCENTAGE
-  (NumberNode "0.05")
-)
-(StateLink 
-  LOCAL_FAR_LINK_RATIO
-  (NumberNode "10")
-)
-(StateLink 
-  MAX_SPREAD_PERCENTAGE
-  (NumberNode "0.4")
-)
-(StateLink
-  SPREADING_FILTER
-  (MemberLink
-    (TypeNode "MemberLink")
-  )
-)
-(StateLink 
-  SPREAD_HEBBIAN_ONLY
-  (NumberNode "0")
-)
-(StateLink 
-  DIFFUSION_TOURNAMENT_SIZE
-  (NumberNode "5")
-)
-(StateLink 
-  STARTING_ATOM_STI_RENT
-  (NumberNode "1")
-)
-(StateLink 
-  STARTING_ATOM_LTI_RENT
-  (NumberNode "1")
-)
-(StateLink 
-  TARGET_STI_FUNDS
-  (NumberNode "10000")
-)
+(Member AF_SIZE                   ECAN_PARAM)
+(Member MAX_AF_SIZE               ECAN_PARAM)
+(Member MIN_AF_SIZE               ECAN_PARAM)
+(Member AFB_DECAY                 ECAN_PARAM)
+(Member AFB_BOTTOM                ECAN_PARAM)
+(Member MAX_AF_SIZE               ECAN_PARAM)
+(Member AF_RENT_FREQUENCY         ECAN_PARAM)
+(Member FORGET_THRESHOLD          ECAN_PARAM)
+(Member MAX_LINKS                 ECAN_PARAM)
+(Member HEBBIAN_MAX_ALLOCATION_PERCENTAGE ECAN_PARAM)
+(Member LOCAL_FAR_LINK_RATIO      ECAN_PARAM)
+(Member MAX_SPREAD_PERCENTAGE     ECAN_PARAM)
+(Member SPREADING_FILTER          ECAN_PARAM)
+(Member SPREAD_HEBBIAN_ONLY       ECAN_PARAM)
+(Member DIFFUSION_TOURNAMENT_SIZE ECAN_PARAM)
+(Member STARTING_ATOM_STI_RENT    ECAN_PARAM)
+(Member STARTING_ATOM_LTI_RENT    ECAN_PARAM)
+(Member TARGET_STI_FUNDS          ECAN_PARAM)
+(Member TARGET_LTI_FUNDS          ECAN_PARAM)
+(Member STI_FUNDS_BUFFER          ECAN_PARAM)
+(Member LTI_FUNDS_BUFFER          ECAN_PARAM)
+(Member TARGET_LTI_FUNDS_BUFFER   ECAN_PARAM)
+(Member RENT_TOURNAMENT_SIZE      ECAN_PARAM)
 
-(StateLink 
-  TARGET_LTI_FUNDS
-  (NumberNode "10000")
-)
-
-(StateLink
-  STI_FUNDS_BUFFER
-  (NumberNode "10000")
-)
-
-(StateLink 
-  LTI_FUNDS_BUFFER
-  (NumberNode "10000")
-)
-(StateLink 
-  TARGET_LTI_FUNDS_BUFFER
-  (NumberNode "10000")
-)
-(StateLink
-  RENT_TOURNAMENT_SIZE
-  (NumberNode "5")
-)
-
+(State AF_SIZE                   (Number 0.2))
+(State MIN_AF_SIZE               (Number 500))
+(State AFB_DECAY                 (Number 0.05))
+(State AFB_BOTTOM                (Number 50))
+(State MAX_AF_SIZE               (Number 1000))
+(State AF_RENT_FREQUENCY         (Number 5))
+(State FORGET_THRESHOLD          (Number 0.05))
+(State MAX_LINKS                 (Number 300))
+(State HEBBIAN_MAX_ALLOCATION_PERCENTAGE (Number 0.05))
+(State LOCAL_FAR_LINK_RATIO      (Number 10))
+(State MAX_SPREAD_PERCENTAGE     (Number 0.4))
+(State SPREADING_FILTER          (MemberLink (Type "MemberLink")))
+(State SPREAD_HEBBIAN_ONLY       (Number 0))
+(State DIFFUSION_TOURNAMENT_SIZE (Number 5))
+(State STARTING_ATOM_STI_RENT    (Number 1))
+(State STARTING_ATOM_LTI_RENT    (Number 1))
+(State TARGET_STI_FUNDS          (Number 10000))
+(State TARGET_LTI_FUNDS          (Number 10000))
+(State STI_FUNDS_BUFFER          (Number 10000))
+(State LTI_FUNDS_BUFFER          (Number 10000))
+(State TARGET_LTI_FUNDS_BUFFER   (Number 10000))
+(State RENT_TOURNAMENT_SIZE      (Number 5))

--- a/opencog/attentionbank/bank/AttentionBank.cc
+++ b/opencog/attentionbank/bank/AttentionBank.cc
@@ -34,21 +34,6 @@ using namespace opencog;
 
 AttentionBank::AttentionBank(AtomSpace* asp)
 {
-#if 0
-    // XXX FIXME -- should not use config() to get these values;
-    // The user of this class should call config(), instead!
-
-This generates warnings whenever the unit tests run.
-    startingFundsSTI = fundsSTI = config().get_double("STARTING_STI_FUNDS", 100000);
-    startingFundsLTI = fundsLTI = config().get_double("STARTING_LTI_FUNDS", 100000);
-    stiFundsBuffer = config().get_double("STI_FUNDS_BUFFER", 10000);
-    ltiFundsBuffer = config().get_double("LTI_FUNDS_BUFFER", 10000);
-    targetLTI = config().get_double("TARGET_LTI_FUNDS", 10000);
-    targetSTI = config().get_double("TARGET_STI_FUNDS", 10000);
-    STIAtomWage = config().get_double("ECAN_STARTING_ATOM_STI_WAGE", 10);
-    LTIAtomWage = config().get_double("ECAN_STARTING_ATOM_LTI_WAGE", 10);
-    maxAFSize = config().get_int("ECAN_MAX_AF_SIZE", 100);
-#endif
     startingFundsSTI = fundsSTI = 100000;
     startingFundsLTI = fundsLTI = 100000;
     stiFundsBuffer = 10000;

--- a/opencog/cogserver/modules/events/AtomSpacePublisherModule.cc
+++ b/opencog/cogserver/modules/events/AtomSpacePublisherModule.cc
@@ -189,8 +189,8 @@ void AtomSpacePublisherModule::proxy()
 	zmq::socket_t pub(*context, ZMQ_PUB);
 	pub.setsockopt(ZMQ_SNDHWM, &HWM, sizeof(HWM));
 
-	std::string zmq_event_port = config().get("ZMQ_EVENT_PORT");
-	bool zmq_use_public_ip = config().get_bool("ZMQ_EVENT_USE_PUBLIC_IP");
+	std::string zmq_event_port = config().get("ZMQ_EVENT_PORT", 5563);
+	bool zmq_use_public_ip = config().get_bool("ZMQ_EVENT_USE_PUBLIC_IP", true);
 	std::string zmq_ip;
 	if (zmq_use_public_ip)
 	{


### PR DESCRIPTION
    Cleanup config files.
    
    About half of the ECAN config paramters were non-existant in the code.
    The remaining ones just shadowed the default values.
    And the rest of the ECAN parameters were not in the config file.
    So just remove all of them.  This helps avoid debugging nightmares.
