### PR TITLE
 Port to the new LG API 

### DIFF
--- a/opencog/nlp/lg-dict/LGDictReader.cc
+++ b/opencog/nlp/lg-dict/LGDictReader.cc
@@ -41,13 +41,26 @@ static LGDictExpContainer lg_exp_to_container(Exp* exp)
     if (CONNECTOR_type == exp->type)
         return LGDictExpContainer(CONNECTOR_type, exp);
 
-    E_list* el = exp->u.l;
     std::vector<LGDictExpContainer> subcontainers;
+
+    // FIXME XXX -- Optionals are handled incorrectly here;
+    // they are denoted by a null Exp pointer in an OR_list!
+    // Ignoring all the nulls is just ... wrong.
+#if (LINK_MAJOR_VERSION == 5) &&  (LINK_MINOR_VERSION < 7)
+    E_list* el = exp->u.l;
     while (el)
     {
         subcontainers.push_back(lg_exp_to_container(el->e));
         el = el->next;
     }
+#else
+    Exp* subexp = lg_exp_operand_first(exp);
+    while (subexp)
+    {
+        subcontainers.push_back(lg_exp_to_container(subexp));
+        subexp = lg_exp_operand_next(subexp);
+    }
+#endif
 
     return LGDictExpContainer(exp->type, subcontainers);
 }

--- a/opencog/nlp/lg-dict/README.md
+++ b/opencog/nlp/lg-dict/README.md
@@ -111,6 +111,8 @@ In addition, the following scheme utilities are provided:
 The core design of this module has a number of issues, some minor, and
 some pretty important.
 
+* Handling of optional links is currently broken.
+
 * The `lg-get-dict-entry` returns a SetLink. It is deprecated; use
   the `lg-dict-entry` method instead. Alternately, perhaps the
   `lg-get-dict-entry` could be redesigned to return a LinkValue,
@@ -140,6 +142,6 @@ some pretty important.
   system, and those are also ignorant of morphology.
 
 * The format of the word-disjunct association in the atomspace does not
-  indicatte which dictionary the disjuncts came from. This prevents
+  indicate which dictionary the disjuncts came from. This prevents
   multi-dictionary use, because its not clear which disjuncts came from
-  which dictionary. This might make translation difficult.
+  which dictionary. This makes multi-language operation impossible.

--- a/opencog/nlp/lg-dict/README.md
+++ b/opencog/nlp/lg-dict/README.md
@@ -1,13 +1,13 @@
 # LG-Dict
 
 Modules and functions for generating a LG dictionary entry of a word
-in the atomspace.
+in the AtomSpace.
 
 ## Scheme module `(opencog nlp lg-dict)`
 
 Defines `LgDictNode`, `LgDictEntry` and `LgHaveDictEntry`.  These can
 be used to look up Link Grammar dictionary entries, and place them
-into the atomspace.  For example:
+into the AtomSpace.  For example:
 
 ```
 	(use-modules (opencog) (opencog nlp) (opencog nlp lg-dict))
@@ -17,8 +17,8 @@ into the atomspace.  For example:
 			(WordNode "...")
 			(LgDictNode "en")))
 ```
-will look up the word "..." in the English langauge Link Grammar
-dictionary, and place the resulting disjuncts into the atomspace.
+will look up the word "..." in the English language Link Grammar
+dictionary, and place the resulting disjuncts into the AtomSpace.
 The `(cog-incoming-set (WordNode "..."))` should resemble the below:
 
   ```
@@ -57,7 +57,7 @@ evaluate to either true of false:
 			(LgDictNode "en")))
 ```
 
-The disjuncts are in [Disjuntive Normal Form](http://en.wikipedia.org/wiki/Disjunctive_normal_form) (DNF)
+The disjuncts are in [Disjunctive Normal Form](http://en.wikipedia.org/wiki/Disjunctive_normal_form) (DNF)
 where `LgOr` and `LgAnd` correspond to the `or` and `&` notation of LG.
 Note that `LgOr` is actually a menu choice, and NOT a boolean OR.
 
@@ -65,7 +65,7 @@ Each LG connector is fully described within the `LgConnector` link,
 with the connector name in `LgConnectorNode`, direction in
 `LgConnDirNode`, and the multi-connect property in `LgConnMultiNode`.
 
-The connector ordering is kept intact. Connectors and thier meaning and
+The connector ordering is kept intact. Connectors and their meaning and
 usage are described in the [Link Grammar documentation](http://www.abisource.com/projects/link-grammar/dict/introduction.html),
 section 1.2.1.
 
@@ -79,7 +79,7 @@ disjunct containing 5+ connectors).**
 In addition, the following scheme utilities are provided:
 - `(lg-dict-entry (WordNode "..."))`
 
-  Wraps up the above-described `(cog-execute (LgDictEnty ...))` into
+  Wraps up the above-described `(cog-execute (LgDictEntry ...))` into
   a nice short convenience utility.
 
 - `(lg-get-dict-entry (WordNode "..."))`
@@ -89,18 +89,18 @@ In addition, the following scheme utilities are provided:
   problems; SetLinks should not be used as dumping grounds for random
   assortments of atoms!
 
-- `(lg-conn-type-match? (LGConnector ...) (LGConnector ...))`
+- `(lg-conn-type-match? (LgConnector ...) (LgConnector ...))`
 
-  Takes two `LGConnector` links as input, and check if the two connectors has
+  Takes two `LgConnector` links as input, and check if the two connectors has
   the same type (aka. connector name).  Proper handling of subscripts &
   head/tail are included.
 
   The same code could have been done purely in scheme, but instead in C++ for
   performance reason (for SuReal usage).
 
-- `(lg-conn-linkable? (LGConnector ...) (LGConnector ...))`
+- `(lg-conn-linkable? (LgConnector ...) (LgConnector ...))`
 
-  Takes two `LGConnector` links as input, and check if the two connectors can
+  Takes two `LgConnector` links as input, and check if the two connectors can
   be linked.  Two connectors can be linked only if they are of different
   direction, and their types match.
 
@@ -124,24 +124,24 @@ some pretty important.
   this will take a few afternoons to fix.
 
 * The `lg-get-dict-entry` and `lg-dict-entry` do the wrong thing, or
-  are invalid/inappropriate, if the word has a non-trivial mophology
+  are invalid/inappropriate, if the word has a non-trivial morphology
   (i.e. can be split into multiple morphemes). In LG, each morpheme
   is treated as a "word", and so a single word-string can be split
   in several different ways (i.e. have multiple splittings).  Word
   splitting is non-trivial in LG.
 
   One way to fix this last issue is to have LG provide an API where
-  the word is split into morphemes, and then the mrophemes are
+  the word is split into morphemes, and then the morphemes are
   recombined, and disjuncts are returned for the recombined splits.
   That is, the morphology can be hidden "under the covers", which is
   part of the beauty of the disjunct style.
 
-  Right now, this is low priiority, since only Russian currently has a
+  Right now, this is low priority, since only Russian currently has a
   non-trivial morphology, and we don't handle Russian.  The other
-  reason is that sureal and microplanning are the only users of this
+  reason is that SuReal and MicroPlanning are the only users of this
   system, and those are also ignorant of morphology.
 
-* The format of the word-disjunct association in the atomspace does not
+* The format of the word-disjunct association in the AtomSpace does not
   indicate which dictionary the disjuncts came from. This prevents
   multi-dictionary use, because its not clear which disjuncts came from
   which dictionary. This makes multi-language operation impossible.


### PR DESCRIPTION
The internal link-grammar API needs to change; update opencog to use the new API.