### PR TITLE
Constify the Dict API. Fixes bug #3667

### DIFF
--- a/opencog/nlp/lg-dict/LGDictExpContainer.cc
+++ b/opencog/nlp/lg-dict/LGDictExpContainer.cc
@@ -36,7 +36,7 @@ using namespace opencog;
  * @param t     must be CONNECTOR_type
  * @param exp   pointer to the LG Exp structure
  */
-LGDictExpContainer::LGDictExpContainer(Exp_type t, Exp* exp)
+LGDictExpContainer::LGDictExpContainer(Exp_type t, const Exp* exp)
     : m_type(t)
 {
     if (t != CONNECTOR_type)

--- a/opencog/nlp/lg-dict/LGDictExpContainer.h
+++ b/opencog/nlp/lg-dict/LGDictExpContainer.h
@@ -40,7 +40,7 @@ namespace opencog
 class LGDictExpContainer
 {
 public:
-    LGDictExpContainer(Exp_type, Exp* exp);
+    LGDictExpContainer(Exp_type, const Exp* exp);
     LGDictExpContainer(Exp_type, const std::vector<LGDictExpContainer>&);
 
     HandleSeq to_handle(const Handle& h);

--- a/opencog/nlp/lg-dict/LGDictReader.cc
+++ b/opencog/nlp/lg-dict/LGDictReader.cc
@@ -36,7 +36,7 @@ using namespace opencog;
  * @param exp   the input expression trees
  * @return      the flatten container
  */
-static LGDictExpContainer lg_exp_to_container(Exp* exp)
+static LGDictExpContainer lg_exp_to_container(const Exp* exp)
 {
     if (CONNECTOR_type == exp->type)
         return LGDictExpContainer(CONNECTOR_type, exp);
@@ -54,7 +54,7 @@ static LGDictExpContainer lg_exp_to_container(Exp* exp)
         el = el->next;
     }
 #else
-    Exp* subexp = lg_exp_operand_first(exp);
+    const Exp* subexp = lg_exp_operand_first(exp);
     while (subexp)
     {
         subcontainers.push_back(lg_exp_to_container(subexp));

--- a/opencog/nlp/lg-dict/LGDictReader.cc
+++ b/opencog/nlp/lg-dict/LGDictReader.cc
@@ -54,11 +54,11 @@ static LGDictExpContainer lg_exp_to_container(const Exp* exp)
         el = el->next;
     }
 #else
-    const Exp* subexp = lg_exp_operand_first(exp);
+    const Exp* subexp = lg_exp_operand_first((Exp*) exp);
     while (subexp)
     {
         subcontainers.push_back(lg_exp_to_container(subexp));
-        subexp = lg_exp_operand_next(subexp);
+        subexp = lg_exp_operand_next((Exp*) subexp);
     }
 #endif
 


### PR DESCRIPTION
The API should have used const from the very beginning.