### PR TITLE
Pass string by value to fix string.decode(...) issue in agent_finder

### DIFF
--- a/opencog/cython/opencog/agent_finder.pyx
+++ b/opencog/cython/opencog/agent_finder.pyx
@@ -28,7 +28,7 @@ cdef extern from "agent_finder_types.h" namespace "opencog":
         vector[bool] req_is_shell
         string err_string 
 
-cdef api requests_and_agents_t load_req_agent_module(string& module_name) with gil:
+cdef api requests_and_agents_t load_req_agent_module(string module_name) with gil:
     """ Load module and return a vector of MindAgent names """
     cdef str mod_name = module_name.decode("UTF-8")
     # for return results


### PR DESCRIPTION
Fix for the issue:
```
[ 18%] Cythonizing agent_finder.pyx

Error compiling Cython file:
------------------------------------------------------------
...
        vector[bool] req_is_shell
        string err_string 

cdef api requests_and_agents_t load_req_agent_module(string& module_name) with gil:
    """ Load module and return a vector of MindAgent names """
    cdef str mod_name = module_name.decode("UTF-8")
                                  ^
------------------------------------------------------------

/ws/opencog/opencog/cython/opencog/agent_finder.pyx:33:35: Object of type 'string &' has no attribute 'decode'
[ 18%] Linking CXX shared library libspacetime-types.so
opencog/cython/opencog/CMakeFiles/agent_finder.dir/build.make:65: recipe for target 'opencog/cython/opencog/agent_finder.cpp' failed
```

See discussion in https://github.com/opencog/opencog/pull/3518

