### PR TITLE
Convert Atom constructors to use move instead of copy semantics

### DIFF
--- a/opencog/nlp/lg-dict/LGDictEntry.cc
+++ b/opencog/nlp/lg-dict/LGDictEntry.cc
@@ -64,8 +64,8 @@ void LGDictEntry::init()
 			oset[1]->to_string().c_str());
 }
 
-LGDictEntry::LGDictEntry(const HandleSeq& oset, Type t)
-	: FunctionLink(oset, t)
+LGDictEntry::LGDictEntry(const HandleSeq&& oset, Type t)
+	: FunctionLink(std::move(oset), t)
 {
 	// Type must be as expected
 	if (not nameserver().isA(t, LG_DICT_ENTRY))
@@ -138,8 +138,8 @@ void LGHaveDictEntry::init()
 			oset[1]->to_string().c_str());
 }
 
-LGHaveDictEntry::LGHaveDictEntry(const HandleSeq& oset, Type t)
-	: Link(oset, t)
+LGHaveDictEntry::LGHaveDictEntry(const HandleSeq&& oset, Type t)
+	: Link(std::move(oset), t)
 {
 	// Type must be as expected
 	if (not nameserver().isA(t, LG_HAVE_DICT_ENTRY))

--- a/opencog/nlp/lg-dict/LGDictEntry.h
+++ b/opencog/nlp/lg-dict/LGDictEntry.h
@@ -55,7 +55,7 @@ protected:
 	void init();
 
 public:
-	LGDictEntry(const HandleSeq&, Type=LG_DICT_ENTRY);
+	LGDictEntry(const HandleSeq&&, Type=LG_DICT_ENTRY);
 	LGDictEntry(const LGDictEntry&) = delete;
 	LGDictEntry& operator=(const LGDictEntry&) = delete;
 
@@ -79,7 +79,7 @@ protected:
 	void init();
 
 public:
-	LGHaveDictEntry(const HandleSeq&, Type=LG_HAVE_DICT_ENTRY);
+	LGHaveDictEntry(const HandleSeq&&, Type=LG_HAVE_DICT_ENTRY);
 	LGHaveDictEntry(const LGHaveDictEntry&) = delete;
 	LGHaveDictEntry& operator=(const LGHaveDictEntry&) = delete;
 

--- a/opencog/nlp/lg-dict/LGDictExpContainer.cc
+++ b/opencog/nlp/lg-dict/LGDictExpContainer.cc
@@ -238,9 +238,10 @@ HandleSeq LGDictExpContainer::to_handle(const Handle& hWordNode)
         // blown up into pairs of disjuncts, one with and one without.
         if (m_string == "OPTIONAL") return { optnl };
 
-        Handle connector(createNode(LG_CONNECTOR_NODE, m_string));
+        Handle connector(createNode(LG_CONNECTOR_NODE,
+                                    std::move(std::string(m_string))));
         Handle direction(createNode(LG_CONN_DIR_NODE,
-                          std::string(1, m_direction)));
+                          std::move(std::string(1, m_direction))));
 
         if (m_multi)
             return { Handle(createLink(LG_CONNECTOR, connector, direction, multi)) };
@@ -257,7 +258,7 @@ HandleSeq LGDictExpContainer::to_handle(const Handle& hWordNode)
     }
 
     if (m_type == AND_type)
-        return { Handle(createLink(outgoing, LG_AND)) };
+        return { Handle(createLink(std::move(outgoing), LG_AND)) };
 
     // remove repeated atoms from OR
     if (m_type == OR_type)

--- a/opencog/nlp/lg-dict/LGDictNode.cc
+++ b/opencog/nlp/lg-dict/LGDictNode.cc
@@ -46,8 +46,8 @@ void error_handler(lg_errinfo *ei, void *data)
 
 // ------------------------------------------------------
 
-LgDictNode::LgDictNode(const std::string& name)
-	: Node(LG_DICT_NODE, name), _dict(nullptr)
+LgDictNode::LgDictNode(const std::string&& name)
+	: Node(LG_DICT_NODE, std::move(name)), _dict(nullptr)
 {
 }
 
@@ -87,7 +87,7 @@ Dictionary LgDictNode::get_dictionary()
 Handle LgDictNode::factory(const Handle& base)
 {
 	if (LgDictNodeCast(base)) return base;
-	Handle h(createLgDictNode(base->get_name()));
+	Handle h(createLgDictNode(std::move(base->get_name())));
 	return h;
 }
 

