### PR TITLE
Condition sureal and microplanning unit tests on HAVE_NLP

### DIFF
--- a/tests/nlp/CMakeLists.txt
+++ b/tests/nlp/CMakeLists.txt
@@ -1,13 +1,9 @@
 IF (HAVE_NLP)
 	ADD_SUBDIRECTORY (fuzzy)
-ENDIF (HAVE_NLP)
-
-IF (HAVE_GUILE AND HAVE_LINK_GRAMMAR)
 	ADD_SUBDIRECTORY (sureal)
-
 	# microplanning depends on sureal, so should test after it
 	ADD_SUBDIRECTORY (microplanning)
-ENDIF (HAVE_GUILE AND HAVE_LINK_GRAMMAR)
+ENDIF (HAVE_NLP)
 
 IF (HAVE_VITERBI)
 	ADD_SUBDIRECTORY (viterbi)


### PR DESCRIPTION
Based on

https://github.com/opencog/opencog/blob/1b3b4b02288d5be868246a2e429d5c9aa635d870/opencog/nlp/CMakeLists.txt#L16-L27

it's clear that the unit tests of `sureal` and `microplanning` should only be enabled when `HAVE_NLP` is true.