### PR TITLE
Statistical boostrapping for surprisingness

### DIFF
--- a/examples/learning/miner/sumo/mine-sumo.scm
+++ b/examples/learning/miner/sumo/mine-sumo.scm
@@ -38,12 +38,12 @@
 
 ;; Run pattern miner
 (define results (cog-mine texts-cpt
-                          #:minsup 5
+                          #:minsup 100
                           #:maximum-iterations 10
                           #:incremental-expansion #t
                           #:max-conjuncts 2
-                          ;; #:surprisingness 'nisurp))
-                          #:surprisingness 'none))
+                          #:surprisingness 'nisurp))
+                          ;; #:surprisingness 'none))
 
 ;; The top results are very abstract, but some are interesting, such as
 ;;

--- a/examples/learning/miner/sumo/mine-sumo.scm
+++ b/examples/learning/miner/sumo/mine-sumo.scm
@@ -9,13 +9,14 @@
 
 ;; Load SUMO
 ;; (load "all-sumo-labeled-kb.scm")
-(load "Geography.scm")
+;; (load "Geography.scm")
+(load "scm/mondial.scm")
 
 ;; Set loggers
 (ure-logger-set-level! "debug")
-(ure-logger-set-timestamp! #f)
+;; (ure-logger-set-timestamp! #f)
 ;; (ure-logger-set-sync! #t)
-(cog-logger-set-timestamp! #f)
+;; (cog-logger-set-timestamp! #f)
 (cog-logger-set-level! "debug")
 ;; (cog-logger-set-sync! #t)
 
@@ -38,7 +39,7 @@
 ;; Run pattern miner
 (define results (cog-mine texts-cpt
                           #:minsup 5
-                          #:maximum-iterations 30
+                          #:maximum-iterations 10
                           #:incremental-expansion #t
                           #:max-conjuncts 2
                           ;; #:surprisingness 'nisurp))

--- a/opencog/learning/miner/Miner.cc
+++ b/opencog/learning/miner/Miner.cc
@@ -78,22 +78,22 @@ Miner::Miner(const MinerParameters& prm)
 
 HandleTree Miner::operator()(const AtomSpace& texts_as)
 {
-	HandleSet texts;
+	HandleSeq texts;
 	texts_as.get_handles_by_type(std::inserter(texts, texts.end()),
 	                             opencog::ATOM, true);
 	return operator()(texts);
 }
 
-HandleTree Miner::operator()(const HandleSet& texts)
+HandleTree Miner::operator()(const HandleSeq& texts)
 {
 	// If the initial pattern is specialized, this initial filtering
 	// may save some computation
-	HandleSet fltexts = filter_texts(param.initpat, texts);
+	HandleSeq fltexts = filter_texts(param.initpat, texts);
 	return specialize(param.initpat, fltexts, param.maxdepth);
 }
 
 HandleTree Miner::specialize(const Handle& pattern,
-                             const HandleSet& texts,
+                             const HandleSeq& texts,
                              int maxdepth)
 {
 	// TODO: decide what to choose and remove or comment
@@ -102,7 +102,7 @@ HandleTree Miner::specialize(const Handle& pattern,
 }
 
 HandleTree Miner::specialize(const Handle& pattern,
-                             const HandleSet& texts,
+                             const HandleSeq& texts,
                              const Valuations& valuations,
                              int maxdepth)
 {
@@ -128,7 +128,7 @@ HandleTree Miner::specialize(const Handle& pattern,
 }
 
 HandleTree Miner::specialize_alt(const Handle& pattern,
-                                 const HandleSet& texts,
+                                 const HandleSeq& texts,
                                  const Valuations& valuations,
                                  int maxdepth)
 {
@@ -159,7 +159,7 @@ HandleTree Miner::specialize_alt(const Handle& pattern,
 }
 
 bool Miner::terminate(const Handle& pattern,
-                      const HandleSet& texts,
+                      const HandleSeq& texts,
                       const Valuations& valuations,
                       int maxdepth) const
 {
@@ -176,7 +176,7 @@ bool Miner::terminate(const Handle& pattern,
 }
 
 HandleTree Miner::specialize_shabs(const Handle& pattern,
-                                   const HandleSet& texts,
+                                   const HandleSeq& texts,
                                    const Valuations& valuations,
                                    int maxdepth)
 {
@@ -208,7 +208,7 @@ HandleTree Miner::specialize_shabs(const Handle& pattern,
 }
 
 HandleTree Miner::specialize_shapat(const Handle& pattern,
-                                    const HandleSet& texts,
+                                    const HandleSeq& texts,
                                     const Handle& var,
                                     const Handle& shapat,
                                     int maxdepth)
@@ -221,7 +221,7 @@ HandleTree Miner::specialize_shapat(const Handle& pattern,
 		return HandleTree();
 
 	// Generate the corresponding text
-	HandleSet fltexts = filter_texts(npat, texts);
+	HandleSeq fltexts = filter_texts(npat, texts);
 
 	// That specialization doesn't have enough support, skip it
 	// and its specializations.
@@ -236,13 +236,13 @@ HandleTree Miner::specialize_shapat(const Handle& pattern,
 }
 
 bool Miner::enough_support(const Handle& pattern,
-                           const HandleSet& texts) const
+                           const HandleSeq& texts) const
 {
 	return param.minsup <= freq(pattern, texts, param.minsup);
 }
 
 unsigned Miner::freq(const Handle& pattern,
-                     const HandleSet& texts,
+                     const HandleSeq& texts,
                      unsigned ms) const
 {
 	HandleSeq cps(MinerUtils::get_component_patterns(pattern));
@@ -267,8 +267,8 @@ unsigned Miner::freq(const std::vector<unsigned>& freqs) const
 	return std::floor(f);
 }
 
-HandleSet Miner::filter_texts(const Handle& pattern,
-                              const HandleSet& texts) const
+HandleSeq Miner::filter_texts(const Handle& pattern,
+                              const HandleSeq& texts) const
 {
 	// No need to filter if most abstract
 	if (MinerUtils::totally_abstract(pattern))
@@ -280,10 +280,11 @@ HandleSet Miner::filter_texts(const Handle& pattern,
 		return texts;
 
 	// Otherwise it is a single conjunct pattern
-	HandleSet filtrd;
+	// TODO: use comprehension
+	HandleSeq filtrd;
 	for (const auto& text : texts)
 		if (match(pattern, text))
-			filtrd.insert(text);
+			filtrd.push_back(text);
 	return filtrd;
 }
 

--- a/opencog/learning/miner/Miner.h
+++ b/opencog/learning/miner/Miner.h
@@ -54,6 +54,7 @@ struct MinerParameters {
 	                int maxdepth=-1,
 	                double info=1.0);
 
+	// TODO: change frequency by support!!!
 	// Minimum support. Mined patterns must have a frequency equal or
 	// above this value.
 	unsigned minsup;
@@ -128,14 +129,14 @@ public:
 	/**
 	 * Like above but only mine amongst the provided text collection.
 	 */
-	HandleTree operator()(const HandleSet& texts);
+	HandleTree operator()(const HandleSeq& texts);
 
 	/**
 	 * Specialization. Given a pattern and a collection to text atoms,
 	 * generate all specialized patterns of the given pattern.
 	 */
 	HandleTree specialize(const Handle& pattern,
-	                      const HandleSet& texts,
+	                      const HandleSeq& texts,
 	                      int maxdepth=-1);
 
 	/**
@@ -143,7 +144,7 @@ public:
 	 * valuations.
 	 */
 	HandleTree specialize(const Handle& pattern,
-	                      const HandleSet& texts,
+	                      const HandleSeq& texts,
 	                      const Valuations& valuations,
 	                      int maxdepth);
 
@@ -151,7 +152,7 @@ public:
 	 * Alternate specialization that reflects how the URE would work.
 	 */
 	HandleTree specialize_alt(const Handle& pattern,
-	                          const HandleSet& texts,
+	                          const HandleSeq& texts,
 	                          const Valuations& valuations,
 	                          int maxdepth);
 
@@ -168,7 +169,7 @@ private:
 	 * whether the valuation has any variable left to specialize from.
 	 */
 	bool terminate(const Handle& pattern,
-	               const HandleSet& texts,
+	               const HandleSeq& texts,
 	               const Valuations& valuations,
 	               int maxdepth) const;
 
@@ -179,7 +180,7 @@ private:
 	 * obtained specializations.
 	 */
 	HandleTree specialize_shabs(const Handle& pattern,
-	                            const HandleSet& texts,
+	                            const HandleSeq& texts,
 	                            const Valuations& valuations,
 	                            int maxdepth);
 
@@ -189,7 +190,7 @@ private:
 	 * obtained specialization.
 	 */
 	HandleTree specialize_shapat(const Handle& pattern,
-	                             const HandleSet& texts,
+	                             const HandleSeq& texts,
 	                             const Handle& var,
 	                             const Handle& shapat,
 	                             int maxdepth);
@@ -200,7 +201,7 @@ private:
 	 * to minsup.
 	 */
 	bool enough_support(const Handle& pattern,
-	                    const HandleSet& texts) const;
+	                    const HandleSeq& texts) const;
 
 	/**
 	 * Given a pattern and a text corpus, calculate the pattern
@@ -216,7 +217,7 @@ private:
 	 * certain maximum, for saving resources.
 	 */
 	unsigned freq(const Handle& pattern,
-	              const HandleSet& texts,
+	              const HandleSeq& texts,
 	              unsigned ms) const;
 
 	/**
@@ -228,8 +229,8 @@ private:
 	/**
 	 * Filter in only texts matching the pattern
 	 */
-	HandleSet filter_texts(const Handle& pattern,
-	                       const HandleSet& texts) const;
+	HandleSeq filter_texts(const Handle& pattern,
+	                       const HandleSeq& texts) const;
 
 	/**
 	 * Check whether a pattern matches a text.

--- a/opencog/learning/miner/MinerSCM.cc
+++ b/opencog/learning/miner/MinerSCM.cc
@@ -161,14 +161,14 @@ Handle MinerSCM::do_shallow_abstract(Handle pattern,
 	AtomSpace *as = SchemeSmob::ss_get_env_as("cog-shallow-abstract");
 
 	// Fetch all texts
-	HandleSet texts_set = MinerUtils::get_texts(texts);
+	HandleSeq texts_seq = MinerUtils::get_texts(texts);
 
 	// Fetch the minimum support
 	unsigned ms_uint = MinerUtils::get_ms(ms);
 
 	// Generate all shallow abstractions
 	HandleSetSeq shabs_per_var =
-		MinerUtils::shallow_abstract(pattern, texts_set, ms_uint);
+		MinerUtils::shallow_abstract(pattern, texts_seq, ms_uint);
 
 	// Turn that sequence of handle sets into a set of ready to be
 	// applied shallow abstractions
@@ -197,13 +197,13 @@ Handle MinerSCM::do_shallow_specialize(Handle pattern,
 	AtomSpace *as = SchemeSmob::ss_get_env_as("cog-shallow-specialize");
 
 	// Fetch all texts
-	HandleSet texts_set = MinerUtils::get_texts(texts);
+	HandleSeq texts_seq = MinerUtils::get_texts(texts);
 
 	// Fetch the minimum support
 	unsigned ms_uint = MinerUtils::get_ms(ms);
 
 	// Generate all shallow specializations
-	HandleSet shaspes = MinerUtils::shallow_specialize(pattern, texts_set, ms_uint);
+	HandleSet shaspes = MinerUtils::shallow_specialize(pattern, texts_seq, ms_uint);
 
 	return as->add_link(SET_LINK, HandleSeq(shaspes.begin(), shaspes.end()));
 }
@@ -211,12 +211,12 @@ Handle MinerSCM::do_shallow_specialize(Handle pattern,
 bool MinerSCM::do_enough_support(Handle pattern, Handle texts, Handle ms)
 {
 	// Fetch all texts
-	HandleSet texts_set = MinerUtils::get_texts(texts);
+	HandleSeq texts_seq = MinerUtils::get_texts(texts);
 
 	// Fetch the minimum support
 	unsigned ms_uint = MinerUtils::get_ms(ms);
 
-	return MinerUtils::enough_support(pattern, texts_set, ms_uint);
+	return MinerUtils::enough_support(pattern, texts_seq, ms_uint);
 }
 
 Handle MinerSCM::do_expand_conjunction(Handle cnjtion, Handle pattern,
@@ -225,13 +225,13 @@ Handle MinerSCM::do_expand_conjunction(Handle cnjtion, Handle pattern,
 	AtomSpace *as = SchemeSmob::ss_get_env_as("cog-expand-conjunction");
 
 	// Fetch all texts
-	HandleSet texts_set = MinerUtils::get_texts(texts);
+	HandleSeq texts_seq = MinerUtils::get_texts(texts);
 
 	// Fetch the minimum support
 	unsigned ms_uint = MinerUtils::get_ms(ms);
 
 	HandleSet results = MinerUtils::expand_conjunction(cnjtion, pattern,
-	                                                   texts_set,
+	                                                   texts_seq,
 	                                                   ms_uint);
 	return as->add_link(SET_LINK, HandleSeq(results.begin(), results.end()));
 }
@@ -239,33 +239,33 @@ Handle MinerSCM::do_expand_conjunction(Handle cnjtion, Handle pattern,
 double MinerSCM::do_isurp_old(Handle pattern, Handle texts)
 {
 	// Fetch all texts
-	HandleSet texts_set = MinerUtils::get_texts(texts);
+	HandleSeq texts_seq = MinerUtils::get_texts(texts);
 
-	return Surprisingness::isurp_old(pattern, texts_set, false);
+	return Surprisingness::isurp_old(pattern, texts_seq, false);
 }
 
 double MinerSCM::do_nisurp_old(Handle pattern, Handle texts)
 {
 	// Fetch all texts
-	HandleSet texts_set = MinerUtils::get_texts(texts);
+	HandleSeq texts_seq = MinerUtils::get_texts(texts);
 
-	return Surprisingness::isurp_old(pattern, texts_set, true);
+	return Surprisingness::isurp_old(pattern, texts_seq, true);
 }
 
 double MinerSCM::do_isurp(Handle pattern, Handle texts)
 {
 	// Fetch all texts
-	HandleSet texts_set = MinerUtils::get_texts(texts);
+	HandleSeq texts_seq = MinerUtils::get_texts(texts);
 
-	return Surprisingness::isurp(pattern, texts_set, false);
+	return Surprisingness::isurp(pattern, texts_seq, false);
 }
 
 double MinerSCM::do_nisurp(Handle pattern, Handle texts)
 {
 	// Fetch all texts
-	HandleSet texts_set = MinerUtils::get_texts(texts);
+	HandleSeq texts_seq = MinerUtils::get_texts(texts);
 
-	return Surprisingness::isurp(pattern, texts_set, true);
+	return Surprisingness::isurp(pattern, texts_seq, true);
 }
 
 extern "C" {

--- a/opencog/learning/miner/MinerUtils.cc
+++ b/opencog/learning/miner/MinerUtils.cc
@@ -334,15 +334,15 @@ Handle MinerUtils::remove_unary_and(const Handle& h)
 	return h;
 }
 
-HandleSet MinerUtils::get_texts(const Handle& texts_cpt)
+HandleSeq MinerUtils::get_texts(const Handle& texts_cpt)
 {
 	// Retrieve all members of texts_cpt
-	HandleSet texts;
+	HandleSeq texts;
 	IncomingSet member_links = texts_cpt->getIncomingSetByType(MEMBER_LINK);
 	for (const LinkPtr l : member_links) {
 		Handle member = l->getOutgoingAtom(0);
 		if (member != texts_cpt)
-			texts.insert(member);
+			texts.push_back(member);
 	}
 	return texts;
 }
@@ -354,7 +354,7 @@ unsigned MinerUtils::get_ms(const Handle& ms)
 }
 
 unsigned MinerUtils::support(const Handle& pattern,
-                             const HandleSet& texts,
+                             const HandleSeq& texts,
                              unsigned ms)
 {
 	// Partition the pattern into strongly connected components
@@ -375,7 +375,7 @@ unsigned MinerUtils::support(const Handle& pattern,
 }
 
 unsigned MinerUtils::component_support(const Handle& component,
-                                       const HandleSet& texts,
+                                       const HandleSeq& texts,
                                        unsigned ms)
 {
 	if (totally_abstract(component))
@@ -384,14 +384,14 @@ unsigned MinerUtils::component_support(const Handle& component,
 }
 
 bool MinerUtils::enough_support(const Handle& pattern,
-                                const HandleSet& texts,
+                                const HandleSeq& texts,
                                 unsigned ms)
 {
 	return ms <= support(pattern, texts, ms);
 }
 
 HandleSetSeq MinerUtils::shallow_abstract(const Handle& pattern,
-                                          const HandleSet& texts,
+                                          const HandleSeq& texts,
                                           unsigned ms)
 {
 	Valuations valuations(pattern, texts);
@@ -399,7 +399,7 @@ HandleSetSeq MinerUtils::shallow_abstract(const Handle& pattern,
 }
 
 HandleSet MinerUtils::shallow_specialize(const Handle& pattern,
-                                         const HandleSet& texts,
+                                         const HandleSeq& texts,
                                          unsigned ms)
 {
 	// Calculate all shallow abstractions of pattern
@@ -487,7 +487,7 @@ HandleSeq MinerUtils::get_conjuncts(const Handle& pattern)
 }
 
 Handle MinerUtils::restricted_satisfying_set(const Handle& pattern,
-                                             const HandleSet& texts,
+                                             const HandleSeq& texts,
                                              unsigned ms)
 {
 	static AtomSpace tmp_texts_as; // TODO: fix to be thread safe
@@ -760,7 +760,7 @@ Handle MinerUtils::expand_conjunction_connect(const Handle& cnjtion,
 
 HandleSet MinerUtils::expand_conjunction(const Handle& cnjtion,
                                          const Handle& pattern,
-                                         const HandleSet& texts,
+                                         const HandleSeq& texts,
                                          unsigned ms)
 {
 	// Alpha convert pattern, if necessary, to avoid collisions between
@@ -804,7 +804,7 @@ double MinerUtils::get_support(const Handle& pattern)
 }
 
 double MinerUtils::calc_support(const Handle& pattern,
-                                const HandleSet& texts,
+                                const HandleSeq& texts,
                                 unsigned ms)
 {
 	// TODO: re-enable memoizing support when ready

--- a/opencog/learning/miner/MinerUtils.cc
+++ b/opencog/learning/miner/MinerUtils.cc
@@ -807,12 +807,14 @@ double MinerUtils::calc_support(const Handle& pattern,
                                 const HandleSet& texts,
                                 unsigned ms)
 {
-	double sup = get_support(pattern);
-	if (sup < 0) {
-		sup = support(pattern, texts, ms);
-		set_support(pattern, sup);
-	}
-	return sup;
+	// TODO: re-enable memoizing support when ready
+	// double sup = get_support(pattern);
+	// if (sup < 0) {
+		// sup = support(pattern, texts, ms);
+		// set_support(pattern, sup);
+	// }
+	// return sup;
+	return support(pattern, texts, ms);
 }
 
 } // namespace opencog

--- a/opencog/learning/miner/MinerUtils.h
+++ b/opencog/learning/miner/MinerUtils.h
@@ -305,7 +305,7 @@ public:
 	 * { (And (Concept "A") (And (Concept "B") (Concept "C"))) }
 	 *
 	 * Also, the pattern may match any subhypergraph of texts, not just
-	 * the root atoms.
+	 * the root atoms (TODO: we probably don't want that!!!).
 	 */
 	static Handle restricted_satisfying_set(const Handle& pattern,
 	                                        const HandleSet& texts,

--- a/opencog/learning/miner/MinerUtils.h
+++ b/opencog/learning/miner/MinerUtils.h
@@ -192,7 +192,7 @@ public:
 	/**
 	 * Given a texts concept node, retrieve all its members
 	 */
-	static HandleSet get_texts(const Handle& texts_cpt);
+	static HandleSeq get_texts(const Handle& texts_cpt);
 
 	/**
 	 * Given a number node holding the minimum support return the
@@ -205,7 +205,7 @@ public:
 	 * frequency up to ms (to avoid unnecessary calculations).
 	 */
 	static unsigned support(const Handle& pattern,
-	                        const HandleSet& texts,
+	                        const HandleSeq& texts,
 	                        unsigned ms);
 
 	/**
@@ -213,7 +213,7 @@ public:
 	 * its variables depends on other clauses).
 	 */
 	static unsigned component_support(const Handle& pattern,
-	                                  const HandleSet& texts,
+	                                  const HandleSeq& texts,
 	                                  unsigned ms);
 
 	/**
@@ -222,7 +222,7 @@ public:
 	 * to ms.
 	 */
 	static bool enough_support(const Handle& pattern,
-	                           const HandleSet& texts,
+	                           const HandleSeq& texts,
 	                           unsigned ms);
 
 	/**
@@ -234,7 +234,7 @@ public:
 	 * details.
 	 */
 	static HandleSetSeq shallow_abstract(const Handle& pattern,
-	                                     const HandleSet& texts,
+	                                     const HandleSeq& texts,
 	                                     unsigned ms);
 
 	/**
@@ -242,7 +242,7 @@ public:
 	 * according to texts.
 	 */
 	static HandleSet shallow_specialize(const Handle& pattern,
-	                                    const HandleSet& texts,
+	                                    const HandleSeq& texts,
 	                                    unsigned ms);
 
 	/**
@@ -308,7 +308,7 @@ public:
 	 * the root atoms (TODO: we probably don't want that!!!).
 	 */
 	static Handle restricted_satisfying_set(const Handle& pattern,
-	                                        const HandleSet& texts,
+	                                        const HandleSeq& texts,
 	                                        unsigned ms=UINT_MAX);
 
 	/**
@@ -455,7 +455,7 @@ public:
 	 */
 	static HandleSet expand_conjunction(const Handle& cnjtion,
 	                                    const Handle& pattern,
-	                                    const HandleSet& texts,
+	                                    const HandleSeq& texts,
 	                                    unsigned ms);
 
 	/**
@@ -482,7 +482,7 @@ public:
 	 * support_key() then calculate and set the support.
 	 */
 	static double calc_support(const Handle& pattern,
-	                           const HandleSet& texts,
+	                           const HandleSeq& texts,
 	                           unsigned ms);
 };
 

--- a/opencog/learning/miner/Surprisingness.cc
+++ b/opencog/learning/miner/Surprisingness.cc
@@ -87,7 +87,7 @@ double Surprisingness::isurp_old(const Handle& pattern,
 
 	// Calculate the I-Surprisingness, normalized if requested.
 	double dst = dst_from_interval(emin, emax, pattern_prob);
-	return normalize ? dst / pattern_prob : dst;
+	return std::min(normalize? dst / pattern_prob : dst, 1.0);
 }
 
 double Surprisingness::isurp(const Handle& pattern,
@@ -117,7 +117,7 @@ double Surprisingness::isurp(const Handle& pattern,
 	// logger().debug() << "dst = " << dst
 	//                  << ", normalize = " << normalize
 	//                  << ", ndst = " << dst / emp;
-	return normalize ? dst / emp : dst;
+	return std::min(normalize ? dst / emp : dst, 1.0);
 }
 
 Handle Surprisingness::isurp_key()

--- a/opencog/learning/miner/Surprisingness.cc
+++ b/opencog/learning/miner/Surprisingness.cc
@@ -418,7 +418,7 @@ unsigned Surprisingness::subsmp_size(const Handle& pattern,
 	//                  << ", support_estimate = " << support_estimate
 	//                  << ", alpha = " << alpha
 	//                  << ", res = " << res;
-	return std::ceil(res);
+	return std::max((unsigned)res, std::min(5000U, (unsigned)ts));
 }
 
 double Surprisingness::ji_prob(const HandleSeqSeq& partition,

--- a/opencog/learning/miner/Surprisingness.cc
+++ b/opencog/learning/miner/Surprisingness.cc
@@ -52,7 +52,7 @@
 namespace opencog {
 
 double Surprisingness::isurp_old(const Handle& pattern,
-                                 const HandleSet& texts,
+                                 const HandleSeq& texts,
                                  bool normalize)
 {
 	// Strictly speaking it should be the power but we use binomial for
@@ -90,7 +90,7 @@ double Surprisingness::isurp_old(const Handle& pattern,
 }
 
 double Surprisingness::isurp(const Handle& pattern,
-                             const HandleSet& texts,
+                             const HandleSeq& texts,
                              bool normalize)
 {
 	// Calculate the empiric probability of pattern
@@ -235,7 +235,7 @@ HandleSeq Surprisingness::joint_variables(const Handle& pattern,
 
 unsigned Surprisingness::value_count(const HandleSeq& block,
                                      const Handle& var,
-                                     const HandleSet& texts)
+                                     const HandleSeq& texts)
 {
 	Valuations vs(MinerUtils::mk_pattern_without_vardecl(block), texts);
 	HandleUCounter values = vs.values(var);
@@ -244,7 +244,7 @@ unsigned Surprisingness::value_count(const HandleSeq& block,
 
 HandleCounter Surprisingness::value_distribution(const HandleSeq& block,
                                                  const Handle& var,
-                                                 const HandleSet& texts)
+                                                 const HandleSeq& texts)
 {
 	Valuations vs(MinerUtils::mk_pattern_without_vardecl(block), texts);
 	HandleUCounter values = vs.values(var);
@@ -275,12 +275,12 @@ double Surprisingness::inner_product(const std::vector<HandleCounter>& dists)
 }
 
 double Surprisingness::universe_count(const Handle& pattern,
-                                      const HandleSet& texts)
+                                      const HandleSeq& texts)
 {
 	return pow((double)texts.size(), MinerUtils::n_conjuncts(pattern));
 }
 
-double Surprisingness::emp_prob(const Handle& pattern, const HandleSet& texts)
+double Surprisingness::emp_prob(const Handle& pattern, const HandleSeq& texts)
 {
 	double ucount = universe_count(pattern, texts);
 	unsigned ms = (unsigned)std::min((double)UINT_MAX, ucount);
@@ -290,7 +290,7 @@ double Surprisingness::emp_prob(const Handle& pattern, const HandleSet& texts)
 }
 
 double Surprisingness::emp_prob_subsmp(const Handle& pattern,
-                                       const HandleSet& texts,
+                                       const HandleSeq& texts,
                                        unsigned subsize)
 {
 	return emp_prob(pattern,
@@ -298,23 +298,23 @@ double Surprisingness::emp_prob_subsmp(const Handle& pattern,
 	                subsmp(texts, subsize) : texts);
 }
 
-HandleSet Surprisingness::subsmp(const HandleSet& texts, unsigned subsize)
+HandleSeq Surprisingness::subsmp(const HandleSeq& texts, unsigned subsize)
 {
 	logger().debug() << "Surprisingness::subsmp begin";
 	unsigned ts = texts.size();
 	if (ts/2 <= subsize and subsize < ts) {
 		// Subsample by randomly removing
-		HandleSet smp_texts(texts);
+		HandleSeq smp_texts(texts);
 		dorepeat(texts.size() - subsize)
 			rand_element_erase(smp_texts);
 		logger().debug() << "Surprisingness::subsmp end 1";
 		return smp_texts;
 	} else if (0 <= subsize and subsize < ts/2) {
 		// Subsample by randomly adding
-		HandleSet smp_texts;
+		HandleSeq smp_texts;
 		lazy_random_selector select(ts);
 		dorepeat(subsize)
-			smp_texts.insert(*std::next(texts.begin(), select()));
+			smp_texts.push_back(*std::next(texts.begin(), select()));
 		logger().debug() << "Surprisingness::subsmp end 2";
 		return smp_texts;
 	} else {
@@ -324,7 +324,7 @@ HandleSet Surprisingness::subsmp(const HandleSet& texts, unsigned subsize)
 }
 
 double Surprisingness::emp_prob_bs(const Handle& pattern,
-                                   const HandleSet& texts,
+                                   const HandleSeq& texts,
                                    unsigned nss,
                                    unsigned subsize)
 {
@@ -338,7 +338,7 @@ double Surprisingness::emp_prob_bs(const Handle& pattern,
 	}
 }
 
-std::pair<unsigned, unsigned> Surprisingness::get_nns_subsize(const HandleSet& texts)
+std::pair<unsigned, unsigned> Surprisingness::get_nns_subsize(const HandleSeq& texts)
 {
 	unsigned subsize = 5000;
 	unsigned nns = std::ceil(sqrt(texts.size() / subsize) + 0.5);
@@ -349,7 +349,7 @@ std::pair<unsigned, unsigned> Surprisingness::get_nns_subsize(const HandleSet& t
 
 double Surprisingness::ji_prob(const HandleSeqSeq& partition,
                                const Handle& pattern,
-                               const HandleSet& texts)
+                               const HandleSeq& texts)
 {
 	// Generate subpatterns from blocks (add them in the atomspace to
 	// memoize support calculation)
@@ -592,7 +592,7 @@ HandleSeqUCounter Surprisingness::group_eq(const HandleSeqSeq& partition,
 
 double Surprisingness::eq_prob(const HandleSeqSeq& partition,
                                const Handle& pattern,
-                               const HandleSet& texts)
+                               const HandleSeq& texts)
 {
 	// logger().debug() << "Surprisingness::eq_prob_alt partition:"
 	//                  << std::endl << oc_to_string(partition)

--- a/opencog/learning/miner/Surprisingness.cc
+++ b/opencog/learning/miner/Surprisingness.cc
@@ -300,26 +300,28 @@ double Surprisingness::emp_prob_subsmp(const Handle& pattern,
 
 HandleSeq Surprisingness::subsmp(const HandleSeq& texts, unsigned subsize)
 {
-	logger().debug() << "Surprisingness::subsmp begin";
 	unsigned ts = texts.size();
 	if (ts/2 <= subsize and subsize < ts) {
-		// Subsample by randomly removing
+		// Subsample by randomly removing (swapping all elements to
+		// remove with the tail, then removing the tail, which is
+		// considerably faster than removing element by element).
 		HandleSeq smp_texts(texts);
-		dorepeat(texts.size() - subsize)
-			rand_element_erase(smp_texts);
-		logger().debug() << "Surprisingness::subsmp end 1";
+		unsigned i = ts;
+		while (subsize < i) {
+			unsigned rnd_idx = randGen().randint(i);
+			std::swap(smp_texts[rnd_idx], smp_texts[--i]);
+		}
+		smp_texts.resize(i);
 		return smp_texts;
-	} else if (0 <= subsize and subsize < ts/2) {
+	} else if (0 <= subsize and subsize < ts/*/2*/) {
 		// Subsample by randomly adding
-		HandleSeq smp_texts;
+		HandleSeq smp_texts(subsize);
 		lazy_random_selector select(ts);
-		dorepeat(subsize)
-			smp_texts.push_back(*std::next(texts.begin(), select()));
-		logger().debug() << "Surprisingness::subsmp end 2";
+		for (size_t i = 0; i < subsize; i++)
+			smp_texts[i] = texts[select()];
 		return smp_texts;
 	} else {
-		OC_ASSERT(false);
-		return {};
+		return texts;
 	}
 }
 

--- a/opencog/learning/miner/Surprisingness.cc
+++ b/opencog/learning/miner/Surprisingness.cc
@@ -289,7 +289,6 @@ double Surprisingness::emp_prob(const Handle& pattern, const HandleSeq& texts)
 	double ucount = universe_count(pattern, texts);
 	unsigned ms = (unsigned)std::min((double)UINT_MAX, ucount);
 	double sup = MinerUtils::calc_support(pattern, texts, ms);
-	logger().debug() << "emp_prob(" << oc_to_string(pattern) << ",texts.size()=" << texts.size() << ") = " << "sup = " << sup << ", ucount = " << ucount << ", res = " << sup/ucount << ", texts.size() < sup = " << (texts.size() < sup);
 	return sup / ucount;
 }
 
@@ -365,6 +364,10 @@ double Surprisingness::emp_prob_pbs(const Handle& pattern,
                                     const HandleSeq& texts,
                                     double prob_estimate)
 {
+	// logger().debug() << "emp_prob_pbs(" << oc_to_string(pattern)
+	//                  << ",texts.size()=" << texts.size()
+	//                  << ",prob_estimate=" << prob_estimate << ")";
+
 	// Calculate an estimate of the support of the pattern to decide
 	// whether we should subsample the texts corpus. Indeed some
 	// pattern have intractably large support.
@@ -410,11 +413,11 @@ unsigned Surprisingness::subsmp_size(const Handle& pattern,
 	double nc = MinerUtils::n_conjuncts(pattern);
 	double alpha = (double)support_estimate / std::pow(ts, nc);
 	double res = std::pow(ts / (10*alpha), 1.0/nc);
-	logger().debug() << "Surprisingness::subsmp_size ts = " << ts
-	                 << ", nc = " << nc
-	                 << ", support_estimate = " << support_estimate
-	                 << ", alpha = " << alpha
-	                 << ", res = " << res;
+	// logger().debug() << "Surprisingness::subsmp_size ts = " << ts
+	//                  << ", nc = " << nc
+	//                  << ", support_estimate = " << support_estimate
+	//                  << ", alpha = " << alpha
+	//                  << ", res = " << res;
 	return std::ceil(res);
 }
 

--- a/opencog/learning/miner/Surprisingness.h
+++ b/opencog/learning/miner/Surprisingness.h
@@ -495,10 +495,55 @@ public:
 	static double inner_product(const std::vector<HandleCounter>& dists);
 
 	/**
+	 * Calculate the universe count of the pattern over the given texts
+	 */
+	static double universe_count(const Handle& pattern, const HandleSet& texts);
+
+	/**
 	 * Calculate the empiric probability of a pattern according to a
 	 * database texts.
 	 */
 	static double emp_prob(const Handle& pattern, const HandleSet& texts);
+
+	/**
+	 * Like emp_prob but subsample the texts to have subsize (if texts
+	 * size is greater than subsize).
+	 *
+	 * TODO: memoizing support is current disabled.
+	 */
+	static double emp_prob_subsmp(const Handle& pattern,
+	                              const HandleSet& texts,
+	                              unsigned subsize=UINT_MAX);
+
+	/**
+	 * Randomly subsample texts so that the resulting texts has size
+	 * subsize.
+	 *
+	 * An assert is raised if subsize is not smaller than texts.size().
+	 */
+	static HandleSet subsmp(const HandleSet& texts, unsigned subsize);
+
+	/**
+	 * Like emp_prob but uses bootstrapping for more efficiency. nbs is
+	 * the number of subsamplings taking place, and subsize is the size
+	 * of each subsample.
+	 *
+	 * TODO: memoizing support is current disabled.
+	 */
+	static double emp_prob_bs(const Handle& pattern,
+	                          const HandleSet& texts,
+	                          unsigned nss=1,
+	                          unsigned subsize=UINT_MAX);
+
+	/**
+	 * Determine the number of samples and the subsample size given a
+	 * text corpus. The formula is as follows:
+	 *
+	 * subsize = 5000
+	 *
+	 * nns = ceiling(sqrt(ts / subsize) + 0.5)
+	 */
+	static std::pair<unsigned, unsigned> get_nns_subsize(const HandleSet& texts);
 
 	/**
 	 * Calculate probability estimate of a pattern given a partition,

--- a/opencog/learning/miner/Surprisingness.h
+++ b/opencog/learning/miner/Surprisingness.h
@@ -518,8 +518,6 @@ public:
 	/**
 	 * Randomly subsample texts so that the resulting texts has size
 	 * subsize.
-	 *
-	 * An assert is raised if subsize is not smaller than texts.size().
 	 */
 	static HandleSeq subsmp(const HandleSeq& texts, unsigned subsize);
 

--- a/opencog/learning/miner/Surprisingness.h
+++ b/opencog/learning/miner/Surprisingness.h
@@ -73,7 +73,7 @@ public:
 	 * they are encoded as lists of lists for performance reasons.
 	 */
 	static double isurp_old(const Handle& pattern,
-	                        const HandleSet& texts,
+	                        const HandleSeq& texts,
 	                        bool normalize=true);
 
 	/**
@@ -331,7 +331,7 @@ public:
 	 * slow). We have not experimented with approximated counts yet.
 	 */
 	static double isurp(const Handle& pattern,
-	                    const HandleSet& texts,
+	                    const HandleSeq& texts,
 	                    bool normalize=true);
 
 	/**
@@ -464,7 +464,7 @@ public:
 	 */
 	static unsigned value_count(const HandleSeq& block,
 	                            const Handle& var,
-	                            const HandleSet& texts);
+	                            const HandleSeq& texts);
 
 	/**
 	 * Return the probability distribution over value of var in the
@@ -472,7 +472,7 @@ public:
 	 */
 	static HandleCounter value_distribution(const HandleSeq& block,
 	                                        const Handle& var,
-	                                        const HandleSet& texts);
+	                                        const HandleSeq& texts);
 
 	/**
 	 * Perform the inner product of a collection of distributions.
@@ -497,13 +497,13 @@ public:
 	/**
 	 * Calculate the universe count of the pattern over the given texts
 	 */
-	static double universe_count(const Handle& pattern, const HandleSet& texts);
+	static double universe_count(const Handle& pattern, const HandleSeq& texts);
 
 	/**
 	 * Calculate the empiric probability of a pattern according to a
 	 * database texts.
 	 */
-	static double emp_prob(const Handle& pattern, const HandleSet& texts);
+	static double emp_prob(const Handle& pattern, const HandleSeq& texts);
 
 	/**
 	 * Like emp_prob but subsample the texts to have subsize (if texts
@@ -512,7 +512,7 @@ public:
 	 * TODO: memoizing support is current disabled.
 	 */
 	static double emp_prob_subsmp(const Handle& pattern,
-	                              const HandleSet& texts,
+	                              const HandleSeq& texts,
 	                              unsigned subsize=UINT_MAX);
 
 	/**
@@ -521,7 +521,7 @@ public:
 	 *
 	 * An assert is raised if subsize is not smaller than texts.size().
 	 */
-	static HandleSet subsmp(const HandleSet& texts, unsigned subsize);
+	static HandleSeq subsmp(const HandleSeq& texts, unsigned subsize);
 
 	/**
 	 * Like emp_prob but uses bootstrapping for more efficiency. nbs is
@@ -531,7 +531,7 @@ public:
 	 * TODO: memoizing support is current disabled.
 	 */
 	static double emp_prob_bs(const Handle& pattern,
-	                          const HandleSet& texts,
+	                          const HandleSeq& texts,
 	                          unsigned nss=1,
 	                          unsigned subsize=UINT_MAX);
 
@@ -543,7 +543,7 @@ public:
 	 *
 	 * nns = ceiling(sqrt(ts / subsize) + 0.5)
 	 */
-	static std::pair<unsigned, unsigned> get_nns_subsize(const HandleSet& texts);
+	static std::pair<unsigned, unsigned> get_nns_subsize(const HandleSeq& texts);
 
 	/**
 	 * Calculate probability estimate of a pattern given a partition,
@@ -554,7 +554,7 @@ public:
 	 */
 	static double ji_prob(const HandleSeqSeq& partition,
 	                      const Handle& pattern,
-	                      const HandleSet& texts);
+	                      const HandleSeq& texts);
 
 	/**
 	 * Return true iff the given variable has the same position (same
@@ -771,7 +771,7 @@ public:
 	 */
 	static double eq_prob(const HandleSeqSeq& partition,
 	                      const Handle& pattern,
-	                      const HandleSet& texts);
+	                      const HandleSeq& texts);
 
 	/**
 	 * Alternate implementation of eq_prob. Takes into syntactical
@@ -780,7 +780,7 @@ public:
 	 */
 	static double eq_prob_alt(const HandleSeqSeq& partition,
 	                          const Handle& pattern,
-	                          const HandleSet& texts);
+	                          const HandleSeq& texts);
 };
 
 /**

--- a/opencog/learning/miner/Surprisingness.h
+++ b/opencog/learning/miner/Surprisingness.h
@@ -514,6 +514,12 @@ public:
 	static double emp_prob(const Handle& pattern, const HandleSeq& texts);
 
 	/**
+	 * Like emp_prob with memoization.
+	 */
+	static double emp_prob_mem(const Handle& pattern,
+	                           const HandleSeq& texts);
+
+	/**
 	 * Like emp_prob but subsample the texts to have subsize (if texts
 	 * size is greater than subsize).
 	 *
@@ -553,6 +559,13 @@ public:
 	static double emp_prob_pbs(const Handle& pattern,
 	                           const HandleSeq& texts,
 	                           double prob_estimate);
+
+	/**
+	 * Like emp_prob_pbs with memoization.
+	 */
+	static double emp_prob_pbs_mem(const Handle& pattern,
+	                               const HandleSeq& texts,
+	                               double prob_estimate);
 
 	/**
 	 * Determine the number of samples and the subsample size given a
@@ -829,6 +842,17 @@ public:
 	static double eq_prob_alt(const HandleSeqSeq& partition,
 	                          const Handle& pattern,
 	                          const HandleSeq& texts);
+
+	/**
+	 * Key of the empirical probability value
+	 */
+	static const Handle& emp_prob_key();
+
+	/**
+	 * Get/set the empirical probability of the given pattern.
+	 */
+	static TruthValuePtr get_emp_prob(const Handle& pattern);
+	static void set_emp_prob(const Handle& pattern, double emp_prob);
 };
 
 /**

--- a/opencog/learning/miner/Valuations.cc
+++ b/opencog/learning/miner/Valuations.cc
@@ -155,7 +155,7 @@ std::string SCValuations::to_string(const std::string& indent) const
 // Valuations //
 ////////////////
 
-Valuations::Valuations(const Handle& pattern, const HandleSet& texts)
+Valuations::Valuations(const Handle& pattern, const HandleSeq& texts)
 	: ValuationsBase(MinerUtils::get_variables(pattern))
 {
 	// Useless clauses (like redundant, constants, and more) are

--- a/opencog/learning/miner/Valuations.h
+++ b/opencog/learning/miner/Valuations.h
@@ -150,7 +150,7 @@ public:
 	 * Given a pattern and texts (ground terms), calculate its
 	 * valuations.
 	 */
-	Valuations(const Handle& pattern, const HandleSet& texts);
+	Valuations(const Handle& pattern, const HandleSeq& texts);
 	Valuations(const Variables& variables, const SCValuationsSet& scvs);
 	Valuations(const Variables& variables);
 

--- a/opencog/learning/miner/miner-utils.scm
+++ b/opencog/learning/miner/miner-utils.scm
@@ -34,12 +34,12 @@
 "
   (> (cog-mean x) (cog-mean y)))
 
-(define (desc-sort-by-tv-strength l)
+(define (desc-sort-by-tv-strength lst)
 "
-  Given a link of atoms, sort these atom in descending order according
+  Given a list of atoms, sort these atom in descending order according
   to their tv strengths.
 "
-  (List (sort (cog-outgoing-set l) greater-tv-strength)))
+  (sort lst greater-tv-strength))
 
 (define (top)
 "
@@ -529,10 +529,9 @@
           (if (equal? surprisingness 'none)
 
               ;; No surprisingness, simple return the pattern list
-              (begin
+              (let* ((parent-patterns-lst (cog-cp parent-as patterns-lst)))
                 (cog-set-atomspace! parent-as)
-                ;; TODO: delete tmp-as but without deleting its atoms
-                patterns-lst)
+                parent-patterns-lst)
 
               ;; Run surprisingness
               (let*
@@ -543,10 +542,14 @@
                    (cfg-s (configure-isurp isurp-rbs surprisingness max-conjuncts))
 
                    ;; Run surprisingness in a backward way
-                   (isurp-results (cog-bc isurp-rbs target #:vardecl vardecl)))
+                   (isurp-res (cog-bc isurp-rbs target #:vardecl vardecl))
+                   (isurp-res-lst (cog-outgoing-set isurp-res))
+                   (isurp-res-sort-lst (desc-sort-by-tv-strength isurp-res-lst))
+
+                   ;; Copy the results to the parent atomspace
+                   (parent-isurp-res (cog-cp parent-as isurp-res-sort-lst)))
                 (cog-set-atomspace! parent-as)
-                ;; TODO: delete tmp-as but without deleting its atoms
-                (desc-sort-by-tv-strength isurp-results)))))))
+                parent-isurp-res))))))
 
 (define (export-miner-utils)
   (export

--- a/opencog/learning/miner/rules/i-surprisingness.scm
+++ b/opencog/learning/miner/rules/i-surprisingness.scm
@@ -91,8 +91,8 @@
 (define (gen-i-surprisingness-formula mode)
   (lambda (conclusion . premises)
 
-    (cog-logger-debug "(i-surprisingness-formula mode = ~a, conclusion = ~a, premises = ~a"
-                      mode conclusion premises)
+    ;; (cog-logger-debug "(i-surprisingness-formula mode = ~a, conclusion = ~a, premises = ~a"
+    ;;                   mode conclusion premises)
 
     (if (= 1 (length premises))
         (let* ((pat-isurp conclusion)

--- a/tests/learning/miner/MinerUTest.cxxtest
+++ b/tests/learning/miner/MinerUTest.cxxtest
@@ -112,7 +112,7 @@ private:
 	              TruthValuePtr incremental_expansion=TruthValue::FALSE_TV(),
 	              int max_conjuncts=-1,
 	              double complexity_penalty=0.0);
-	Handle ure_pm(const HandleSet& texts, int minsup,
+	Handle ure_pm(const HandleSeq& texts, int minsup,
 	              int max_iter=-1, Handle initpat=Handle::UNDEFINED,
 	              TruthValuePtr incremental_expansion=TruthValue::FALSE_TV(),
 	              int max_conjuncts=-1,
@@ -125,7 +125,7 @@ private:
 	                  int conjuncts=1,
 	                  const Handle& initpat=Handle::UNDEFINED,
 	                  int maxdepth=-1, double info=1.0);
-	HandleTree cpp_pm(const HandleSet& texts, int minsup=1,
+	HandleTree cpp_pm(const HandleSeq& texts, int minsup=1,
 	                  int conjuncts=1,
 	                  const Handle& initpat=Handle::UNDEFINED,
 	                  int maxdepth=-1, double info=1.0);
@@ -202,7 +202,7 @@ Handle MinerUTest::ure_pm(const AtomSpace& texts_as, int minsup,
 	                               complexity_penalty);
 }
 
-Handle MinerUTest::ure_pm(const HandleSet& texts, int minsup,
+Handle MinerUTest::ure_pm(const HandleSeq& texts, int minsup,
                           int maximum_iterations, Handle initpat,
                           TruthValuePtr incremental_expansion,
                           int max_conjuncts,
@@ -223,7 +223,7 @@ HandleTree MinerUTest::cpp_pm(const AtomSpace& texts_as,
 	return MinerUTestUtils::cpp_pm(texts_as, minsup, conjuncts, initpat, maxdepth, info);
 }
 
-HandleTree MinerUTest::cpp_pm(const HandleSet& texts,
+HandleTree MinerUTest::cpp_pm(const HandleSeq& texts,
                               int minsup,
                               int conjuncts,
                               const Handle& initpat,
@@ -424,7 +424,7 @@ void MinerUTest::test_expand_conjunction_1()
 	Handle
 		InhAB = al(INHERITANCE_LINK, A, B),
 		InhBC = al(INHERITANCE_LINK, B, C);
-	HandleSet texts{InhAB, InhBC};
+	HandleSeq texts{InhAB, InhBC};
 
 	Handle InhXY = al(INHERITANCE_LINK, X, Y),
 		VarXY = al(VARIABLE_LIST, X, Y),
@@ -471,7 +471,7 @@ void MinerUTest::test_expand_conjunction_2()
 	Handle
 		InhAC = al(INHERITANCE_LINK, A, C),
 		InhBC = al(INHERITANCE_LINK, B, C);
-	HandleSet texts{InhAC, InhBC};
+	HandleSeq texts{InhAC, InhBC};
 
 	Handle InhXC = al(INHERITANCE_LINK, X, C),
 		pat = al(LAMBDA_LINK,
@@ -508,7 +508,7 @@ void MinerUTest::test_shallow_abstract()
 		pattern = al(LAMBDA_LINK, VarXZW, clauses);
 
 	// Define texts
-	HandleSet texts;
+	HandleSeq texts;
 	_tmp_as.get_handles_by_type(std::inserter(texts, texts.end()),
 	                            opencog::ATOM, true);
 
@@ -603,7 +603,7 @@ void MinerUTest::test_AB_AC()
 	// Define texts
 	Handle InhAB = al(INHERITANCE_LINK, A, B),
 		InhAC = al(INHERITANCE_LINK, A, C);
-	HandleSet texts{InhAB, InhAC};
+	HandleSeq texts{InhAB, InhAC};
 
 	// Define pattern parts
 	Handle VarXY = al(VARIABLE_LIST, X, Y),
@@ -640,7 +640,7 @@ void MinerUTest::test_AB_AC_BC()
 	Handle InhAB = al(INHERITANCE_LINK, A, B),
 		InhAC = al(INHERITANCE_LINK, A, C),
 		InhBC = al(INHERITANCE_LINK, B, C);
-	HandleSet texts{A, B, C, InhAB, InhAC, InhBC};
+	HandleSeq texts{A, B, C, InhAB, InhAC, InhBC};
 
 	// Define pattern parts
 	Handle VarXY = al(VARIABLE_LIST, X, Y),
@@ -680,7 +680,7 @@ void MinerUTest::test_AB_ABC()
 	// Define texts
 	Handle InhAB = al(INHERITANCE_LINK, A, B),
 		InhABC = al(INHERITANCE_LINK, A, al(AND_LINK, B, C));
-	HandleSet texts{A, B, C, InhAB, InhABC};
+	HandleSeq texts{A, B, C, InhAB, InhABC};
 
 	// Define pattern parts
 	Handle VarXY = al(VARIABLE_LIST, X, Y),
@@ -723,7 +723,7 @@ void MinerUTest::test_ABCD()
 		InhGH = al(INHERITANCE_LINK, G, H),
 		ImpABCD = al(IMPLICATION_LINK, InhAB, InhCD),
 		ImpEFGH = al(IMPLICATION_LINK, InhEF, InhGH);
-	HandleSet texts{InhAB, InhCD, InhEF, InhGH, ImpABCD, ImpEFGH};
+	HandleSeq texts{InhAB, InhCD, InhEF, InhGH, ImpABCD, ImpEFGH};
 
 	// Define pattern parts
 	Handle InhXY = al(INHERITANCE_LINK, X, Y),
@@ -776,7 +776,7 @@ void MinerUTest::test_ABAB()
 		InhBC = al(INHERITANCE_LINK, B, C),
 		ImpABAB = al(IMPLICATION_LINK, InhAB, InhAB),
 		ImpBCBC = al(IMPLICATION_LINK, InhBC, InhBC);
-	HandleSet texts{ImpABAB, ImpBCBC};
+	HandleSeq texts{ImpABAB, ImpBCBC};
 
 	// Define pattern parts
 	Handle VarXY = al(VARIABLE_LIST, X, Y),
@@ -817,7 +817,7 @@ void MinerUTest::test_AAAA()
 		BB = al(INHERITANCE_LINK, B, B),
 		AAAA = al(IMPLICATION_LINK, AA, AA),
 		BBBB = al(IMPLICATION_LINK, BB, BB);
-	HandleSet texts{AAAA, BBBB};
+	HandleSeq texts{AAAA, BBBB};
 
 	// Define pattern parts
 	Handle InhXX = al(INHERITANCE_LINK, X, X);
@@ -860,7 +860,7 @@ void MinerUTest::test_evaluation()
 	Handle P = an(PREDICATE_NODE, "P"),
 		PA = al(EVALUATION_LINK, P, A),
 		PB = al(EVALUATION_LINK, P, B);
-	HandleSet texts{PA, PB};
+	HandleSeq texts{PA, PB};
 
 	// Define expected pattern
 	Handle PX = al(EVALUATION_LINK, P, X),
@@ -892,7 +892,7 @@ void MinerUTest::test_2conjuncts_1()
 	Handle InhAB = al(INHERITANCE_LINK, A, B),
 		InhBC1 = al(INHERITANCE_LINK, B, C1),
 		InhBC2 = al(INHERITANCE_LINK, B, C2);
-	HandleSet texts{InhAB, InhBC1, InhBC2};
+	HandleSeq texts{InhAB, InhBC1, InhBC2};
 
 	// Define pattern parts
 	Handle VarXY = al(VARIABLE_LIST, X, Y),
@@ -927,7 +927,7 @@ void MinerUTest::test_2conjuncts_2()
 	Handle AB = al(INHERITANCE_LINK, A, B),
 		BC1 = al(INHERITANCE_LINK, B, C1),
 		BC2 = al(INHERITANCE_LINK, B, C2);
-	HandleSet texts{AB, BC1, BC2};
+	HandleSeq texts{AB, BC1, BC2};
 
 	// Define pattern parts
 	Handle VarXYZ = al(VARIABLE_LIST, X, Y, Z),
@@ -979,7 +979,7 @@ void MinerUTest::test_2conjuncts_3()
 	Handle InhAB = al(INHERITANCE_LINK, A, B),
 		InhBC1 = al(INHERITANCE_LINK, B, C1),
 		InhBC2 = al(INHERITANCE_LINK, B, C2);
-	HandleSet texts{InhAB, InhBC1, InhBC2};
+	HandleSeq texts{InhAB, InhBC1, InhBC2};
 
 	// Define pattern parts
 	Handle VarXYZ = al(VARIABLE_LIST, X, Y, Z),
@@ -1023,7 +1023,7 @@ void MinerUTest::test_2conjuncts_4()
 		InhA2B = al(INHERITANCE_LINK, A2, B),
 		InhBC1 = al(INHERITANCE_LINK, B, C1),
 		InhBC2 = al(INHERITANCE_LINK, B, C2);
-	HandleSet texts{InhA1B, InhA2B, InhBC1, InhBC2};
+	HandleSeq texts{InhA1B, InhA2B, InhBC1, InhBC2};
 
 	// Define pattern parts
 	Handle VarXYZ = al(VARIABLE_LIST, X, Y, Z),
@@ -1070,7 +1070,7 @@ void MinerUTest::test_2conjuncts_5()
 		InhBC1 = al(INHERITANCE_LINK, B, C1),
 		InhBC2 = al(INHERITANCE_LINK, B, C2),
 		InhBC3 = al(INHERITANCE_LINK, B, C3);
-	HandleSet texts{InhA1B, InhA2B, InhBC1, InhBC2};
+	HandleSeq texts{InhA1B, InhA2B, InhBC1, InhBC2};
 
 	// Define pattern parts
 	Handle VarXYZ = al(VARIABLE_LIST, X, Y, Z),

--- a/tests/learning/miner/MinerUTestUtils.cc
+++ b/tests/learning/miner/MinerUTestUtils.cc
@@ -148,7 +148,7 @@ Handle MinerUTestUtils::ure_pm(AtomSpace& as,
                                int max_conjuncts,
                                double complexity_penalty)
 {
-	HandleSet texts;
+	HandleSeq texts;
 	texts_as.get_handles_by_type(std::inserter(texts, texts.end()),
 	                             opencog::ATOM, true);
 	return ure_pm(as, scm, pm_rb, texts, minsup, maximum_iterations, initpat,
@@ -158,7 +158,7 @@ Handle MinerUTestUtils::ure_pm(AtomSpace& as,
 Handle MinerUTestUtils::ure_pm(AtomSpace& as,
                                SchemeEval& scm,
                                const Handle& pm_rb,
-                               const HandleSet& texts,
+                               const HandleSeq& texts,
                                int minsup,
                                int maximum_iterations,
                                Handle initpat,
@@ -222,7 +222,7 @@ HandleTree MinerUTestUtils::cpp_pm(const AtomSpace& texts_as,
 	return pm(texts_as);
 }
 
-HandleTree MinerUTestUtils::cpp_pm(const HandleSet& texts,
+HandleTree MinerUTestUtils::cpp_pm(const HandleSeq& texts,
                                    int minsup,
                                    int conjuncts,
                                    const Handle& initpat,

--- a/tests/learning/miner/MinerUTestUtils.h
+++ b/tests/learning/miner/MinerUTestUtils.h
@@ -184,7 +184,7 @@ public:
 	static Handle ure_pm(AtomSpace& as,
 	                     SchemeEval& scm,
 	                     const Handle& pm_rb,
-	                     const HandleSet& texts, int minsup,
+	                     const HandleSeq& texts, int minsup,
 	                     int max_iter=-1,
 	                     Handle initpat=Handle::UNDEFINED,
 	                     TruthValuePtr incremental_expansion=TruthValue::FALSE_TV(),
@@ -200,7 +200,7 @@ public:
 	                         const Handle& initpat=Handle::UNDEFINED,
 	                         int maxdepth=-1,
 	                         double info=1.0);
-	static HandleTree cpp_pm(const HandleSet& texts,
+	static HandleTree cpp_pm(const HandleSeq& texts,
 	                         int minsup=1,
 	                         int conjuncts=1,
 	                         const Handle& initpat=Handle::UNDEFINED,

--- a/tests/learning/miner/SurprisingnessUTest.cxxtest
+++ b/tests/learning/miner/SurprisingnessUTest.cxxtest
@@ -638,7 +638,7 @@ void SurprisingnessUTest::test_nisurp_no_linkage_synthetic_1()
 	// Since the pattern is composed of 2 independent patterns, it
 	// should be completely unsurprising, thus have a nearly null
 	// nisurp measure.
-	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 1e-9);
+	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 0.1);
 }
 
 // Similar to above for pattern
@@ -856,7 +856,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_3()
 	// Since the pattern is composed of 2 independent patterns, it
 	// should be completely unsurprising, thus have a nearly null
 	// nisurp measure.
-	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 1e-3);
+	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 0.1);
 }
 
 // Similar to above for pattern
@@ -923,7 +923,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_4()
 	// Since the pattern is composed of 2 independent patterns, it
 	// should be completely unsurprising, thus have a nearly null
 	// nisurp measure.
-	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 0.1);
+	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 0.2);
 }
 
 // Similar to above for pattern
@@ -1056,7 +1056,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_6()
 	// Since the pattern is composed of 2 independent patterns, it
 	// should be completely unsurprising, thus have a nearly null
 	// nisurp measure.
-	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 0.3);
+	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 0.4);
 }
 
 // Similar to above for pattern
@@ -1200,7 +1200,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_8()
 	// Since the pattern is composed of 2 independent patterns, it
 	// should be completely unsurprising, thus have a nearly null
 	// nisurp measure.
-	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 0.3);
+	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 0.4);
 }
 
 // Similar to above for pattern
@@ -1315,7 +1315,7 @@ void SurprisingnessUTest::test_nisurp_emp_prob_bs_1()
 	// Since the pattern is composed of 2 independent patterns, it
 	// should be completely unsurprising, thus have a nearly null
 	// nisurp measure.
-	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 0.1);
+	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 0.2);
 }
 
 // Test normalized I-Surprisingess for the ugly male soda drinker

--- a/tests/learning/miner/SurprisingnessUTest.cxxtest
+++ b/tests/learning/miner/SurprisingnessUTest.cxxtest
@@ -95,12 +95,18 @@ public:
 	// TODO: fix is_more_abstract to support that case
 	void xtest_is_more_abstract_4();
 	void test_is_strictly_more_abstract();
+	void test_emp_prob_bs_1();
+	void test_emp_prob_bs_2();
 
-	// Test surprisingness measures
+	// Test old surprisingness measures
 	void test_nisurp_old_ugly_man();
 	void test_nisurp_old_ugly_man_soda_drinker();
+
+	// Test surprisingness without joint variables on synthetic data
 	void test_nisurp_no_linkage_synthetic_1();
 	void test_nisurp_no_linkage_synthetic_2();
+
+	// Test surprisingness with joint variables on synthetic data
 	// TODO: that one is really difficult to get because it ultimately
 	// depends on data generator to determine the universe of possible
 	// values of each variable, which is hard to guess.
@@ -113,6 +119,12 @@ public:
 	void test_nisurp_linkage_synthetic_7();
 	void test_nisurp_linkage_synthetic_8();
 	void test_nisurp_linkage_synthetic_9();
+
+	// Test surprisingness using bootstrapping to calculate
+	// probabilities
+	void test_nisurp_emp_prob_bs_1();
+
+	// Test surprisingness on toy datasets
 	void test_nisurp_ugly_man_soda_drinker();
 };
 
@@ -193,7 +205,7 @@ SurprisingnessUTest::SurprisingnessUTest() : _scm(&_as)
 
 	// Main logger
 	logger().set_level(Logger::DEBUG);
-	logger().set_timestamp_flag(false);
+	// logger().set_timestamp_flag(false);
 	logger().set_sync_flag(true);
 	logger().set_print_to_stdout_flag(true);
 
@@ -237,6 +249,8 @@ void SurprisingnessUTest::tearDown()
 // Test partition({A,B,C})
 void SurprisingnessUTest::test_partitions()
 {
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
 	Handle A = an(CONCEPT_NODE, "A"),
 		B = an(CONCEPT_NODE, "B"),
 		C = an(CONCEPT_NODE, "C");
@@ -255,15 +269,20 @@ void SurprisingnessUTest::test_partitions()
 
 void SurprisingnessUTest::test_is_syntax_more_abstract()
 {
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
 	HandleSeq l_blk{al(LIST_LINK, Z, W, X)};
 	HandleSeq r_blk{al(LIST_LINK, X, Y, X)};
 
 	// Left block/subpattern is syntactically more abstract than
 	// right block/subpattern, relative to X.
-	TS_ASSERT(Surprisingness::is_more_abstract(l_blk, r_blk, X)); }
+	TS_ASSERT(Surprisingness::is_more_abstract(l_blk, r_blk, X));
+}
 
 void SurprisingnessUTest::test_is_more_abstract_1()
 {
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
 	Handle l_pat = al(LAMBDA_LINK,
 	                  al(VARIABLE_LIST, X, Y, Z),
 	                  al(AND_LINK,
@@ -279,6 +298,8 @@ void SurprisingnessUTest::test_is_more_abstract_1()
 
 void SurprisingnessUTest::test_is_more_abstract_2()
 {
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
 	Handle l_pat = al(LAMBDA_LINK,
 	                  al(VARIABLE_LIST, X, Y),
 	                  al(INHERITANCE_LINK, X, Z));
@@ -295,6 +316,8 @@ void SurprisingnessUTest::test_is_more_abstract_2()
 
 void SurprisingnessUTest::test_is_more_abstract_3()
 {
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
 	Handle l_pat = al(LAMBDA_LINK,
 	                  al(VARIABLE_LIST, X, Y, Z),
 	                  al(AND_LINK,
@@ -333,6 +356,8 @@ void SurprisingnessUTest::xtest_is_more_abstract_4()
 
 void SurprisingnessUTest::test_is_strictly_more_abstract()
 {
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
 	HandleSeq l_blk{al(LIST_LINK, X, Y, Z)};
 	HandleSeq r_blk{al(LIST_LINK, W, C0, Z)};
 
@@ -347,6 +372,68 @@ void SurprisingnessUTest::test_is_strictly_more_abstract()
 	// Left block/subpattern is not more abstract than itself relative
 	// to Z, since it is equivalent.
 	TS_ASSERT(not Surprisingness::is_strictly_more_abstract(l_blk, l_blk, Z));
+}
+
+void SurprisingnessUTest::test_emp_prob_bs_1()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Create data base
+	populate_uniform_inheritance_links(1000, 0.01);
+
+	// Create pattern to measure empiric probability with and without
+	// boostrapping
+	//
+	// LambdaLink
+	//   X Y
+	//   InheritanceLink
+	//     X
+	//     Y
+	Handle pattern = al(LAMBDA_LINK,
+	                    al(VARIABLE_LIST, X, Y),
+	                    al(INHERITANCE_LINK, X, Y));
+
+	HandleSet texts = MinerUtils::get_texts(_texts_cpt);
+	double epr = Surprisingness::emp_prob(pattern, texts);
+	double epr_bs = Surprisingness::emp_prob_bs(pattern, texts, 10, 1000);
+	logger().debug() << "texts.size() = " << texts.size()
+	                << ", epr = " << epr
+	                << ", epr_bs = " << epr_bs;
+	TS_ASSERT_DELTA(epr, epr_bs, 0.1);
+}
+
+void SurprisingnessUTest::test_emp_prob_bs_2()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Create data base
+	populate_uniform_inheritance_links(1000, 0.001068);
+
+	// Create pattern to measure empiric probability with and without
+	// boostrapping
+	//
+	// LambdaLink
+	//   X Y Z
+	//   AndLink
+	//     InheritanceLink
+	//       X
+	//       Y
+	//     InheritanceLink
+	//       Z
+	//       Y
+	Handle pattern = al(LAMBDA_LINK,
+	                    al(VARIABLE_LIST, X, Y, Z),
+	                    al(AND_LINK,
+	                       al(INHERITANCE_LINK, X, Y),
+	                       al(INHERITANCE_LINK, Y, Z)));
+
+	HandleSet texts = MinerUtils::get_texts(_texts_cpt);
+	double epr = Surprisingness::emp_prob(pattern, texts);
+	double epr_bs = Surprisingness::emp_prob_bs(pattern, texts, 100, 1500);
+	logger().info() << "texts.size() = " << texts.size()
+	                << ", epr = " << epr
+	                << ", epr_bs = " << epr_bs;
+	TS_ASSERT_DELTA(epr, epr_bs, 0.001);
 }
 
 // Test old normalized I-Surprisingess for the ugly male
@@ -481,6 +568,8 @@ void SurprisingnessUTest::test_nisurp_old_ugly_man_soda_drinker()
 //       W
 void SurprisingnessUTest::test_nisurp_no_linkage_synthetic_1()
 {
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
 	// Create data base
 	populate_uniform_inheritance_links(1000, 0.01);
 
@@ -533,6 +622,8 @@ void SurprisingnessUTest::test_nisurp_no_linkage_synthetic_1()
 //       C1
 void SurprisingnessUTest::test_nisurp_no_linkage_synthetic_2()
 {
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
 	// Create data base
 	populate_uniform_inheritance_links(1000, 0.5);
 
@@ -641,6 +732,8 @@ void SurprisingnessUTest::xtest_nisurp_linkage_synthetic_1()
 //       C0
 void SurprisingnessUTest::test_nisurp_linkage_synthetic_2()
 {
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
 	// Create data base
 	populate_uniform_inheritance_links(1000, 0.1);
 
@@ -693,6 +786,8 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_2()
 //       Z
 void SurprisingnessUTest::test_nisurp_linkage_synthetic_3()
 {
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
 	// Create data base
 	populate_uniform_inheritance_links(10000, 0.001);
 
@@ -754,6 +849,8 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_3()
 // clauses.
 void SurprisingnessUTest::test_nisurp_linkage_synthetic_4()
 {
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
 	// Create data base
 	populate_uniform_inheritance_links(1000, 0.01);
 
@@ -817,6 +914,8 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_4()
 // independent like in test_nisurp_linkage_synthetic_3
 void SurprisingnessUTest::test_nisurp_linkage_synthetic_5()
 {
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
 	// Create data base
 	populate_uniform_inheritance_links(1000, 0.1);
 
@@ -857,7 +956,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_5()
 	// Since the pattern is composed of 2 independent patterns, it
 	// should be completely unsurprising, thus have a nearly null
 	// nisurp measure.
-	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 1e-2);
+	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 1e-1);
 }
 
 // Similar to above for pattern
@@ -879,6 +978,8 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_5()
 //       Y
 void SurprisingnessUTest::test_nisurp_linkage_synthetic_6()
 {
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
 	// Create data base
 	populate_uniform_inheritance_links(1000, 0.01);
 
@@ -948,6 +1049,8 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_6()
 //       C1
 void SurprisingnessUTest::test_nisurp_linkage_synthetic_7()
 {
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
 	// Create data base
 	populate_uniform_inheritance_links(1000, 0.01);
 
@@ -1021,6 +1124,8 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_7()
 //       Z
 void SurprisingnessUTest::test_nisurp_linkage_synthetic_8()
 {
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
 	// Create data base
 	populate_uniform_list_links(50, 3, 0.1);
 
@@ -1085,6 +1190,8 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_8()
 //       X
 void SurprisingnessUTest::test_nisurp_linkage_synthetic_9()
 {
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
 	// Create data base
 	populate_uniform_list_links(50, 3, 0.1);
 
@@ -1128,6 +1235,55 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_9()
 	// should be completely unsurprising, thus have a nearly null
 	// nisurp measure.
 	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 0.3);
+}
+
+// Like test_nisurp_linkage_synthetic_4 but using bootstrapping to
+// calculate empirical probability and estimates.
+void SurprisingnessUTest::test_nisurp_emp_prob_bs_1()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Create data base
+	populate_uniform_inheritance_links(1000, 0.01);
+
+	// Create pattern to measure surprisingness of
+	//
+	// LambdaLink
+	//   X Y Z
+	//   AndLink
+	//     InheritanceLink
+	//       X
+	//       Y
+	//     InheritanceLink
+	//       Z
+	//       Y
+	Handle pattern = al(LAMBDA_LINK,
+	                    al(VARIABLE_LIST, X, Y, Z),
+	                    al(AND_LINK,
+	                       al(INHERITANCE_LINK, X, Y),
+	                       al(INHERITANCE_LINK, Z, Y)));
+	MinerUTestUtils::add_minsup_eval(_as, pattern, 5, TruthValue::TRUE_TV());
+
+	// Test normalized I-Surprisingness
+	std::string mode = "nisurp";
+	HandleSeq isurp_results = ure_isurp(mode, 2);
+	Handle expected = MinerUTestUtils::add_isurp_eval(_as, mode, pattern);
+
+	logger().debug() << "isurp_results = " << oc_to_string(isurp_results);
+
+	TS_ASSERT(not isurp_results.empty());
+
+	Handle isurp_front = isurp_results.front();
+
+	logger().debug() << "expected = " << oc_to_string(expected);
+	logger().debug() << "isurp_front = " << oc_to_string(isurp_front);
+
+	TS_ASSERT(content_eq(expected, isurp_front));
+
+	// Since the pattern is composed of 2 independent patterns, it
+	// should be completely unsurprising, thus have a nearly null
+	// nisurp measure.
+	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 0.1);
 }
 
 // Test normalized I-Surprisingess for the ugly male soda drinker

--- a/tests/learning/miner/SurprisingnessUTest.cxxtest
+++ b/tests/learning/miner/SurprisingnessUTest.cxxtest
@@ -95,6 +95,7 @@ public:
 	// TODO: fix is_more_abstract to support that case
 	void xtest_is_more_abstract_4();
 	void test_is_strictly_more_abstract();
+	void test_subsmp();
 	void test_emp_prob_bs_1();
 	void test_emp_prob_bs_2();
 
@@ -372,6 +373,37 @@ void SurprisingnessUTest::test_is_strictly_more_abstract()
 	// Left block/subpattern is not more abstract than itself relative
 	// to Z, since it is equivalent.
 	TS_ASSERT(not Surprisingness::is_strictly_more_abstract(l_blk, l_blk, Z));
+}
+
+void SurprisingnessUTest::test_subsmp()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Create data base
+	populate_uniform_inheritance_links(4000, 0.1);
+	HandleSeq texts = MinerUtils::get_texts(_texts_cpt);
+	logger().debug() << "texts.size() = " << texts.size();
+
+	// Subsample texts
+	HandleSeq texts_smp_1 = Surprisingness::subsmp(texts, 1000);
+	logger().debug() << "texts_smp_1.size() = " << texts_smp_1.size();
+	TS_ASSERT_EQUALS(texts_smp_1.size(), 1000);
+
+	HandleSeq texts_smp_2 = Surprisingness::subsmp(texts, 10000);
+	logger().debug() << "texts_smp_2.size() = " << texts_smp_2.size();
+	TS_ASSERT_EQUALS(texts_smp_2.size(), 10000);
+
+	HandleSeq texts_smp_3 = Surprisingness::subsmp(texts, 100000);
+	logger().debug() << "texts_smp_3.size() = " << texts_smp_3.size();
+	TS_ASSERT_EQUALS(texts_smp_3.size(), 100000);
+
+	HandleSeq texts_smp_4 = Surprisingness::subsmp(texts, 1000000);
+	logger().debug() << "texts_smp_4.size() = " << texts_smp_4.size();
+	TS_ASSERT_EQUALS(texts_smp_4.size(), 1000000);
+
+	HandleSeq texts_smp_5 = Surprisingness::subsmp(texts, 10000000);
+	logger().debug() << "texts_smp_5.size() = " << texts_smp_5.size();
+	TS_ASSERT_EQUALS(texts_smp_5.size(), texts.size());
 }
 
 void SurprisingnessUTest::test_emp_prob_bs_1()

--- a/tests/learning/miner/SurprisingnessUTest.cxxtest
+++ b/tests/learning/miner/SurprisingnessUTest.cxxtest
@@ -393,7 +393,7 @@ void SurprisingnessUTest::test_emp_prob_bs_1()
 	                    al(VARIABLE_LIST, X, Y),
 	                    al(INHERITANCE_LINK, X, Y));
 
-	HandleSet texts = MinerUtils::get_texts(_texts_cpt);
+	HandleSeq texts = MinerUtils::get_texts(_texts_cpt);
 	double epr = Surprisingness::emp_prob(pattern, texts);
 	double epr_bs = Surprisingness::emp_prob_bs(pattern, texts, 10, 1000);
 	logger().debug() << "texts.size() = " << texts.size()
@@ -427,7 +427,7 @@ void SurprisingnessUTest::test_emp_prob_bs_2()
 	                       al(INHERITANCE_LINK, X, Y),
 	                       al(INHERITANCE_LINK, Y, Z)));
 
-	HandleSet texts = MinerUtils::get_texts(_texts_cpt);
+	HandleSeq texts = MinerUtils::get_texts(_texts_cpt);
 	double epr = Surprisingness::emp_prob(pattern, texts);
 	double epr_bs = Surprisingness::emp_prob_bs(pattern, texts, 100, 1500);
 	logger().info() << "texts.size() = " << texts.size()

--- a/tests/learning/miner/SurprisingnessUTest.cxxtest
+++ b/tests/learning/miner/SurprisingnessUTest.cxxtest
@@ -206,7 +206,7 @@ SurprisingnessUTest::SurprisingnessUTest() : _scm(&_as)
 
 	// Main logger
 	logger().set_level(Logger::DEBUG);
-	// logger().set_timestamp_flag(false);
+	logger().set_timestamp_flag(false);
 	logger().set_sync_flag(true);
 	logger().set_print_to_stdout_flag(true);
 

--- a/tests/learning/miner/SurprisingnessUTest.cxxtest
+++ b/tests/learning/miner/SurprisingnessUTest.cxxtest
@@ -856,7 +856,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_3()
 	// Since the pattern is composed of 2 independent patterns, it
 	// should be completely unsurprising, thus have a nearly null
 	// nisurp measure.
-	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 0.1);
+	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 0.2);
 }
 
 // Similar to above for pattern
@@ -923,7 +923,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_4()
 	// Since the pattern is composed of 2 independent patterns, it
 	// should be completely unsurprising, thus have a nearly null
 	// nisurp measure.
-	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 0.2);
+	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 0.3);
 }
 
 // Similar to above for pattern


### PR DESCRIPTION
This PR contains various optimizations the main one being to use statistically bootstrapping to estimate the empirical probability of a pattern when it has a very large support (exceeding the corpus size, which may happen when the pattern has multiple conjunctions). This optimization introduces some noise in the surprisingness measure of such large-support pattern.

More optimizations are possible, in particular by implementing specialized callbacks for
1. Counting matches without instantiating them to efficiently get the support.
2. Finding shallow abstractions in the shallow specialization rule, cause one doesn't need to find all groundings of a given shallow abstraction, only one.