### PR TITLE
Avoid parallel test.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,8 @@ jobs:
           command: cd build && make -j2 tests
       - run:
           name: Run tests
-          command: cd build && make -j2 test ARGS=-j2
+          # command: cd build && make -j2 test ARGS=-j2
+          command: cd build && make test
       - run:
           name: Print test log
           command: cat build/tests/Testing/Temporary/LastTest.log


### PR DESCRIPTION
This is a sanity check, to understand why circle-ci is failing
on the related pull req #3634 -- its a python change that seems
to make scheme code fail...