### PR TITLE
silence cython language level warnings

### DIFF
--- a/opencog/attentionbank/cython/opencog/CMakeLists.txt
+++ b/opencog/attentionbank/cython/opencog/CMakeLists.txt
@@ -13,7 +13,7 @@ INCLUDE_DIRECTORIES(
 	${CMAKE_CURRENT_BINARY_DIR}
 )
 
-SET(CYTHON_FLAGS "-f" "-I" "${ATOMSPACE_INCLUDE_DIR}/opencog/cython")
+SET(CYTHON_FLAGS "-2" "-f" "-I" "${ATOMSPACE_INCLUDE_DIR}/opencog/cython")
 
 ##################### Attention Bank ##################
 

--- a/opencog/cython/opencog/CMakeLists.txt
+++ b/opencog/cython/opencog/CMakeLists.txt
@@ -14,7 +14,7 @@ INCLUDE_DIRECTORIES(
 	${CMAKE_CURRENT_BINARY_DIR}
 )
 
-SET(CYTHON_FLAGS "-f" "-I" "${ATOMSPACE_INCLUDE_DIR}/opencog/cython")
+SET(CYTHON_FLAGS "-2" "-f" "-I" "${ATOMSPACE_INCLUDE_DIR}/opencog/cython")
 
 # Use this as a guide:
 # https://github.com/OpenKinect/libfreenect/blob/master/wrappers/python/CMakeLists.txt


### PR DESCRIPTION
Silences this FutureWarning from cython:

`/home/joel/.virtualenvs/opencog/lib/python3.6/site-packages/Cython/Compiler/Main.py:367: FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release!`