### PR TITLE
Fix issues with the Ghost matcher

### DIFF
--- a/opencog/ghost/matcher.scm
+++ b/opencog/ghost/matcher.scm
@@ -104,7 +104,7 @@
   (define context-alist '())
 
   ; Store the sum of action-weights [sum(Wcagi)]
-  (define sum-weight-alist '())
+  (define rule-weight-alist '())
 
   ; For random number generation
   (define total-weight 0)
@@ -118,7 +118,7 @@
 
   ; ----------
   ; Calculate the weight of the rule R [Wcagi]
-  (define (calculate-rweight R)
+  (define (calculate-rule-weight R)
     (define strength
       (if (> strength-weight 0)
         (* strength-weight (cog-mean R)) 1))
@@ -160,13 +160,13 @@
                 (cog-tv-mean (psi-satisfiable? r)))))
 
           ; Calculate the weight of this rule
-          (let ((w (calculate-rweight r)))
+          (let ((w (calculate-rule-weight r)))
             (set! rules-eval-cnt (1+ rules-eval-cnt))
             (if (> w 0)
               (begin
                 (set! rules-sat-cnt (1+ rules-sat-cnt))
                 (set! ruled-satisfied (cons r rules-satisfied))
-                (set! sum-weight-alist (assoc-set! sum-weight-alist r w)))
+                (set! rule-weight-alist (assoc-set! rule-weight-alist r w)))
               (cog-logger-debug ghost-logger
                 "Skipping action with zero weight: ~a" ra))
           ))
@@ -227,7 +227,7 @@
                        (lambda (a)
                          (set! accum-weight (+ accum-weight (cdr a)))
                          (<= cutoff accum-weight))
-                       sum-weight-alist)))
+                       rule-weight-alist)))
               (if rule-rtn
                 (car rule-rtn)
                 (list)

--- a/opencog/ghost/matcher.scm
+++ b/opencog/ghost/matcher.scm
@@ -114,7 +114,6 @@
 
   ; For monitoring the status
   (define rules-eval-cnt 0)
-  (define rules-sat-cnt 0)
 
   ; ----------
   ; Calculate the weight of the rule R [Wcagi]
@@ -164,7 +163,6 @@
             (set! rules-eval-cnt (1+ rules-eval-cnt))
             (if (> w 0)
               (begin
-                (set! rules-sat-cnt (1+ rules-sat-cnt))
                 (set! ruled-satisfied (cons r rules-satisfied))
                 (set! rule-weight-alist (assoc-set! rule-weight-alist r w)))
               (cog-logger-debug ghost-logger
@@ -177,7 +175,7 @@
   ; Update the status
   (set! num-rules-found (length RULES))
   (set! num-rules-evaluated rules-eval-cnt)
-  (set! num-rules-satisfied rules-sat-cnt)
+  (set! num-rules-satisfied (length rules-satisfied))
 
   ; If there is only one action in the list, return that
   ; Otherwise, pick one based on their weights

--- a/opencog/ghost/matcher.scm
+++ b/opencog/ghost/matcher.scm
@@ -163,7 +163,7 @@
             (set! rules-eval-cnt (1+ rules-eval-cnt))
             (if (> w 0)
               (begin
-                (set! ruled-satisfied (cons r rules-satisfied))
+                (set! rules-satisfied (cons r rules-satisfied))
                 (set! rule-weight-alist (assoc-set! rule-weight-alist r w)))
               (cog-logger-debug ghost-logger
                 "Skipping action with zero weight: ~a" ra))

--- a/opencog/ghost/matcher.scm
+++ b/opencog/ghost/matcher.scm
@@ -87,11 +87,8 @@
   Evaluate the candidates and see which of them, if any, satisfy the
   current context, and then select one of them based on their weights.
 
-  The weight of an action will be calculated in this way:
-  Wa = 1/Na * sum(Wcagi)
-
-  Na = number of satisfied rules [i] that have the action [a]
-  Wcagi = Scag * Sc * Icag * Ug
+  The weight of a rule will be calculated in this way:
+  Wr = Scag * Sc * Icag * Ug
 
   Scag = Strength of the psi-rule (c ∧ a => g)
   Sc = Satisfiability of the context of the psi-rule
@@ -103,20 +100,20 @@
   ; won't be evaluated again, in the same psi-step
   (define context-alist '())
 
-  ; Store the sum of action-weights [sum(Wcagi)]
+  ; Store the weight of each evaluated rule
   (define rule-weight-alist '())
 
   ; For random number generation
   (define total-weight 0)
 
-  ; Store which rules satisfy the current context
+  ; Store which rules satisfied the current context
   (define rules-satisfied '())
 
   ; For monitoring the status
   (define rules-eval-cnt 0)
 
   ; ----------
-  ; Calculate the weight of the rule R [Wcagi]
+  ; Calculate the weight of the rule R [Wr]
   (define (calculate-rule-weight R)
     (define strength
       (if (> strength-weight 0)


### PR DESCRIPTION
The selection should be on the rule level as there are features associated with the rules, and also this will  make things consistent with the rest of the pipeline.