### PR TITLE
Workaround for distutils bug in Ubuntu/Debian's Python3 versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,7 +345,7 @@ IF(HAVE_PY_INTERP)
 		# Find python destination dir for python bindings
 		# because it may differ on each operating system.
 		EXECUTE_PROCESS(
-			COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import *;print(get_python_lib(True, False, '${CMAKE_INSTALL_PREFIX}'))"
+			COMMAND ${PYTHON_EXECUTABLE} "${PROJECT_SOURCE_DIR}/scripts/get_python_lib.py" "${CMAKE_INSTALL_PREFIX}"
 			OUTPUT_VARIABLE PYTHON_DEST
 		)
 

--- a/scripts/get_python_lib.py
+++ b/scripts/get_python_lib.py
@@ -1,0 +1,26 @@
+import sys
+import sysconfig
+import site
+
+if __name__ == '__main__':
+    # This is a hack due to the distutils in debian/ubuntu's python3 being misconfigured
+    # see discussion https://github.com/opencog/atomspace/issues/1782
+    #
+    # If the bug is fixed, this script could be replaced by:
+    #
+    # from distutils.sysconfig import get_python_lib; print(get_python_lib(plat_specific=True, prefix=prefix))
+    #
+    # However, using this would not respect a python virtual environments, so in a way this is better!
+
+    prefix = sys.argv[1]
+
+    # use sites if the prefix is recognized and the sites module is available
+    # (virtualenv is missing getsitepackages())
+    if hasattr(site, 'getsitepackages'):
+        paths = [p for p in site.getsitepackages() if p.startswith(prefix)]
+        if len(paths) == 1:
+            print(paths[0])
+            exit(0)
+    
+    # use sysconfig platlib as the fall back
+    print(sysconfig.get_paths()['platlib'])


### PR DESCRIPTION
To be paired with opencog/atomspace#2220 - which has additional context.