### PR TITLE
fix #3550: atomspace object _as gets a new unique UUID get_uuid()

### DIFF
--- a/opencog/attentionbank/bank/AttentionBank.cc
+++ b/opencog/attentionbank/bank/AttentionBank.cc
@@ -238,6 +238,7 @@ AttentionBank& opencog::attentionbank(AtomSpace* asp)
 {
     static AttentionBank* _instance = nullptr;
     static AtomSpace* _as = nullptr;
+    _as->get_uuid();
 
     // Protect setting and getting against thread races.
     // This is probably not needed.


### PR DESCRIPTION
Nullpointer Atomspace instance (_as) has now a unique UUID to prevent same object reference.