### PR TITLE
Prevent AnaphoraUTest from running on older systems

### DIFF
--- a/tests/nlp/CMakeLists.txt
+++ b/tests/nlp/CMakeLists.txt
@@ -15,11 +15,17 @@ ENDIF (HAVE_VITERBI)
 
 IF (HAVE_NOSETESTS)
 
-	ADD_TEST(AnaphoraTest ${NOSETESTS_EXECUTABLE} -vs
-		${CMAKE_SOURCE_DIR}/tests/nlp/anaphora)
-	SET_TESTS_PROPERTIES(AnaphoraTest PROPERTIES ENVIRONMENT
-		"PYTHONPATH=${PYTHON_ROOT}:${PROJECT_SOURCE_DIR}/opencog/nlp/anaphora:${PROJECT_BINARY_DIR}/opencog/cython;GUILE_LOAD_PATH=${PROJECT_BINARY_DIR}/opencog/scm"
-	)
+	# AnaphoraUTest fails on guile-2.2 with a bdw-gc error:
+	# "Too many root sets".  It appears to work for guile-3.0
+	IF (GUILE_FOUND AND (GUILE_VERSION_MAJOR EQUAL 3)
+			OR ((GUILE_VERSION_MAJOR EQUAL 2) AND
+				(GUILE_VERSION_MINOR GREATER 4)))
+		ADD_TEST(AnaphoraTest ${NOSETESTS_EXECUTABLE} -vs
+			${CMAKE_SOURCE_DIR}/tests/nlp/anaphora)
+		SET_TESTS_PROPERTIES(AnaphoraTest PROPERTIES ENVIRONMENT
+			"PYTHONPATH=${PYTHON_ROOT}:${PROJECT_SOURCE_DIR}/opencog/nlp/anaphora:${PROJECT_BINARY_DIR}/opencog/cython;GUILE_LOAD_PATH=${PROJECT_BINARY_DIR}/opencog/scm"
+		)
+	ENDIF ()
 
 ENDIF (HAVE_NOSETESTS)
 


### PR DESCRIPTION
Per discussions at #3509 and elsewhere, the current guile-2.2 generates "Too many root sets" when running this test.  This is actually a bdw-gc issue, with the GC build for a small memory model. Stub out the test, for now.  (it otherwise does pass, for me).