### PR TITLE
Enable build and test if cogserver is not installed

### DIFF
--- a/opencog/nlp/wsd/SenseRank.cc
+++ b/opencog/nlp/wsd/SenseRank.cc
@@ -17,7 +17,6 @@
 #include <opencog/atoms/truthvalue/CountTruthValue.h>
 #include <opencog/atoms/truthvalue/TruthValue.h>
 #include <opencog/nlp/wsd/ForeachWord.h>
-#include <opencog/cogserver/server/CogServer.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,7 +21,9 @@ IF (CXXTEST_FOUND)
 
 	IF (HAVE_ATOMSPACE)
 		ADD_SUBDIRECTORY (attentionbank)
-		ADD_SUBDIRECTORY (attention)
+		IF (HAVE_SERVER)
+			ADD_SUBDIRECTORY (attention)
+		ENDIF (HAVE_SERVER)
 		ADD_SUBDIRECTORY (neighbors)
 
 		# Persistence is for saving/restoring atomspace to disk.

--- a/tests/nlp/lojban/CMakeLists.txt
+++ b/tests/nlp/lojban/CMakeLists.txt
@@ -3,8 +3,8 @@ LINK_DIRECTORIES(${CMAKE_BINARY_DIR}/opencog/nlp/lojban/CWrapper/)
 
 LINK_LIBRARIES(
 	${ATOMSPACE_LIBRARY}
-	server
-    LojbanModule
+	${COGSERVER_LIBRARIES}
+	LojbanModule
 )
 
 ADD_CXXTEST(LojbanModuleTest)

--- a/tests/persist/zmq/events/CMakeLists.txt
+++ b/tests/persist/zmq/events/CMakeLists.txt
@@ -4,13 +4,12 @@ INCLUDE_DIRECTORIES (
 )
 
 LINK_DIRECTORIES(
-	${PROJECT_BINARY_DIR}/opencog/cogserver/server
 	${TBB_INCLUDE_DIR}
 	${TBB_LIBRARY_DIRS}
 )
 
 LINK_LIBRARIES(
-	server
+	${COGSERVER_LIBRARIES}
 	${ATOMSPACE_LIBRARIES}
 	zmq
 	tbb
@@ -20,9 +19,4 @@ ADD_CXXTEST(AtomSpacePublisherModuleUTest)
 
 TARGET_LINK_LIBRARIES(AtomSpacePublisherModuleUTest
 	atomspacepublishermodule
-)
-
-SET_TESTS_PROPERTIES(AtomSpacePublisherModuleUTest
-	PROPERTIES ENVIRONMENT
-	"PYTHONPATH=/usr/local/share/opencog/python"
 )


### PR DESCRIPTION
This fixes issue #3611 -- build of the system had not been tested, when cogserver is not installed.