### PR TITLE
Remove the remote-tracking submodule "learn"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "opencog/nlp/learn"]
-	path = opencog/nlp/learn
-	url = https://github.com/opencog/learn

--- a/opencog/nlp/CMakeLists.txt
+++ b/opencog/nlp/CMakeLists.txt
@@ -2,7 +2,6 @@
 # Build C++ code in assorted NLP subdirectories
 
 ADD_SUBDIRECTORY (irc)
-# ADD_SUBDIRECTORY (learn)
 ADD_SUBDIRECTORY (scm)
 ADD_SUBDIRECTORY (sentiment)
 ADD_SUBDIRECTORY (types)


### PR DESCRIPTION
It probably should never have been a submodules in the first place.

FYI @glicerico I believe this will not affect you, but please double-check and let me know.