### PR TITLE
use cog-extract! not cog-delete

### DIFF
--- a/opencog/ghost/procedures/pln-reasoner.scm
+++ b/opencog/ghost/procedures/pln-reasoner.scm
@@ -124,7 +124,7 @@
      ; Do the filtering
     (define result (cog-execute! (MapLink filter-in-pattern filter-from)))
      ; Delete the filter-from SetLink and its encompasing MapLink.
-    (cog-delete-recursive filter-from)
+    (cog-extract-recursive! filter-from)
      result
 )
 

--- a/opencog/nlp/aiml/aiml.scm
+++ b/opencog/nlp/aiml/aiml.scm
@@ -273,7 +273,7 @@
 	(define results (cog-execute! maplk))
 
 	; Remove the bindlink, to avoid garbaging up the atomspace.
-	(cog-delete maplk)
+	(cog-extract! maplk)
 	results
 )
 

--- a/opencog/nlp/chatbot/chat-utils.scm
+++ b/opencog/nlp/chatbot/chat-utils.scm
@@ -78,7 +78,7 @@
 
     (let ((sents (cog-execute! query)))
         (for-each last-sent (cog-outgoing-set sents))
-        (cog-delete sents)
+        (cog-extract! sents)
         result
     )
 )
@@ -118,7 +118,7 @@
 
     (let ((sents (cog-execute! query)))
         (for-each last-sent (cog-outgoing-set sents))
-        (cog-delete sents)
+        (cog-extract! sents)
         result
     )
 )

--- a/opencog/openpsi/demand.scm
+++ b/opencog/openpsi/demand.scm
@@ -55,7 +55,7 @@
     )
 
     ; Delete the SetLink, so it does not pollute the atomspace.
-    (cog-delete skip-set)
+    (cog-extract! skip-set)
 )
 
 ; --------------------------------------------------------------

--- a/opencog/openpsi/dynamics/utilities.scm
+++ b/opencog/openpsi/dynamics/utilities.scm
@@ -17,7 +17,7 @@
 				entity
 				(Variable "$n"))))
 	(define result (cog-execute! query))
-	;(cog-delete query) ; maybe more optimal to keep this in the atomspace
+	;(cog-extract! query) ; maybe more optimal to keep this in the atomspace
 	(if (not (nil? (cog-outgoing-set result)))
 		(gar result)
 		#f))


### PR DESCRIPTION
The correct function was always cog-extract!
It was never cog-delete ... recent changes to the atomspace exposed
this bug.