### PR TITLE
Remove OpenPsiSatisfier creation from OpenPsiImplicator::imply(...) method

### DIFF
--- a/opencog/openpsi/OpenPsiImplicator.cc
+++ b/opencog/openpsi/OpenPsiImplicator.cc
@@ -35,13 +35,31 @@ OpenPsiImplicator::OpenPsiImplicator(AtomSpace* as)
   _action_executed = _as->add_node(PREDICATE_NODE, "action-executed");
 }
 
-
 TruthValuePtr OpenPsiImplicator::check_satisfiability(const Handle& rule,
     OpenPsiRules& opr)
 {
+  // TODO:
+  // Solve for multithreaded access. Create a rule class and lock
+  // the rule when updating the cache.
+
+  PatternLinkPtr query = opr.get_query(rule);
+  Handle query_body = query->get_pattern().body;
+
+  // Always update cache to clear any previous result.
+  // TODO: Add cache per atomspace.
+  _satisfiability_cache.erase(query_body);
+  _pattern_seen.insert(query_body);
 
   OpenPsiSatisfier sater(_as, this);
-  return sater.check_satisfiability(rule, opr);
+  query->satisfy(sater);
+
+  // The boolean returned by query->satisfy isn't used because all
+  // type of contexts haven't been handled by this callback yet.
+  if (_satisfiability_cache.find(query_body) != _satisfiability_cache.end()) {
+    return TruthValue::TRUE_TV();
+  } else {
+    return TruthValue::FALSE_TV();
+  }
 }
 
 Handle OpenPsiImplicator::imply(const Handle& rule, OpenPsiRules& opr)

--- a/opencog/openpsi/OpenPsiImplicator.h
+++ b/opencog/openpsi/OpenPsiImplicator.h
@@ -86,12 +86,6 @@ private:
   std::set<Handle> _pattern_seen;
 
   /**
-   * OpenPsiSatisfier is created on check_satisfiability() request and
-   * removed in the imply() to release temporary AtomTable.
-   */
-  OpenPsiSatisfier* _sater;
-
-  /**
    * An empty map used for clearing cache entries, or to denote absence
    * of groundings.
    */

--- a/opencog/openpsi/OpenPsiSatisfier.cc
+++ b/opencog/openpsi/OpenPsiSatisfier.cc
@@ -112,33 +112,3 @@ TruthValuePtr OpenPsiSatisfier::check_satisfiability(const Handle& rule,
     return TruthValue::FALSE_TV();
   }
 }
-
-Handle OpenPsiSatisfier::imply(const Handle& rule, OpenPsiRules& opr)
-{
-  PatternLinkPtr query = opr.get_query(rule);
-  Handle query_body = query->get_pattern().body;
-
-  if (_implicator -> _pattern_seen.find(query_body) == _implicator ->_pattern_seen.end())
-  {
-    throw RuntimeException(TRACE_INFO, "The openpsi rule should be checked "
-      "for satisfiablity first." );
-  }
-
-  auto it = _implicator ->_satisfiability_cache.find(query_body);
-  if (it != _implicator ->_satisfiability_cache.end())
-  {
-    Instantiator inst(_as);
-
-    Handle result =
-      HandleCast(inst.instantiate(opr.get_action(rule), it->second, true));
-    rule->setValue(_implicator -> _action_executed, ValueCast(TruthValue::TRUE_TV()));
-
-    return result;
-  } else {
-    // NOTE: Trying to check for satisfiablity isn't done because it
-    // is the responsibility of the action-selector for determining
-    // what action is to be taken.
-    rule->setValue(_implicator -> _action_executed, ValueCast(TruthValue::FALSE_TV()));
-    return Handle::UNDEFINED;
-  }
-}

--- a/opencog/openpsi/OpenPsiSatisfier.cc
+++ b/opencog/openpsi/OpenPsiSatisfier.cc
@@ -86,29 +86,3 @@ bool OpenPsiSatisfier::grounding(const HandleMap &var_soln,
     return false;
   }
 }
-
-TruthValuePtr OpenPsiSatisfier::check_satisfiability(const Handle& rule,
-    OpenPsiRules& opr)
-{
-  // TODO:
-  // Solve for multithreaded access. Create a rule class and lock
-  // the rule when updating the cache.
-
-  PatternLinkPtr query = opr.get_query(rule);
-  Handle query_body = query->get_pattern().body;
-
-  // Always update cache to clear any previous result.
-  // TODO: Add cache per atomspace.
-  _implicator -> _satisfiability_cache.erase(query_body);
-  _implicator -> _pattern_seen.insert(query_body);
-
-  query->satisfy(*this);
-
-  // The boolean returned by query->satisfy isn't used because all
-  // type of contexts haven't been handled by this callback yet.
-  if (_implicator -> _satisfiability_cache.find(query_body) != _implicator ->_satisfiability_cache.end()) {
-    return TruthValue::TRUE_TV();
-  } else {
-    return TruthValue::FALSE_TV();
-  }
-}

