### PR TITLE
Normalize by max of empirical and estimate probabilities

### DIFF
--- a/opencog/learning/miner/Surprisingness.cc
+++ b/opencog/learning/miner/Surprisingness.cc
@@ -117,7 +117,8 @@ double Surprisingness::isurp(const Handle& pattern,
 	// logger().debug() << "dst = " << dst
 	//                  << ", normalize = " << normalize
 	//                  << ", ndst = " << dst / emp;
-	return std::min(normalize ? dst / emp : dst, 1.0);
+	double maxprb = std::max(emp, emax);
+	return std::min(normalize ? dst / maxprb : dst, 1.0);
 }
 
 Handle Surprisingness::isurp_key()


### PR DESCRIPTION
Only normalizing by the empirical probability would over value anti-patterns as surprising.