### PR TITLE
fix (3550): attentionbank objects

### DIFF
--- a/opencog/attentionbank/bank/AttentionBank.cc
+++ b/opencog/attentionbank/bank/AttentionBank.cc
@@ -238,6 +238,7 @@ AttentionBank& opencog::attentionbank(AtomSpace* asp)
 {
     static AttentionBank* _instance = nullptr;
     static AtomSpace* _as = nullptr;
+    _as->get_uuid();
 
     // Protect setting and getting against thread races.
     // This is probably not needed.

--- a/opencog/attentionbank/bank/AttentionBank.cc
+++ b/opencog/attentionbank/bank/AttentionBank.cc
@@ -237,7 +237,7 @@ double AttentionBank::getNormalisedZeroToOneSTI(AttentionValuePtr av,
 AttentionBank& opencog::attentionbank(AtomSpace* asp)
 {
     static AttentionBank* _instance = nullptr;
-    static AtomSpace* _as = nullptr;
+    static AtomSpace* _as;
     _as->get_uuid();
 
     // Protect setting and getting against thread races.


### PR DESCRIPTION
Atomspace instance _as has now a unique UUID to prevent same object reference.