### PR TITLE
Use std::move to avoid copying.

### DIFF
--- a/opencog/nlp/fuzzy/FuzzySCM.cc
+++ b/opencog/nlp/fuzzy/FuzzySCM.cc
@@ -120,7 +120,7 @@ Handle FuzzySCM::find_approximate_match(Handle hp)
 		solns.emplace_back(rs.first);
 
 	AtomSpace *as = SchemeSmob::ss_get_env_as("cog-fuzzy-match");
-	return as->add_link(LIST_LINK, solns);
+	return as->add_link(LIST_LINK, std::move(solns));
 }
 
 /**
@@ -154,7 +154,7 @@ Handle FuzzySCM::do_nlp_fuzzy_match(Handle pat, Type rtn_type,
     }
 
     // Wrap everything in a ListLink and then return it
-    Handle results = as->add_link(LIST_LINK, rtn_solns);
+    Handle results = as->add_link(LIST_LINK, std::move(rtn_solns));
 
     return results;
 }

--- a/opencog/nlp/lg-parse/LGParseLink.cc
+++ b/opencog/nlp/lg-parse/LGParseLink.cc
@@ -353,7 +353,7 @@ Handle LGParseLink::cvt_linkage(Linkage lkg, int i, const char* idstr,
 		// Set up the disjuncts on each word
 		if (0 < conseq.size())
 			as->add_link(LG_WORD_CSET, winst,
-				as->add_link(LG_AND, conseq));
+				as->add_link(LG_AND, std::move(conseq)));
 	}
 
 	// Loop over all the links

--- a/opencog/nlp/sureal/SuRealPMCB.cc
+++ b/opencog/nlp/sureal/SuRealPMCB.cc
@@ -528,7 +528,7 @@ bool SuRealPMCB::grounding(const HandleMap &var_soln, const HandleMap &pred_soln
                         Handle hNewPred = m_as->get_handle(PREDICATE_NODE, sWord);
 
                         if (hNewPred == Handle::UNDEFINED)
-                            hNewPred = m_as->add_node(PREDICATE_NODE, sWord);
+                            hNewPred = m_as->add_node(PREDICATE_NODE, std::move(sWord));
 
                         // update the mapping by replacing the lemma
                         // by the one that passed the disjunct match

--- a/opencog/nlp/wsd/MihalceaEdge.cc
+++ b/opencog/nlp/wsd/MihalceaEdge.cc
@@ -265,11 +265,7 @@ bool MihalceaEdge::sense_of_second_inst(const Handle& second_word_sense_h,
 	if (stv->get_mean() < 0.01) return false;
 
 	// Create a link connecting the first pair to the second pair.
-	HandleSeq out;
-	out.push_back(first_sense_link);
-	out.push_back(second_sense_link);
-
-	atom_space->add_link(COSENSE_LINK, out)->setTruthValue(stv);
+	atom_space->add_link(COSENSE_LINK, first_sense_link, second_sense_link)->setTruthValue(stv);
 	edge_count ++;
 
 #ifdef LINK_DEBUG

--- a/opencog/nlp/wsd/MihalceaLabel.cc
+++ b/opencog/nlp/wsd/MihalceaLabel.cc
@@ -130,13 +130,9 @@ bool MihalceaLabel::annotate_word_sense(const Handle& word_sense)
 #endif
 
 	// Create a link connecting this word-instance to this word-sense.
-	HandleSeq out;
-	out.push_back(word_instance);
-	out.push_back(word_sense);
-
 	// Give it a true truth value; but no confidence.
 	TruthValuePtr ctv(CountTruthValue::createTV(1.0f, 0.0f, 1.0f));
-	atom_space->add_link(INHERITANCE_LINK, out)->setTruthValue(ctv);
+	atom_space->add_link(INHERITANCE_LINK, word_instance, word_sense)->setTruthValue(ctv);
 
 	return false;
 }

--- a/opencog/openpsi/OpenPsiRules.cc
+++ b/opencog/openpsi/OpenPsiRules.cc
@@ -39,7 +39,7 @@ Handle OpenPsiRules::add_rule(const HandleSeq& context, const Handle& action,
   // implicant of the psi-rule.
   HandleSeq temp_c =  context;
   temp_c.push_back(action);
-  Handle hca = _as->add_link(AND_LINK, temp_c);
+  Handle hca = _as->add_link(AND_LINK, std::move(temp_c));
 
   // Add the psi-rule, set the truthvalue and default record of whether
   // the action of the rule was executed.

--- a/tests/nlp/fuzzy/FuzzyUTest.cxxtest
+++ b/tests/nlp/fuzzy/FuzzyUTest.cxxtest
@@ -75,7 +75,7 @@ Handle find_approximate_match(AtomSpace* as, const Handle& hp)
     HandleSeq solns;
     for (auto rs: ranked_solns)
         solns.emplace_back(rs.first);
-    return as->add_link(LIST_LINK, solns);
+    return as->add_link(LIST_LINK, std::move(solns));
 }
 
 void FuzzyPatternUTest::test_basic_fuzzy_match(void)


### PR DESCRIPTION
This change doesn't have much of an effect until the atompace
pull reqs are fully merged; but it is a pre-req.