--- a/opencog/nlp/lg-dict/LGDictNode.h
+++ b/opencog/nlp/lg-dict/LGDictNode.h
@@ -45,7 +45,7 @@ protected:
 	Dictionary _dict;
 
 public:
-	LgDictNode(const std::string&);
+	LgDictNode(const std::string&&);
 	LgDictNode(const LgDictNode&) = delete;
 	LgDictNode& operator=(const LgDictNode&) = delete;
 	virtual ~LgDictNode();

--- a/opencog/nlp/lg-dict/LGDictReader.cc
+++ b/opencog/nlp/lg-dict/LGDictReader.cc
@@ -106,7 +106,7 @@ HandleSeq opencog::getDictEntry(Dictionary _dictionary,
 // automatically.
     if (!dn_head) return outgoing;
 
-    Handle hWord(createNode(WORD_NODE, word));
+    Handle hWord(createNode(WORD_NODE, std::move(std::string(word))));
 
     for (Dict_node* dn = dn_head; dn; dn = dn->right)
     {

--- a/opencog/nlp/lg-parse/LGParseLink.cc
+++ b/opencog/nlp/lg-parse/LGParseLink.cc
@@ -83,8 +83,8 @@ void LGParseLink::init()
 	}
 }
 
-LGParseLink::LGParseLink(const HandleSeq& oset, Type t)
-	: FunctionLink(oset, t)
+LGParseLink::LGParseLink(const HandleSeq&& oset, Type t)
+	: FunctionLink(std::move(oset), t)
 {
 	// Type must be as expected
 	if (not nameserver().isA(t, LG_PARSE_LINK))
@@ -96,8 +96,8 @@ LGParseLink::LGParseLink(const HandleSeq& oset, Type t)
 	init();
 }
 
-LGParseMinimal::LGParseMinimal(const HandleSeq& oset, Type t)
-	: LGParseLink(oset, t)
+LGParseMinimal::LGParseMinimal(const HandleSeq&& oset, Type t)
+	: LGParseLink(std::move(oset), t)
 {
 	// Type must be as expected
 	if (not nameserver().isA(t, LG_PARSE_MINIMAL))
@@ -346,7 +346,7 @@ Handle LGParseLink::cvt_linkage(Linkage lkg, int i, const char* idstr,
 				Handle mu(createNode(LG_CONN_MULTI_NODE, "@"));
 				cono.push_back(mu);
 			}
-			Handle conl(createLink(cono, LG_CONNECTOR));
+			Handle conl(createLink(std::move(cono), LG_CONNECTOR));
 			conseq.push_back(conl);
 		}
 

--- a/opencog/nlp/lg-parse/LGParseLink.h
+++ b/opencog/nlp/lg-parse/LGParseLink.h
@@ -52,7 +52,7 @@ protected:
 	                   bool, AtomSpace*) const;
 
 public:
-	LGParseLink(const HandleSeq&, Type=LG_PARSE_LINK);
+	LGParseLink(const HandleSeq&&, Type=LG_PARSE_LINK);
 	LGParseLink(const LGParseLink&) = delete;
 	LGParseLink& operator=(const LGParseLink&) = delete;
 
@@ -65,7 +65,7 @@ public:
 class LGParseMinimal : public LGParseLink
 {
 public:
-	LGParseMinimal(const HandleSeq&, Type=LG_PARSE_MINIMAL);
+	LGParseMinimal(const HandleSeq&&, Type=LG_PARSE_MINIMAL);
 	LGParseMinimal(const LGParseMinimal&) = delete;
 	LGParseMinimal& operator=(const LGParseMinimal&) = delete;
 };

--- a/opencog/openpsi/OpenPsiRules.cc
+++ b/opencog/openpsi/OpenPsiRules.cc
@@ -71,7 +71,7 @@ Handle OpenPsiRules::add_rule(const HandleSeq& context, const Handle& action,
 
     // Add to the index of rules.
     PatternLinkPtr query_body = \
-      createPatternLink(Handle(createLink(context, AND_LINK)));
+      createPatternLink(std::move(Handle(createLink(std::move(context), AND_LINK))));
     _psi_rules[rule] = std::make_tuple(context, action, goal, query_body);
   }
 


### PR DESCRIPTION
This enables pull req opencog/atomspace#2458 to pass.