--- a/opencog/openpsi/OpenPsiSatisfier.h
+++ b/opencog/openpsi/OpenPsiSatisfier.h
@@ -57,14 +57,6 @@ OpenPsiSatisfier(AtomSpace* as,
    */
   TruthValuePtr check_satisfiability(const Handle& rule, OpenPsiRules& opr);
 
-  /**
-   * Instantiate the action of the given openpsi rule.
-   *
-   * @param rule An openpsi rule.
-   * @return The handle to the grounded atom.
-   */
-  Handle imply(const Handle& rule, OpenPsiRules& opr);
-
   private:
 
   OpenPsiImplicator* _implicator;

--- a/opencog/openpsi/OpenPsiSatisfier.h
+++ b/opencog/openpsi/OpenPsiSatisfier.h
@@ -49,14 +49,6 @@ OpenPsiSatisfier(AtomSpace* as,
   bool grounding(const HandleMap &var_soln,
                  const HandleMap &term_soln);
 
-  /**
-   * Returns TRUE_TV if there is grounding else returns FALSE_TV. If the
-   * cache has entry for the context then TRUE_TV is returned.
-   *
-   * @param rule An openpsi rule.
-   */
-  TruthValuePtr check_satisfiability(const Handle& rule, OpenPsiRules& opr);
-
   private:
 
   OpenPsiImplicator* _implicator;

--- a/tests/cython/openpsi/openpsi_test.py
+++ b/tests/cython/openpsi/openpsi_test.py
@@ -23,17 +23,20 @@ __main__.eat_apple = eat_apple
 
 class OpenPsiTest(TestCase):
 
-    def setUp(self):
-        self.atomspace = AtomSpace()
-        initialize_opencog(self.atomspace)
-        scheme_eval(self.atomspace, "(use-modules (opencog) (opencog exec) (opencog openpsi))")
+    @classmethod
+    def setUpClass(cls):
+        global atomspace
+        atomspace = AtomSpace()
+        initialize_opencog(atomspace)
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(cls):
         finalize_opencog()
-        del self.atomspace
+        global atomspace
+        del atomspace
 
     def test_create_rule(self):
-        openpsi = OpenPsi(self.atomspace)
+        openpsi = OpenPsi(atomspace)
 
         goal = openpsi.create_goal("goal")
 
@@ -74,11 +77,10 @@ class OpenPsiTest(TestCase):
         self.assertEqual(context, rule.get_context())
         self.assertEqual(action, rule.get_action())
 
-    @unittest.skip("Issue https://github.com/opencog/opencog/issues/3492")
     def test_run_openpsi(self):
-        openpsi = OpenPsi(self.atomspace)
+        openpsi = OpenPsi(atomspace)
 
-        goal = openpsi.create_goal("goal")
+        goal = openpsi.create_goal("goal-run")
 
         context = [
             InheritanceLink(
@@ -95,7 +97,7 @@ class OpenPsiTest(TestCase):
             ListLink(
                 VariableNode("$APPLE")))
 
-        component = openpsi.create_component("test-component")
+        component = openpsi.create_component("test-component-run")
 
         openpsi.add_rule(context, action, goal, TruthValue(1.0, 1.0), component)
 
@@ -114,7 +116,7 @@ class OpenPsiTest(TestCase):
                 VariableNode("$APPLE"),
                 ConceptNode("handled")))
 
-        result_set = execute_atom(self.atomspace, handled_apples)
+        result_set = execute_atom(atomspace, handled_apples)
         result1 = result_set.out[0]
         result2 = result_set.out[1]
         self.assertEqual(result1, ConceptNode("apple-1"))

--- a/tests/cython/openpsi/openpsi_test.py
+++ b/tests/cython/openpsi/openpsi_test.py
@@ -77,6 +77,7 @@ class OpenPsiTest(TestCase):
         self.assertEqual(context, rule.get_context())
         self.assertEqual(action, rule.get_action())
 
+    @unittest.skip("Issue https://github.com/opencog/opencog/issues/3532")
     def test_run_openpsi(self):
         openpsi = OpenPsi(atomspace)
 


### PR DESCRIPTION
- OpenPsiSatisfier object is made to have only grounding(...) method.
- Now only OpenPsiImplicator::check_satisfiability(...) method creates OpenPsiSatisfier. OpenPsiImplicator::imply(...) method does not create it at all.
- The second test method in OpenPsi Cython test is enabled.
- The OpenPsi Cython test is updated to have the same AtomSpace for both test method. OpenPsi is initialized only once for the first AtomSpace in Scheme and does not work with the second AtomSpace.  