### PR TITLE
resolve LgConnectorNode naming conflict; issue #3662

### DIFF
--- a/opencog/nlp/lg-dict/LGDictExpContainer.cc
+++ b/opencog/nlp/lg-dict/LGDictExpContainer.cc
@@ -230,7 +230,7 @@ HandleSeq LGDictExpContainer::to_handle(const Handle& hWordNode)
 {
     static Handle multi(createNode(LG_CONN_MULTI_NODE, "@"));
     static Handle optnl(createLink(LG_CONNECTOR,
-                           Handle(createNode(LG_CONNECTOR_NODE, "0"))));
+                           Handle(createNode(LG_CONN_NODE, "0"))));
 
     if (m_type == CONNECTOR_type)
     {
@@ -238,7 +238,7 @@ HandleSeq LGDictExpContainer::to_handle(const Handle& hWordNode)
         // blown up into pairs of disjuncts, one with and one without.
         if (m_string == "OPTIONAL") return { optnl };
 
-        Handle connector(createNode(LG_CONNECTOR_NODE,
+        Handle connector(createNode(LG_CONN_NODE,
                                     std::move(std::string(m_string))));
         Handle direction(createNode(LG_CONN_DIR_NODE,
                           std::move(std::string(1, m_direction))));

--- a/opencog/nlp/lg-dict/LGDictExpContainer.cc
+++ b/opencog/nlp/lg-dict/LGDictExpContainer.cc
@@ -36,7 +36,7 @@ using namespace opencog;
  * @param t     must be CONNECTOR_type
  * @param exp   pointer to the LG Exp structure
  */
-LGDictExpContainer::LGDictExpContainer(Exp_type t, Exp* exp)
+LGDictExpContainer::LGDictExpContainer(Exp_type t, const Exp* exp)
     : m_type(t)
 {
     if (t != CONNECTOR_type)

--- a/opencog/nlp/lg-dict/LGDictExpContainer.h
+++ b/opencog/nlp/lg-dict/LGDictExpContainer.h
@@ -40,7 +40,7 @@ namespace opencog
 class LGDictExpContainer
 {
 public:
-    LGDictExpContainer(Exp_type, Exp* exp);
+    LGDictExpContainer(Exp_type, const Exp* exp);
     LGDictExpContainer(Exp_type, const std::vector<LGDictExpContainer>&);
 
     HandleSeq to_handle(const Handle& h);

--- a/opencog/nlp/lg-dict/LGDictReader.cc
+++ b/opencog/nlp/lg-dict/LGDictReader.cc
@@ -36,7 +36,7 @@ using namespace opencog;
  * @param exp   the input expression trees
  * @return      the flatten container
  */
-static LGDictExpContainer lg_exp_to_container(Exp* exp)
+static LGDictExpContainer lg_exp_to_container(const Exp* exp)
 {
     if (CONNECTOR_type == exp->type)
         return LGDictExpContainer(CONNECTOR_type, exp);
@@ -54,7 +54,7 @@ static LGDictExpContainer lg_exp_to_container(Exp* exp)
         el = el->next;
     }
 #else
-    Exp* subexp = lg_exp_operand_first(exp);
+    const Exp* subexp = lg_exp_operand_first(exp);
     while (subexp)
     {
         subcontainers.push_back(lg_exp_to_container(subexp));

--- a/opencog/nlp/lg-dict/README.md
+++ b/opencog/nlp/lg-dict/README.md
@@ -25,7 +25,7 @@ The `(cog-incoming-set (WordNode "..."))` should resemble the below:
    (LgDisjunct
       (WordNode "...")
       (LgConnector
-         (LgConnectorNode "Sp")
+         (LgConnNode "Sp")
          (LgConnDirNode "-")
       )
    )
@@ -33,11 +33,11 @@ The `(cog-incoming-set (WordNode "..."))` should resemble the below:
       (WordNode "...")
       (LgAnd
          (LgConnector
-            (LgConnectorNode "Sp")
+            (LgConnNode "Sp")
             (LgConnDirNode "-")
          )
          (LgConnector
-            (LgConnectorNode "dWV")
+            (LgConnNode "dWV")
             (LgConnDirNode "-")
          )
          ...
@@ -62,8 +62,8 @@ where `LgOr` and `LgAnd` correspond to the `or` and `&` notation of LG.
 Note that `LgOr` is actually a menu choice, and NOT a boolean OR.
 
 Each LG connector is fully described within the `LgConnector` link,
-with the connector name in `LgConnectorNode`, direction in
-`LgConnDirNode`, and the multi-connect property in `LgConnMultiNode`.
+with the connector name in `LgConnNode`, direction in `LgConnDirNode`,
+and the multi-connect property in `LgConnMultiNode`.
 
 The connector ordering is kept intact. Connectors and their meaning and
 usage are described in the [Link Grammar documentation](http://www.abisource.com/projects/link-grammar/dict/introduction.html),

--- a/opencog/nlp/lg-dict/lg-dict.scm
+++ b/opencog/nlp/lg-dict/lg-dict.scm
@@ -100,7 +100,7 @@
 
 (define-public (lg-conn-get-type conn)
 "
-  lg-conn-get-type CON - Get the LgConnectorNode out of LgConnector link
+  lg-conn-get-type CON - Get the LgConnNode out of LgConnector link
 "
 	(cog-outgoing-atom conn 0)
 )

--- a/opencog/nlp/lg-parse/LGParseLink.cc
+++ b/opencog/nlp/lg-parse/LGParseLink.cc
@@ -340,7 +340,7 @@ Handle LGParseLink::cvt_linkage(Linkage lkg, int i, const char* idstr,
 					"LGParseLink: Dictionary has a bug; Uuexpectedly long connector=%s", djstr);
 			strncpy(cstr, p, len);
 			cstr[len] = 0;
-			Handle con(createNode(LG_CONNECTOR_NODE, cstr));
+			Handle con(createNode(LG_CONN_NODE, cstr));
 			cstr[0] = *(p+len);
 			cstr[1] = 0;
 			Handle dir(createNode(LG_CONN_DIR_NODE, cstr));
@@ -395,10 +395,10 @@ Handle LGParseLink::cvt_linkage(Linkage lkg, int i, const char* idstr,
 		as->add_link(LG_LINK_INSTANCE_LINK,
 			linst,
 			as->add_link(LG_CONNECTOR,
-				as->add_node(LG_CONNECTOR_NODE, llab),
+				as->add_node(LG_CONN_NODE, llab),
 				as->add_node(LG_CONN_DIR_NODE, "+")),
 			as->add_link(LG_CONNECTOR,
-				as->add_node(LG_CONNECTOR_NODE, rlab),
+				as->add_node(LG_CONN_NODE, rlab),
 				as->add_node(LG_CONN_DIR_NODE, "-")));
 	}
 

--- a/opencog/nlp/scm/nlp.scm
+++ b/opencog/nlp/scm/nlp.scm
@@ -16,6 +16,11 @@
 (load "nlp/relex-utils.scm")
 (load "nlp/processing-utils.scm")
 
+; Backwards compat
+(define-public (LgConnnnectorNode . x)
+   (apply cog-new-node (cons LgConnNodeType x)))
+
+
 ; Weird ... MUST say `(export)` or no define-publics are visible!
 ; XXX What? nothing else anywhere needs this! FIXME, somethings broke.
 (export)

--- a/opencog/nlp/sureal/README.md
+++ b/opencog/nlp/sureal/README.md
@@ -85,11 +85,11 @@ links of the style:
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Ds**c@4432ef3-3c4e-42a9-8072-9975d168a12c")
    (LgConnector
-      (LgConnectorNode "D")
+      (LgConnNode "D")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Ds**c")
+      (LgConnNode "Ds**c")
       (LgConnDirNode "-")
    )
 )
@@ -127,11 +127,11 @@ to link the two words in the sentence.
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Ds**c@4432ef3-3c4e-42a9-8072-9975d168a12c")
    (LgConnector
-      (LgConnectorNode "D")
+      (LgConnNode "D")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Ds**c")
+      (LgConnNode "Ds**c")
       (LgConnDirNode "-")
    )
 )

--- a/opencog/nlp/types/atom_types.script
+++ b/opencog/nlp/types/atom_types.script
@@ -123,7 +123,7 @@ LG_PARSE_MINIMAL <- LG_PARSE_LINK
 
 // Connector: same meaning and syntax as in link-grammar, except that
 // the direction and the multi-connector parts get distinct types.
-LG_CONNECTOR_NODE <- PREDICATE_NODE   // e.g. "MX"
+LG_CONN_NODE <- PREDICATE_NODE   // e.g. "MX"
 LG_CONN_MULTI_NODE <- NODE  // multi-connector "@"
 LG_CONN_DIR_NODE <- NODE    // e.g. "+"
 

--- a/tests/nlp/microplanning/r2l-atomspace.scm
+++ b/tests/nlp/microplanning/r2l-atomspace.scm
@@ -2815,11 +2815,11 @@
    (WordInstanceNode "?@38ea74a1-60c9-447a-ace3-1ce881f5e434")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "RW")
+         (LgConnNode "RW")
          (LgConnDirNode "+")
       )
    )
@@ -2828,11 +2828,11 @@
    (WordInstanceNode ".@b9a01102-f039-47c5-bf25-2488fecefbc1")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "RW")
+         (LgConnNode "RW")
          (LgConnDirNode "+")
       )
    )
@@ -2841,7 +2841,7 @@
    (WordInstanceNode "brown@62945422-ac5f-4aef-bca6-4491369928dc")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "A")
+         (LgConnNode "A")
          (LgConnDirNode "+")
       )
    )
@@ -2850,15 +2850,15 @@
    (WordInstanceNode "steals@40cc074b-75f1-4e8d-a1dc-b55c529078f3")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "dWV")
+         (LgConnNode "dWV")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "O")
+         (LgConnNode "O")
          (LgConnDirNode "+")
       )
    )
@@ -2867,11 +2867,11 @@
    (WordInstanceNode "grow@4cf777c1-a989-4aac-831c-8c1175d4b197")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Sp")
+         (LgConnNode "Sp")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "dWV")
+         (LgConnNode "dWV")
          (LgConnDirNode "-")
       )
    )
@@ -2880,15 +2880,15 @@
    (WordInstanceNode "LEFT-WALL@sentence@8ea9842b-a66c-42bf-8a32-1cbaa596c457_parse_0")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "hWV")
+         (LgConnNode "hWV")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "+")
       )
    )
@@ -2897,11 +2897,11 @@
    (WordInstanceNode "they@deb8f479-5b5a-447c-9ef3-c31a60e21371")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Sp")
+         (LgConnNode "Sp")
          (LgConnDirNode "+")
       )
    )
@@ -2910,15 +2910,15 @@
    (WordInstanceNode "LEFT-WALL@sentence@c32280f6-14d5-4af1-adfb-ec99494c1dd4_parse_0")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "hWV")
+         (LgConnNode "hWV")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "+")
       )
    )
@@ -2927,11 +2927,11 @@
    (WordInstanceNode "grow@cbf77b70-75b4-4902-9339-a54639377ec4")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Sp")
+         (LgConnNode "Sp")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "dWV")
+         (LgConnNode "dWV")
          (LgConnDirNode "-")
       )
    )
@@ -2940,11 +2940,11 @@
    (WordInstanceNode "John@6a8c11d0-cfb9-4740-a88e-1aaab20af288")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "+")
       )
    )
@@ -2953,11 +2953,11 @@
    (WordInstanceNode ".@a5482656-464e-46b9-9b87-ec75cabba1af")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "RW")
+         (LgConnNode "RW")
          (LgConnDirNode "+")
       )
    )
@@ -2966,15 +2966,15 @@
    (WordInstanceNode "dogs@e80edc9e-b5c5-4cae-90d9-eb91296b2e18")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Dmc")
+         (LgConnNode "Dmc")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Sp")
+         (LgConnNode "Sp")
          (LgConnDirNode "+")
       )
    )
@@ -2983,7 +2983,7 @@
    (WordInstanceNode "the@b93a907b-84f5-42c1-bc1f-abaeb0dcfd3d")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "D")
+         (LgConnNode "D")
          (LgConnDirNode "+")
       )
    )
@@ -2992,15 +2992,15 @@
    (WordInstanceNode "LEFT-WALL@sentence@b98794e2-4a35-4642-b0ac-59914848df22_parse_0")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "hWV")
+         (LgConnNode "hWV")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "+")
       )
    )
@@ -3009,16 +3009,16 @@
    (WordInstanceNode "bones@b30ec255-69ae-433d-bdb4-4ba943ce659f")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "A")
+         (LgConnNode "A")
          (LgConnDirNode "-")
          (LgConnMultiNode "@")
       )
       (LgConnector
-         (LgConnectorNode "Dmc")
+         (LgConnNode "Dmc")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Op")
+         (LgConnNode "Op")
          (LgConnDirNode "-")
       )
    )
@@ -3027,11 +3027,11 @@
    (WordInstanceNode "tree@70199077-d25f-4abd-9519-5fddd34c5e18")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Ds**c")
+         (LgConnNode "Ds**c")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Os")
+         (LgConnNode "Os")
          (LgConnDirNode "-")
       )
    )
@@ -3040,11 +3040,11 @@
    (WordInstanceNode "'s@bacbf373-f106-43f9-93c1-fba6c106a7bd")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "YS")
+         (LgConnNode "YS")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "D")
+         (LgConnNode "D")
          (LgConnDirNode "+")
       )
    )
@@ -3053,15 +3053,15 @@
    (WordInstanceNode "LEFT-WALL@sentence@bb54d100-5325-400d-ac0b-9f5d2c1bd4bf_parse_0")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "hWV")
+         (LgConnNode "hWV")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "+")
       )
    )
@@ -3070,7 +3070,7 @@
    (WordInstanceNode "tiny@7db7acbd-9ef8-483c-88e6-5e04964b0eef")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "A")
+         (LgConnNode "A")
          (LgConnDirNode "+")
       )
    )
@@ -3079,7 +3079,7 @@
    (WordInstanceNode "the@a8b4b026-e253-4adc-9b97-55d84de4a7c7")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "D")
+         (LgConnNode "D")
          (LgConnDirNode "+")
       )
    )
@@ -3088,7 +3088,7 @@
    (WordInstanceNode "the@cce7f69a-9d6d-41a1-b0db-acd72486931b")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "D")
+         (LgConnNode "D")
          (LgConnDirNode "+")
       )
    )
@@ -3097,7 +3097,7 @@
    (WordInstanceNode "the@526b055a-cd08-46e5-8e1a-04132d9a996a")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "D")
+         (LgConnNode "D")
          (LgConnDirNode "+")
       )
    )
@@ -3106,11 +3106,11 @@
    (WordInstanceNode "I@58decb35-c9b0-4328-88a2-f1d0ff42470d")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Sp*i")
+         (LgConnNode "Sp*i")
          (LgConnDirNode "+")
       )
    )
@@ -3119,15 +3119,15 @@
    (WordInstanceNode "LEFT-WALL@sentence@73cbe607-c500-435c-9893-16704bb84be1_parse_0")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "hWV")
+         (LgConnNode "hWV")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "+")
       )
    )
@@ -3136,11 +3136,11 @@
    (WordInstanceNode ".@2997225b-691d-473e-a8ac-bb1790e8e42e")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "RW")
+         (LgConnNode "RW")
          (LgConnDirNode "+")
       )
    )
@@ -3149,15 +3149,15 @@
    (WordInstanceNode "climbs@0addbb01-d017-47ff-bd2d-c7a2afa3c60c")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "dWV")
+         (LgConnNode "dWV")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "O")
+         (LgConnNode "O")
          (LgConnDirNode "+")
       )
    )
@@ -3166,7 +3166,7 @@
    (WordInstanceNode "the@e44e8335-3aec-4990-8816-9c54aef4d822")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "D")
+         (LgConnNode "D")
          (LgConnDirNode "+")
       )
    )
@@ -3175,20 +3175,20 @@
    (WordInstanceNode "cat@9f3565d0-834e-4b30-a598-11cfb8adb3b9")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "A")
+         (LgConnNode "A")
          (LgConnDirNode "-")
          (LgConnMultiNode "@")
       )
       (LgConnector
-         (LgConnectorNode "Ds**x")
+         (LgConnNode "Ds**x")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "+")
       )
    )
@@ -3197,11 +3197,11 @@
    (WordInstanceNode "John@82cd9bb7-b68a-44d5-a5ee-8dd96313532b")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "+")
       )
    )
@@ -3210,11 +3210,11 @@
    (WordInstanceNode ".@45eac6cd-fcff-4f59-971f-f232ec685eff")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "RW")
+         (LgConnNode "RW")
          (LgConnDirNode "+")
       )
    )
@@ -3223,11 +3223,11 @@
    (WordInstanceNode "what@63e66bb3-7efa-4580-b6b0-ce8411276a2f")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Ws")
+         (LgConnNode "Ws")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Ss*w")
+         (LgConnNode "Ss*w")
          (LgConnDirNode "+")
       )
    )
@@ -3236,15 +3236,15 @@
    (WordInstanceNode "Sam@8c89bbba-4638-4370-a4ad-4c8918f3bdc6")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "ZZZ")
+         (LgConnNode "ZZZ")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "+")
       )
    )
@@ -3253,15 +3253,15 @@
    (WordInstanceNode "LEFT-WALL@sentence@6c386699-9d21-4d1f-8eec-ff8518c18d90_parse_0")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "hWV")
+         (LgConnNode "hWV")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "+")
       )
    )
@@ -3270,11 +3270,11 @@
    (WordInstanceNode ".@d82aa918-166e-4be0-aecc-3e85fb7e622a")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "RW")
+         (LgConnNode "RW")
          (LgConnDirNode "+")
       )
    )
@@ -3283,7 +3283,7 @@
    (WordInstanceNode "the@47de1134-299c-48c7-b5d2-9ff76f3d3ce1")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "D")
+         (LgConnNode "D")
          (LgConnDirNode "+")
       )
    )
@@ -3292,15 +3292,15 @@
    (WordInstanceNode "LEFT-WALL@sentence@c98270c2-c94e-47ec-8d57-94d67930c972_parse_0")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "hWV")
+         (LgConnNode "hWV")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "+")
       )
    )
@@ -3309,15 +3309,15 @@
    (WordInstanceNode "steals@95cb50da-10ac-493c-928a-d52e6f2c3644")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "dWV")
+         (LgConnNode "dWV")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "O")
+         (LgConnNode "O")
          (LgConnDirNode "+")
       )
    )
@@ -3326,11 +3326,11 @@
    (WordInstanceNode "orange@138d2783-960d-4030-86d9-e19597d3b5e9")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Ds**v")
+         (LgConnNode "Ds**v")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Os")
+         (LgConnNode "Os")
          (LgConnDirNode "-")
       )
    )
@@ -3339,11 +3339,11 @@
    (WordInstanceNode "table@54e19a50-96a3-48c4-805b-954e1c91dce6")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Ds**c")
+         (LgConnNode "Ds**c")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Os")
+         (LgConnNode "Os")
          (LgConnDirNode "-")
       )
    )
@@ -3352,7 +3352,7 @@
    (WordInstanceNode "it@3cbaf1c9-026d-4464-9fb3-afcd4bc09574")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Osm")
+         (LgConnNode "Osm")
          (LgConnDirNode "-")
       )
    )
@@ -3361,15 +3361,15 @@
    (WordInstanceNode "LEFT-WALL@sentence@8989dbfa-4ebd-4b78-9b5d-11c48fb87475_parse_0")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Ws")
+         (LgConnNode "Ws")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "hWV")
+         (LgConnNode "hWV")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "+")
       )
    )
@@ -3378,11 +3378,11 @@
    (WordInstanceNode ".@1d3c5cc7-1ae2-42f3-a439-2200187b9cda")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "RW")
+         (LgConnNode "RW")
          (LgConnDirNode "+")
       )
    )
@@ -3391,15 +3391,15 @@
    (WordInstanceNode "mean@3973436d-87f8-4abf-b5c8-f297c173c6a7")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Sp")
+         (LgConnNode "Sp")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "dWV")
+         (LgConnNode "dWV")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "O")
+         (LgConnNode "O")
          (LgConnDirNode "+")
       )
    )
@@ -3408,15 +3408,15 @@
    (WordInstanceNode "burns@e491539f-5f54-487b-ace6-d1055a422ec5")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "dWV")
+         (LgConnNode "dWV")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "O")
+         (LgConnNode "O")
          (LgConnDirNode "+")
       )
    )
@@ -3425,7 +3425,7 @@
    (WordInstanceNode "apple@dd5f32bb-5bca-4b23-81f0-39f71e06b55f")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "YS")
+         (LgConnNode "YS")
          (LgConnDirNode "+")
       )
    )
@@ -3434,15 +3434,15 @@
    (WordInstanceNode "collects@553733bb-8159-44a5-a0b0-1b815aeafdce")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "dWV")
+         (LgConnNode "dWV")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "O")
+         (LgConnNode "O")
          (LgConnDirNode "+")
       )
    )
@@ -3451,7 +3451,7 @@
    (WordInstanceNode "tall@66156a86-5eb9-4eaf-80ee-f17a04d1de7e")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "A")
+         (LgConnNode "A")
          (LgConnDirNode "+")
       )
    )
@@ -3460,16 +3460,16 @@
    (WordInstanceNode "man@8cffb349-5881-433f-af6d-79cd72c23aa7")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "A")
+         (LgConnNode "A")
          (LgConnDirNode "-")
          (LgConnMultiNode "@")
       )
       (LgConnector
-         (LgConnectorNode "Ds**x")
+         (LgConnNode "Ds**x")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Os")
+         (LgConnNode "Os")
          (LgConnDirNode "-")
       )
    )
@@ -3478,11 +3478,11 @@
    (WordInstanceNode ".@cc6f999d-f779-494b-81c8-8d9e36a02854")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "RW")
+         (LgConnNode "RW")
          (LgConnDirNode "+")
       )
    )
@@ -3490,539 +3490,539 @@
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Os@ef5b6df6-63ef-49bf-a356-95ecb0de3182")
    (LgConnector
-      (LgConnectorNode "O")
+      (LgConnNode "O")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Os")
+      (LgConnNode "Os")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Wd@5b3d6cfa-2827-44db-afa7-f1d4295f75e9")
    (LgConnector
-      (LgConnectorNode "Wd")
+      (LgConnNode "Wd")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Wd")
+      (LgConnNode "Wd")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "A@fdc0827b-f1be-4b48-b02b-3c9c9fd9c292")
    (LgConnector
-      (LgConnectorNode "A")
+      (LgConnNode "A")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "A")
+      (LgConnNode "A")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Os@0c2576eb-fb1d-40e2-b2ef-f8768374eb15")
    (LgConnector
-      (LgConnectorNode "O")
+      (LgConnNode "O")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Os")
+      (LgConnNode "Os")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Ds**x@b7d96691-41fe-42a2-9eec-966c891bed74")
    (LgConnector
-      (LgConnectorNode "D")
+      (LgConnNode "D")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Ds**x")
+      (LgConnNode "Ds**x")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Ds**v@180cd187-d804-4373-b04e-c2720fa9446e")
    (LgConnector
-      (LgConnectorNode "D")
+      (LgConnNode "D")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Ds**v")
+      (LgConnNode "Ds**v")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Ws@7f9d7031-01b0-47ea-9702-3e72f00701e9")
    (LgConnector
-      (LgConnectorNode "Ws")
+      (LgConnNode "Ws")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Ws")
+      (LgConnNode "Ws")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "WV@539473f6-9d84-4ad6-aa37-79c82ac5e2eb")
    (LgConnector
-      (LgConnectorNode "hWV")
+      (LgConnNode "hWV")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "dWV")
+      (LgConnNode "dWV")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Wd@18722252-fbb2-4b3c-9bf8-698dfbb84fa7")
    (LgConnector
-      (LgConnectorNode "Wd")
+      (LgConnNode "Wd")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Wd")
+      (LgConnNode "Wd")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Dmc@e48da3e3-c273-4524-b128-25ff6a9fa32d")
    (LgConnector
-      (LgConnectorNode "D")
+      (LgConnNode "D")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Dmc")
+      (LgConnNode "Dmc")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Ds**x@70f0028c-01ea-4d07-9a17-8c945e521ff8")
    (LgConnector
-      (LgConnectorNode "D")
+      (LgConnNode "D")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Ds**x")
+      (LgConnNode "Ds**x")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Sp@822550bc-a595-45a2-854a-d56b0c8431c3")
    (LgConnector
-      (LgConnectorNode "Sp")
+      (LgConnNode "Sp")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Sp")
+      (LgConnNode "Sp")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Xp@0b47785f-f0f6-4d74-8930-2b3d70071915")
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Ss@850ba150-f0de-4afe-9493-a63201b47feb")
    (LgConnector
-      (LgConnectorNode "Ss")
+      (LgConnNode "Ss")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Ss")
+      (LgConnNode "Ss")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Op@9f5290a2-0443-4bb5-af58-c5bf0ba96440")
    (LgConnector
-      (LgConnectorNode "O")
+      (LgConnNode "O")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Op")
+      (LgConnNode "Op")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Ds**c@2c49dbae-8e8a-49e6-9cc5-0ce0cce3bd19")
    (LgConnector
-      (LgConnectorNode "D")
+      (LgConnNode "D")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Ds**c")
+      (LgConnNode "Ds**c")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Dmc@c58316a0-da3c-4ec0-9182-4e26abb85e28")
    (LgConnector
-      (LgConnectorNode "D")
+      (LgConnNode "D")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Dmc")
+      (LgConnNode "Dmc")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Xp@79e5f188-db8b-4eb9-bb19-949d174efa78")
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Ss@55caf999-1fa0-4987-8bc7-7e2778a3badb")
    (LgConnector
-      (LgConnectorNode "Ss")
+      (LgConnNode "Ss")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Ss")
+      (LgConnNode "Ss")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Ss@e21122f0-759b-4f4d-b1f9-594460940b2b")
    (LgConnector
-      (LgConnectorNode "Ss")
+      (LgConnNode "Ss")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Ss")
+      (LgConnNode "Ss")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Xp@13b227dd-3546-47ac-a5c0-c8ef726e9590")
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "WV@0e424683-92df-4dbb-8f67-9f2e27c8ddb4")
    (LgConnector
-      (LgConnectorNode "hWV")
+      (LgConnNode "hWV")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "dWV")
+      (LgConnNode "dWV")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Xp@8cafae31-7a72-4403-ba8b-6b808b0b9481")
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Wd@312908d5-ef45-42e4-bb71-7f61fcc48e47")
    (LgConnector
-      (LgConnectorNode "Wd")
+      (LgConnNode "Wd")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Wd")
+      (LgConnNode "Wd")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "A@bbe5ff2a-efde-4d6a-bc68-42c23274c1f1")
    (LgConnector
-      (LgConnectorNode "A")
+      (LgConnNode "A")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "A")
+      (LgConnNode "A")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Os@c89ff359-9ebb-4375-9f41-42fe3d4d3d17")
    (LgConnector
-      (LgConnectorNode "O")
+      (LgConnNode "O")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Os")
+      (LgConnNode "Os")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Wd@87538538-aa01-489d-be9e-ff87e958f35f")
    (LgConnector
-      (LgConnectorNode "Wd")
+      (LgConnNode "Wd")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Wd")
+      (LgConnNode "Wd")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Wd@78f0be3e-2f25-4e30-8535-131543046a08")
    (LgConnector
-      (LgConnectorNode "Wd")
+      (LgConnNode "Wd")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Wd")
+      (LgConnNode "Wd")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Xp@3a072e59-ef1d-4ef0-b740-d1ae28f8fba8")
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Wd@fc26f6ee-76f7-4505-95c5-df49d63764fc")
    (LgConnector
-      (LgConnectorNode "Wd")
+      (LgConnNode "Wd")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Wd")
+      (LgConnNode "Wd")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "A@b14b24ed-ce2f-4ccc-8daa-1cdc0b99efb4")
    (LgConnector
-      (LgConnectorNode "A")
+      (LgConnNode "A")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "A")
+      (LgConnNode "A")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "YS@709e8d11-fce7-44e0-9049-99fe5d3c2c1d")
    (LgConnector
-      (LgConnectorNode "YS")
+      (LgConnNode "YS")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "YS")
+      (LgConnNode "YS")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "WV@01c52027-403c-4a9b-9531-a38fcd163c4f")
    (LgConnector
-      (LgConnectorNode "hWV")
+      (LgConnNode "hWV")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "dWV")
+      (LgConnNode "dWV")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Os@d0d1e8dc-63a8-42e6-9988-c526d2ab72b0")
    (LgConnector
-      (LgConnectorNode "O")
+      (LgConnNode "O")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Os")
+      (LgConnNode "Os")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "WV@93de2567-d437-45b2-8f43-8e3b98ac1a57")
    (LgConnector
-      (LgConnectorNode "hWV")
+      (LgConnNode "hWV")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "dWV")
+      (LgConnNode "dWV")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Osm@9a50b435-4695-4def-bca2-d479e3f75123")
    (LgConnector
-      (LgConnectorNode "O")
+      (LgConnNode "O")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Osm")
+      (LgConnNode "Osm")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Xp@bad30900-81b5-411c-9fb8-37dcdb01dbad")
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Ds**c@e7688675-c89e-4403-a208-9ab2dcd9558f")
    (LgConnector
-      (LgConnectorNode "D")
+      (LgConnNode "D")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Ds**c")
+      (LgConnNode "Ds**c")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "WV@a31eb17a-cc93-49f8-9b82-a0f321fd5afc")
    (LgConnector
-      (LgConnectorNode "hWV")
+      (LgConnNode "hWV")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "dWV")
+      (LgConnNode "dWV")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "WV@6b102f24-48c9-4222-a053-3fb3775f6382")
    (LgConnector
-      (LgConnectorNode "hWV")
+      (LgConnNode "hWV")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "dWV")
+      (LgConnNode "dWV")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Sp*i@694b5346-56d3-4894-a8ce-71b1257fefca")
    (LgConnector
-      (LgConnectorNode "Sp*i")
+      (LgConnNode "Sp*i")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Sp")
+      (LgConnNode "Sp")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "WV@c73defe8-cf06-4a11-9d6a-d82069f8c8e9")
    (LgConnector
-      (LgConnectorNode "hWV")
+      (LgConnNode "hWV")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "dWV")
+      (LgConnNode "dWV")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Xp@38516ea5-6d18-41c7-b881-d7b7862d6e6a")
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Xp@617d8bcc-85c2-4408-9110-c09cb370fef5")
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Ss*w@888051a7-500a-4309-a0a2-36e11bc44210")
    (LgConnector
-      (LgConnectorNode "Ss*w")
+      (LgConnNode "Ss*w")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Ss")
+      (LgConnNode "Ss")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Sp@ca87f55c-26f9-4473-b66a-7373d6708e6a")
    (LgConnector
-      (LgConnectorNode "Sp")
+      (LgConnNode "Sp")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Sp")
+      (LgConnNode "Sp")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Ss@aa79ca62-9b81-407b-bd16-a1cc1d8b7707")
    (LgConnector
-      (LgConnectorNode "Ss")
+      (LgConnNode "Ss")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Ss")
+      (LgConnNode "Ss")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Wd@d533752e-bede-4117-9b47-c06ce5bb7494")
    (LgConnector
-      (LgConnectorNode "Wd")
+      (LgConnNode "Wd")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Wd")
+      (LgConnNode "Wd")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "WV@0bc59e2f-8c60-4258-a4e8-381914bd0ba8")
    (LgConnector
-      (LgConnectorNode "hWV")
+      (LgConnNode "hWV")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "dWV")
+      (LgConnNode "dWV")
       (LgConnDirNode "-")
    )
 )

--- a/tests/nlp/microplanning/test-atomspace.scm
+++ b/tests/nlp/microplanning/test-atomspace.scm
@@ -655,7 +655,7 @@ For now, most of the results are in r2l-atomspace.scm
    (WordInstanceNode "tall@7bd00625-1ff7-4e77-9900-5e943141d281")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "A")
+         (LgConnNode "A")
          (LgConnDirNode "+")
       )
    )
@@ -664,15 +664,15 @@ For now, most of the results are in r2l-atomspace.scm
    (WordInstanceNode "mean@524fdbed-149e-47ce-a2a2-494e80962580")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Sp")
+         (LgConnNode "Sp")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "dWV")
+         (LgConnNode "dWV")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "O")
+         (LgConnNode "O")
          (LgConnDirNode "+")
       )
    )
@@ -681,11 +681,11 @@ For now, most of the results are in r2l-atomspace.scm
    (WordInstanceNode "I@5219488c-e6f1-413a-8494-77deeb9f33f3")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Sp*i")
+         (LgConnNode "Sp*i")
          (LgConnDirNode "+")
       )
    )
@@ -694,11 +694,11 @@ For now, most of the results are in r2l-atomspace.scm
    (WordInstanceNode "grow@3fe4efed-5135-408f-bc1b-d02343bb69c1")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Sp")
+         (LgConnNode "Sp")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "dWV")
+         (LgConnNode "dWV")
          (LgConnDirNode "-")
       )
    )
@@ -707,11 +707,11 @@ For now, most of the results are in r2l-atomspace.scm
    (WordInstanceNode "plants@0f71e243-1327-49af-8020-f6aa3ef0d273")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "VJr*i")
+         (LgConnNode "VJr*i")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "O")
+         (LgConnNode "O")
          (LgConnDirNode "+")
       )
    )
@@ -720,11 +720,11 @@ For now, most of the results are in r2l-atomspace.scm
    (WordInstanceNode "collects@78c90976-cb18-4b09-9169-00bc3cc6a70a")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "O")
+         (LgConnNode "O")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "VJl*i")
+         (LgConnNode "VJl*i")
          (LgConnDirNode "+")
       )
    )
@@ -733,7 +733,7 @@ For now, most of the results are in r2l-atomspace.scm
    (WordInstanceNode "tiny@ab783d83-a6cb-4be8-9d6d-45b97a1bd955")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "A")
+         (LgConnNode "A")
          (LgConnDirNode "+")
       )
    )
@@ -742,11 +742,11 @@ For now, most of the results are in r2l-atomspace.scm
    (WordInstanceNode "seeds@474593d7-5a5c-4ceb-9cbb-173ade98cc59")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Dmc")
+         (LgConnNode "Dmc")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Op")
+         (LgConnNode "Op")
          (LgConnDirNode "-")
       )
    )
@@ -755,7 +755,7 @@ For now, most of the results are in r2l-atomspace.scm
    (WordInstanceNode "eats@5ec780eb-a98b-4650-a680-3b0163a8822e")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "VJr*t")
+         (LgConnNode "VJr*t")
          (LgConnDirNode "-")
       )
    )
@@ -764,7 +764,7 @@ For now, most of the results are in r2l-atomspace.scm
    (WordInstanceNode "steals@d88d647d-5c02-481e-b8d0-cfd20d33fb23")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "VJl*t")
+         (LgConnNode "VJl*t")
          (LgConnDirNode "+")
       )
    )
@@ -773,11 +773,11 @@ For now, most of the results are in r2l-atomspace.scm
    (WordInstanceNode "Bob@fd5fb72f-0d3f-4517-8b20-8147df2ee7d3")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "+")
       )
    )
@@ -786,11 +786,11 @@ For now, most of the results are in r2l-atomspace.scm
    (WordInstanceNode "climbs@cc237a97-1cde-4939-bf7e-93d607eb3d7d")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "O")
+         (LgConnNode "O")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "VJl*i")
+         (LgConnNode "VJl*i")
          (LgConnDirNode "+")
       )
    )
@@ -799,7 +799,7 @@ For now, most of the results are in r2l-atomspace.scm
    (WordInstanceNode "green@7bdd117a-14ab-4699-81e3-f89259d848df")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "A")
+         (LgConnNode "A")
          (LgConnDirNode "+")
       )
    )
@@ -808,15 +808,15 @@ For now, most of the results are in r2l-atomspace.scm
    (WordInstanceNode "robot@91c3e125-bca8-42f3-8a48-deea6a29c0de")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Ds**c")
+         (LgConnNode "Ds**c")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "+")
       )
    )
@@ -825,16 +825,16 @@ For now, most of the results are in r2l-atomspace.scm
    (WordInstanceNode "apple@ca552878-32d4-41e3-aaa3-34239ba98f34")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "A")
+         (LgConnNode "A")
          (LgConnDirNode "-")
          (LgConnMultiNode "@")
       )
       (LgConnector
-         (LgConnectorNode "Dmu")
+         (LgConnNode "Dmu")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Ou")
+         (LgConnNode "Ou")
          (LgConnDirNode "-")
       )
    )
@@ -843,11 +843,11 @@ For now, most of the results are in r2l-atomspace.scm
    (WordInstanceNode "tree@160bc480-942c-4421-b798-04c004c011f5")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Ds**c")
+         (LgConnNode "Ds**c")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Os")
+         (LgConnNode "Os")
          (LgConnDirNode "-")
       )
    )
@@ -856,11 +856,11 @@ For now, most of the results are in r2l-atomspace.scm
    (WordInstanceNode "grabs@50f22d3b-c293-41e7-afdd-b2731d6578ef")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "VJr*i")
+         (LgConnNode "VJr*i")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "O")
+         (LgConnNode "O")
          (LgConnDirNode "+")
       )
    )

--- a/tests/nlp/sureal/r2l-atomspace1.scm
+++ b/tests/nlp/sureal/r2l-atomspace1.scm
@@ -234,15 +234,15 @@
    (WordInstanceNode "LEFT-WALL@sentence@17302cea-0d43-40f0-b454-311c18d6478b_parse_0")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "hWV")
+         (LgConnNode "hWV")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "+")
       )
    )
@@ -251,11 +251,11 @@
    (WordInstanceNode "he@5c3978be-30a7-493b-b276-ebaf4a879669")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "+")
       )
    )
@@ -264,11 +264,11 @@
    (WordInstanceNode "runs@838adddd-073f-4e19-8e53-2f6b398809ea")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "dWV")
+         (LgConnNode "dWV")
          (LgConnDirNode "-")
       )
    )
@@ -277,11 +277,11 @@
    (WordInstanceNode ".@fdd913dc-2262-46ca-94e1-eda3630fcbe9")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "RW")
+         (LgConnNode "RW")
          (LgConnDirNode "+")
       )
    )
@@ -289,44 +289,44 @@
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Ss@cbd19ce8-c893-49c5-8b19-0e1a2d06a43f")
    (LgConnector
-      (LgConnectorNode "Ss")
+      (LgConnNode "Ss")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Ss")
+      (LgConnNode "Ss")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Wd@57a18b7c-2fdf-40b2-aaf3-a444bf7df212")
    (LgConnector
-      (LgConnectorNode "Wd")
+      (LgConnNode "Wd")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Wd")
+      (LgConnNode "Wd")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Xp@58792729-0309-4fc1-afdc-267b6908791b")
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "WV@65356044-9b52-4580-81c2-5fe7c90553d7")
    (LgConnector
-      (LgConnectorNode "hWV")
+      (LgConnNode "hWV")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "dWV")
+      (LgConnNode "dWV")
       (LgConnDirNode "-")
    )
 )

--- a/tests/nlp/sureal/r2l-atomspace2.scm
+++ b/tests/nlp/sureal/r2l-atomspace2.scm
@@ -525,15 +525,15 @@
    (WordInstanceNode "LEFT-WALL@sentence@7385a85d-928e-4d89-a87f-6f36a470491e_parse_0")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "hWV")
+         (LgConnNode "hWV")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "+")
       )
    )
@@ -542,11 +542,11 @@
    (WordInstanceNode "he@0dc3eaff-5250-4a13-a49c-b823f1329c73")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "+")
       )
    )
@@ -555,11 +555,11 @@
    (WordInstanceNode "he@be348474-26a7-4bb7-b37a-1cb282327d73")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "+")
       )
    )
@@ -568,11 +568,11 @@
    (WordInstanceNode "runs@3c28a178-5584-4800-bef7-68f7c25a9f78")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "dWV")
+         (LgConnNode "dWV")
          (LgConnDirNode "-")
       )
    )
@@ -581,15 +581,15 @@
    (WordInstanceNode "runs@ab2940c8-f997-4d4d-9200-80c7ab661019")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "dWV")
+         (LgConnNode "dWV")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "MV")
+         (LgConnNode "MV")
          (LgConnDirNode "+")
       )
    )
@@ -598,11 +598,11 @@
    (WordInstanceNode ".@7eb1de0f-f72e-4a1f-a881-47341119a150")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "RW")
+         (LgConnNode "RW")
          (LgConnDirNode "+")
       )
    )
@@ -611,15 +611,15 @@
    (WordInstanceNode "LEFT-WALL@sentence@9f079f5d-052f-47d5-aae4-a0f1c1b8ea93_parse_0")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "hWV")
+         (LgConnNode "hWV")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "+")
       )
    )
@@ -628,7 +628,7 @@
    (WordInstanceNode "quickly@7c8c7ca3-44bd-46b9-9e09-941254ac91d7")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "MVa")
+         (LgConnNode "MVa")
          (LgConnDirNode "-")
       )
    )
@@ -637,11 +637,11 @@
    (WordInstanceNode ".@9d9fdef4-db0f-4ad4-908f-7d397e6eb0d1")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "RW")
+         (LgConnNode "RW")
          (LgConnDirNode "+")
       )
    )
@@ -649,99 +649,99 @@
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Ss@179225fd-e0c2-479e-8a2e-ccb0d69b93fd")
    (LgConnector
-      (LgConnectorNode "Ss")
+      (LgConnNode "Ss")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Ss")
+      (LgConnNode "Ss")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Wd@3bc94a11-569b-44d2-a3f2-56927fa2811a")
    (LgConnector
-      (LgConnectorNode "Wd")
+      (LgConnNode "Wd")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Wd")
+      (LgConnNode "Wd")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Wd@45cfbdac-5eb0-48f2-889c-e42c204e1458")
    (LgConnector
-      (LgConnectorNode "Wd")
+      (LgConnNode "Wd")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Wd")
+      (LgConnNode "Wd")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "MVa@48608ad3-93b1-4736-8ab4-aba058391a56")
    (LgConnector
-      (LgConnectorNode "MV")
+      (LgConnNode "MV")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "MVa")
+      (LgConnNode "MVa")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Xp@0f5eee7a-7541-49b3-9057-e831f402fb0b")
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "WV@d6dae407-a5b9-4ef7-9aaf-f1177d45faf7")
    (LgConnector
-      (LgConnectorNode "hWV")
+      (LgConnNode "hWV")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "dWV")
+      (LgConnNode "dWV")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Ss@c8ca87c2-3064-48e1-bce8-4e10dab8fea5")
    (LgConnector
-      (LgConnectorNode "Ss")
+      (LgConnNode "Ss")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Ss")
+      (LgConnNode "Ss")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Xp@44355044-58b9-44ad-8406-58cc60a9bbc5")
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "WV@90f5e59e-d7e3-470d-a213-47dfb642af5c")
    (LgConnector
-      (LgConnectorNode "hWV")
+      (LgConnNode "hWV")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "dWV")
+      (LgConnNode "dWV")
       (LgConnDirNode "-")
    )
 )

--- a/tests/nlp/sureal/r2l-atomspace3.scm
+++ b/tests/nlp/sureal/r2l-atomspace3.scm
@@ -439,15 +439,15 @@
    (WordInstanceNode "LEFT-WALL@sentence@991a9f76-4485-454b-8a2e-0caa9176ca5e_parse_0")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "hWV")
+         (LgConnNode "hWV")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "+")
       )
    )
@@ -456,7 +456,7 @@
    (WordInstanceNode "the@36a7d53d-6e02-4524-bd27-fea65d1aa7de")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "D")
+         (LgConnNode "D")
          (LgConnDirNode "+")
       )
    )
@@ -465,7 +465,7 @@
    (WordInstanceNode "yellow@3ef5a0ee-558d-4157-be61-29700a00451f")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "A")
+         (LgConnNode "A")
          (LgConnDirNode "+")
       )
    )
@@ -474,19 +474,19 @@
    (WordInstanceNode "dog@ef0b81f7-f20f-43cf-a650-80150dc8f121")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "A")
+         (LgConnNode "A")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Ds**x")
+         (LgConnNode "Ds**x")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "+")
       )
    )
@@ -495,15 +495,15 @@
    (WordInstanceNode "hates@b1c858bb-6a0c-4488-b95c-3d3413d1d3a5")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "dWV")
+         (LgConnNode "dWV")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "O")
+         (LgConnNode "O")
          (LgConnDirNode "+")
       )
    )
@@ -512,7 +512,7 @@
    (WordInstanceNode "the@19347b37-c8b3-4f52-bae4-30a196eb134c")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "D")
+         (LgConnNode "D")
          (LgConnDirNode "+")
       )
    )
@@ -521,11 +521,11 @@
    (WordInstanceNode "cat@fb08d0ff-337f-425e-88ce-c07d7dc0919f")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Ds**c")
+         (LgConnNode "Ds**c")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Os")
+         (LgConnNode "Os")
          (LgConnDirNode "-")
       )
    )
@@ -534,11 +534,11 @@
    (WordInstanceNode ".@a15ff372-419e-482c-9973-ae3868094818")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "RW")
+         (LgConnNode "RW")
          (LgConnDirNode "+")
       )
    )
@@ -546,88 +546,88 @@
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Ss@d4fccdde-8bad-4d70-9ab6-e52634ff6db0")
    (LgConnector
-      (LgConnectorNode "Ss")
+      (LgConnNode "Ss")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Ss")
+      (LgConnNode "Ss")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Xp@797954e6-9df4-4968-8e87-b94d2ab54b6e")
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Ds**c@bfedd0bd-7d57-4a70-9ef1-c22dd471c30c")
    (LgConnector
-      (LgConnectorNode "D")
+      (LgConnNode "D")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Ds**c")
+      (LgConnNode "Ds**c")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Os@cdc85e64-a6fe-435c-bbea-3820cc669498")
    (LgConnector
-      (LgConnectorNode "O")
+      (LgConnNode "O")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Os")
+      (LgConnNode "Os")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Ds**x@01f3a3f8-ce3b-431f-886e-6fd20df74dad")
    (LgConnector
-      (LgConnectorNode "D")
+      (LgConnNode "D")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Ds**x")
+      (LgConnNode "Ds**x")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "A@73e03589-13f2-4c11-9485-26c110f12f85")
    (LgConnector
-      (LgConnectorNode "A")
+      (LgConnNode "A")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "A")
+      (LgConnNode "A")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Wd@d37c12cc-cae7-433c-b453-83047820f67c")
    (LgConnector
-      (LgConnectorNode "Wd")
+      (LgConnNode "Wd")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Wd")
+      (LgConnNode "Wd")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "WV@8af62156-7490-403a-839c-84b9ee6f31cd")
    (LgConnector
-      (LgConnectorNode "hWV")
+      (LgConnNode "hWV")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "dWV")
+      (LgConnNode "dWV")
       (LgConnDirNode "-")
    )
 )

--- a/tests/nlp/sureal/r2l-atomspace4.scm
+++ b/tests/nlp/sureal/r2l-atomspace4.scm
@@ -10,7 +10,7 @@
       (WordInstanceNode "slowly@6abf64e4-4a58-4b46-b61e-9c3b57a24a7e")
       (LgAnd
          (LgConnector
-            (LgConnectorNode "MVa")
+            (LgConnNode "MVa")
             (LgConnDirNode "-")
          )
       )
@@ -59,11 +59,11 @@
    (LgLinkInstanceLink
       (LgLinkInstanceNode "Xx@eba84408-d5cd-42a8-91a4-c1a63c7ebcc0")
       (LgConnector
-         (LgConnectorNode "Xx")
+         (LgConnNode "Xx")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Xx")
+         (LgConnNode "Xx")
          (LgConnDirNode "-")
       )
    )
@@ -114,15 +114,15 @@
       (WordInstanceNode "and@1ef48d92-1900-4ff2-bb9e-15f3f340a9f6")
       (LgAnd
          (LgConnector
-            (LgConnectorNode "Xx")
+            (LgConnNode "Xx")
             (LgConnDirNode "-")
          )
          (LgConnector
-            (LgConnectorNode "Wdc")
+            (LgConnNode "Wdc")
             (LgConnDirNode "+")
          )
          (LgConnector
-            (LgConnectorNode "hWV")
+            (LgConnNode "hWV")
             (LgConnDirNode "+")
          )
       )
@@ -180,15 +180,15 @@
       (WordInstanceNode "ran@c77c0ad2-9cb9-41e7-9f09-9e607c8c1bca")
       (LgAnd
          (LgConnector
-            (LgConnectorNode "S")
+            (LgConnNode "S")
             (LgConnDirNode "-")
          )
          (LgConnector
-            (LgConnectorNode "dWV")
+            (LgConnNode "dWV")
             (LgConnDirNode "-")
          )
          (LgConnector
-            (LgConnectorNode "MV")
+            (LgConnNode "MV")
             (LgConnDirNode "+")
             (LgConnMultiNode "@")
          )
@@ -205,15 +205,15 @@
       (WordInstanceNode "walked@9502ed4e-4dd9-4655-a17b-3ac2d1296a9c")
       (LgAnd
          (LgConnector
-            (LgConnectorNode "S")
+            (LgConnNode "S")
             (LgConnDirNode "-")
          )
          (LgConnector
-            (LgConnectorNode "dWV")
+            (LgConnNode "dWV")
             (LgConnDirNode "-")
          )
          (LgConnector
-            (LgConnectorNode "MV")
+            (LgConnNode "MV")
             (LgConnDirNode "+")
             (LgConnMultiNode "@")
          )
@@ -249,19 +249,19 @@
       (WordInstanceNode "LEFT-WALL@sentence@dcf4acc4-45e1-4787-9a67-5e0c326b0fa7_parse_0")
       (LgAnd
          (LgConnector
-            (LgConnectorNode "Wd")
+            (LgConnNode "Wd")
             (LgConnDirNode "+")
          )
          (LgConnector
-            (LgConnectorNode "hWV")
+            (LgConnNode "hWV")
             (LgConnDirNode "+")
          )
          (LgConnector
-            (LgConnectorNode "Xx")
+            (LgConnNode "Xx")
             (LgConnDirNode "+")
          )
          (LgConnector
-            (LgConnectorNode "Xp")
+            (LgConnNode "Xp")
             (LgConnDirNode "+")
          )
       )
@@ -273,11 +273,11 @@
    (LgLinkInstanceLink
       (LgLinkInstanceNode "MVa@a524dfc4-bfa0-4def-9be9-d5a2d6cf40ca")
       (LgConnector
-         (LgConnectorNode "MV")
+         (LgConnNode "MV")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "MVa")
+         (LgConnNode "MVa")
          (LgConnDirNode "-")
       )
    )
@@ -305,11 +305,11 @@
       (WordInstanceNode ".@d2a76d9e-2e93-41b8-96fa-be1607d08a7a")
       (LgAnd
          (LgConnector
-            (LgConnectorNode "Xp")
+            (LgConnNode "Xp")
             (LgConnDirNode "-")
          )
          (LgConnector
-            (LgConnectorNode "RW")
+            (LgConnNode "RW")
             (LgConnDirNode "+")
          )
       )
@@ -329,11 +329,11 @@
       (WordInstanceNode "he@4723bbce-6397-4702-a377-1ff634cd5d24")
       (LgAnd
          (LgConnector
-            (LgConnectorNode "Wd")
+            (LgConnNode "Wd")
             (LgConnDirNode "-")
          )
          (LgConnector
-            (LgConnectorNode "Ss")
+            (LgConnNode "Ss")
             (LgConnDirNode "+")
          )
       )
@@ -353,11 +353,11 @@
    (LgLinkInstanceLink
       (LgLinkInstanceNode "WV@c68260ae-0d3e-48d1-8cfe-2df0db261268")
       (LgConnector
-         (LgConnectorNode "hWV")
+         (LgConnNode "hWV")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "dWV")
+         (LgConnNode "dWV")
          (LgConnDirNode "-")
       )
    )
@@ -372,22 +372,22 @@
    (LgLinkInstanceLink
       (LgLinkInstanceNode "Ss@52352fa0-180f-40e2-ac47-3ca092ddaebf")
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "S")
+         (LgConnNode "S")
          (LgConnDirNode "-")
       )
    )
    (LgLinkInstanceLink
       (LgLinkInstanceNode "Ss@2ad1ab03-997c-463b-876a-1bb629208429")
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "S")
+         (LgConnNode "S")
          (LgConnDirNode "-")
       )
    )
@@ -504,11 +504,11 @@
    (LgLinkInstanceLink
       (LgLinkInstanceNode "Wd@d7ab32c2-13e8-499a-ac20-4b64f2a10720")
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "-")
       )
    )
@@ -562,11 +562,11 @@
    (LgLinkInstanceLink
       (LgLinkInstanceNode "Xp@ec0fa957-f0ea-4bd0-9e36-1b14451945f0")
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "-")
       )
    )
@@ -574,11 +574,11 @@
       (WordInstanceNode "she@ff7b10a4-60df-4d80-8e39-43eb13f1071c")
       (LgAnd
          (LgConnector
-            (LgConnectorNode "Wd")
+            (LgConnNode "Wd")
             (LgConnDirNode "-")
          )
          (LgConnector
-            (LgConnectorNode "Ss")
+            (LgConnNode "Ss")
             (LgConnDirNode "+")
          )
       )
@@ -624,11 +624,11 @@
    (LgLinkInstanceLink
       (LgLinkInstanceNode "Wdc@20038dfc-66b9-4f3b-b89c-1c045c770399")
       (LgConnector
-         (LgConnectorNode "Wdc")
+         (LgConnNode "Wdc")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "-")
       )
    )
@@ -640,7 +640,7 @@
       (WordInstanceNode "quickly@2ea7ff49-ca69-4451-be82-2d38d422f1da")
       (LgAnd
          (LgConnector
-            (LgConnectorNode "MVa")
+            (LgConnNode "MVa")
             (LgConnDirNode "-")
          )
       )
@@ -682,11 +682,11 @@
    (LgLinkInstanceLink
       (LgLinkInstanceNode "WV@176b6fa3-a1e3-4547-8bbe-0e9a371b8220")
       (LgConnector
-         (LgConnectorNode "hWV")
+         (LgConnNode "hWV")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "dWV")
+         (LgConnNode "dWV")
          (LgConnDirNode "-")
       )
    )
@@ -705,11 +705,11 @@
    (LgLinkInstanceLink
       (LgLinkInstanceNode "MVa@256c8e59-c420-4908-a530-576166bfe85f")
       (LgConnector
-         (LgConnectorNode "MV")
+         (LgConnNode "MV")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "MVa")
+         (LgConnNode "MVa")
          (LgConnDirNode "-")
       )
    )

--- a/tests/nlp/sureal/r2l-atomspace5.scm
+++ b/tests/nlp/sureal/r2l-atomspace5.scm
@@ -474,15 +474,15 @@
    (WordInstanceNode "LEFT-WALL@sentence@75d2a7b8-8ace-43f9-b823-592c63e17f04_parse_0")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "hWV")
+         (LgConnNode "hWV")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "+")
       )
    )
@@ -491,11 +491,11 @@
    (WordInstanceNode "he@23716e27-65f3-4a65-9be8-a37b5fbb0195")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "+")
       )
    )
@@ -504,15 +504,15 @@
    (WordInstanceNode "ate@2248db85-cdb2-44e3-a7db-51222fe86ca4")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "S")
+         (LgConnNode "S")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "dWV")
+         (LgConnNode "dWV")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "O")
+         (LgConnNode "O")
          (LgConnDirNode "+")
       )
    )
@@ -521,11 +521,11 @@
    (WordInstanceNode "a@947690d1-e072-45a8-977c-805ad58cb671")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "PHc")
+         (LgConnNode "PHc")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Ds**x")
+         (LgConnNode "Ds**x")
          (LgConnDirNode "+")
       )
    )
@@ -534,11 +534,11 @@
    (WordInstanceNode "big@cc6d1269-54f2-434e-8c25-ed561845de18")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "PHc")
+         (LgConnNode "PHc")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "A")
+         (LgConnNode "A")
          (LgConnDirNode "+")
       )
    )
@@ -547,7 +547,7 @@
    (WordInstanceNode "round@c2e4cf62-8009-42b5-a0fb-4b50a1ef20ea")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "A")
+         (LgConnNode "A")
          (LgConnDirNode "+")
       )
    )
@@ -556,16 +556,16 @@
    (WordInstanceNode "olive@f574fb10-4d6d-4b35-a925-6addc9cf9392")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "A")
+         (LgConnNode "A")
          (LgConnDirNode "-")
          (LgConnMultiNode "@")
       )
       (LgConnector
-         (LgConnectorNode "Ds**x")
+         (LgConnNode "Ds**x")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Os")
+         (LgConnNode "Os")
          (LgConnDirNode "-")
       )
    )
@@ -574,11 +574,11 @@
    (WordInstanceNode ".@eed112fc-2060-4829-adc3-5c68c5dcc0d7")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "RW")
+         (LgConnNode "RW")
          (LgConnDirNode "+")
       )
    )
@@ -586,99 +586,99 @@
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Ss@d2153f37-ce5e-4bb1-9885-74585c1f7e27")
    (LgConnector
-      (LgConnectorNode "Ss")
+      (LgConnNode "Ss")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "S")
+      (LgConnNode "S")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Ds**x@86990337-35c3-48f2-bd03-f179321ef97b")
    (LgConnector
-      (LgConnectorNode "Ds**x")
+      (LgConnNode "Ds**x")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Ds**x")
+      (LgConnNode "Ds**x")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "PHc@e75d0c42-6594-4d3e-a1a7-11628c79409c")
    (LgConnector
-      (LgConnectorNode "PHc")
+      (LgConnNode "PHc")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "PHc")
+      (LgConnNode "PHc")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "A@b1013a2d-0106-4558-b059-ebafda5f4f15")
    (LgConnector
-      (LgConnectorNode "A")
+      (LgConnNode "A")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "A")
+      (LgConnNode "A")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "A@445ef233-2992-448c-bacd-5702b14f3d0c")
    (LgConnector
-      (LgConnectorNode "A")
+      (LgConnNode "A")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "A")
+      (LgConnNode "A")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Os@83fcef0d-7533-42a9-879f-74dcd9394342")
    (LgConnector
-      (LgConnectorNode "O")
+      (LgConnNode "O")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Os")
+      (LgConnNode "Os")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Xp@fb2d90de-397c-42ab-8ae9-024f0a8da47c")
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Wd@a4ffa517-489a-40dd-88cf-e002bf092056")
    (LgConnector
-      (LgConnectorNode "Wd")
+      (LgConnNode "Wd")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Wd")
+      (LgConnNode "Wd")
       (LgConnDirNode "-")
    )
 )
 (LgLinkInstanceLink
    (LgLinkInstanceNode "WV@552831ab-c52d-40dc-98a5-969e6c3e7e68")
    (LgConnector
-      (LgConnectorNode "hWV")
+      (LgConnNode "hWV")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "dWV")
+      (LgConnNode "dWV")
       (LgConnDirNode "-")
    )
 )

--- a/tests/nlp/sureal/r2l-atomspace6.scm
+++ b/tests/nlp/sureal/r2l-atomspace6.scm
@@ -63,15 +63,15 @@
    (WordInstanceNode "eats@b2862737-d65b-4c81-a1db-7ef65f5bf0c8")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "dWV")
+         (LgConnNode "dWV")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "MV")
+         (LgConnNode "MV")
          (LgConnDirNode "+")
          (LgConnMultiNode "@")
       )
@@ -121,7 +121,7 @@
    (WordInstanceNode "quickly@6d5b0484-eb56-4a4e-887a-108fb300e391")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "MVa")
+         (LgConnNode "MVa")
          (LgConnDirNode "-")
       )
    )
@@ -142,15 +142,15 @@
    (WordInstanceNode "LEFT-WALL@sentence@42268c2b-9a82-4247-9c61-2b565818c9ac_parse_0")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "hWV")
+         (LgConnNode "hWV")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "+")
       )
    )
@@ -191,11 +191,11 @@
    (WordInstanceNode ".@af81ed10-7bd4-4e7c-b4f9-255ac44ff7f5")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "RW")
+         (LgConnNode "RW")
          (LgConnDirNode "+")
       )
    )
@@ -232,11 +232,11 @@
    (WordInstanceNode "she@cc9806ed-8bbc-4ec2-9c4d-a97ba41f700f")
    (LgAnd
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "-")
       )
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "+")
       )
    )
@@ -268,11 +268,11 @@
 (LgLinkInstanceLink
    (LgLinkInstanceNode "MVa@54917077-b881-4840-b88c-d1c0c9ee06f6")
    (LgConnector
-      (LgConnectorNode "MV")
+      (LgConnNode "MV")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "MVa")
+      (LgConnNode "MVa")
       (LgConnDirNode "-")
    )
 )
@@ -297,11 +297,11 @@
 (LgLinkInstanceLink
    (LgLinkInstanceNode "WV@5bc2e712-4688-4c94-b4b5-fdab55535193")
    (LgConnector
-      (LgConnectorNode "hWV")
+      (LgConnNode "hWV")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "dWV")
+      (LgConnNode "dWV")
       (LgConnDirNode "-")
    )
 )
@@ -319,11 +319,11 @@
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Ss@d5fed3b0-9ed5-4ec7-8a93-025f76481318")
    (LgConnector
-      (LgConnectorNode "Ss")
+      (LgConnNode "Ss")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Ss")
+      (LgConnNode "Ss")
       (LgConnDirNode "-")
    )
 )
@@ -341,11 +341,11 @@
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Xp@01d297ec-49e6-4ff5-a8a9-ca153f2ad37b")
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Xp")
+      (LgConnNode "Xp")
       (LgConnDirNode "-")
    )
 )
@@ -363,11 +363,11 @@
 (LgLinkInstanceLink
    (LgLinkInstanceNode "Wd@dec4f2f9-fef5-4732-bf21-f37a2a923d96")
    (LgConnector
-      (LgConnectorNode "Wd")
+      (LgConnNode "Wd")
       (LgConnDirNode "+")
    )
    (LgConnector
-      (LgConnectorNode "Wd")
+      (LgConnNode "Wd")
       (LgConnDirNode "-")
    )
 )

--- a/tests/nlp/sureal/r2l-atomspace7.scm
+++ b/tests/nlp/sureal/r2l-atomspace7.scm
@@ -19,11 +19,11 @@
    (LgLinkInstanceLink
       (LgLinkInstanceNode "WV@bd37d44a-b2aa-44e3-8523-dc0a9f226b5f")
       (LgConnector
-         (LgConnectorNode "hWV")
+         (LgConnNode "hWV")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "dWV")
+         (LgConnNode "dWV")
          (LgConnDirNode "-")
       )
    )
@@ -42,19 +42,19 @@
       (WordInstanceNode "LEFT-WALL@sentence@c4d06d71-4b2b-476b-8442-aece0563ce3b_parse_0")
       (LgAnd
          (LgConnector
-            (LgConnectorNode "Wd")
+            (LgConnNode "Wd")
             (LgConnDirNode "+")
          )
          (LgConnector
-            (LgConnectorNode "hWV")
+            (LgConnNode "hWV")
             (LgConnDirNode "+")
          )
          (LgConnector
-            (LgConnectorNode "Xx")
+            (LgConnNode "Xx")
             (LgConnDirNode "+")
          )
          (LgConnector
-            (LgConnectorNode "Xp")
+            (LgConnNode "Xp")
             (LgConnDirNode "+")
          )
       )
@@ -70,11 +70,11 @@
    (LgLinkInstanceLink
       (LgLinkInstanceNode "Xp@872de086-c9e5-4ba3-9568-a0da74041b50")
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "-")
       )
    )
@@ -82,11 +82,11 @@
       (WordInstanceNode "spoke@366b1bb0-aabf-4b57-9557-a3bdd994079f")
       (LgAnd
          (LgConnector
-            (LgConnectorNode "S")
+            (LgConnNode "S")
             (LgConnDirNode "-")
          )
          (LgConnector
-            (LgConnectorNode "dWV")
+            (LgConnNode "dWV")
             (LgConnDirNode "-")
          )
       )
@@ -124,11 +124,11 @@
    (LgLinkInstanceLink
       (LgLinkInstanceNode "Xx@2dd09ffb-6f0f-4ef8-8078-ffaa15aa3295")
       (LgConnector
-         (LgConnectorNode "Xx")
+         (LgConnNode "Xx")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Xx")
+         (LgConnNode "Xx")
          (LgConnDirNode "-")
       )
    )
@@ -172,11 +172,11 @@
    (LgLinkInstanceLink
       (LgLinkInstanceNode "WV@dfefe23e-adea-4187-89df-57be79f976cc")
       (LgConnector
-         (LgConnectorNode "hWV")
+         (LgConnNode "hWV")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "dWV")
+         (LgConnNode "dWV")
          (LgConnDirNode "-")
       )
    )
@@ -260,11 +260,11 @@
    (LgLinkInstanceLink
       (LgLinkInstanceNode "Ss@0f088e9a-9f4e-405d-8521-ec9be85c24ac")
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "-")
       )
    )
@@ -311,11 +311,11 @@
       (WordInstanceNode "drinks@7e2661f6-5361-468b-91ac-c39b6e2b2e50")
       (LgAnd
          (LgConnector
-            (LgConnectorNode "Ss")
+            (LgConnNode "Ss")
             (LgConnDirNode "-")
          )
          (LgConnector
-            (LgConnectorNode "dWV")
+            (LgConnNode "dWV")
             (LgConnDirNode "-")
          )
       )
@@ -343,11 +343,11 @@
    (LgLinkInstanceLink
       (LgLinkInstanceNode "Ss@dc62d97c-ed9a-408e-aee4-f66f3f4c56ee")
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "S")
+         (LgConnNode "S")
          (LgConnDirNode "-")
       )
    )
@@ -367,11 +367,11 @@
       (WordInstanceNode "she@9aa88879-9bb7-4fdf-9565-955ca8672a86")
       (LgAnd
          (LgConnector
-            (LgConnectorNode "Wd")
+            (LgConnNode "Wd")
             (LgConnDirNode "-")
          )
          (LgConnector
-            (LgConnectorNode "Ss")
+            (LgConnNode "Ss")
             (LgConnDirNode "+")
          )
       )
@@ -410,15 +410,15 @@
       (WordInstanceNode "and@f078a05c-1ae1-4dde-92c9-73a78076e014")
       (LgAnd
          (LgConnector
-            (LgConnectorNode "Xx")
+            (LgConnNode "Xx")
             (LgConnDirNode "-")
          )
          (LgConnector
-            (LgConnectorNode "Wdc")
+            (LgConnNode "Wdc")
             (LgConnDirNode "+")
          )
          (LgConnector
-            (LgConnectorNode "hWV")
+            (LgConnNode "hWV")
             (LgConnDirNode "+")
          )
       )
@@ -453,11 +453,11 @@
    (LgLinkInstanceLink
       (LgLinkInstanceNode "Wdc@36800318-cf6f-4d59-b189-7f904300454e")
       (LgConnector
-         (LgConnectorNode "Wdc")
+         (LgConnNode "Wdc")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "-")
       )
    )
@@ -465,11 +465,11 @@
       (WordInstanceNode "John@d729ad67-55a6-431d-9704-c327935a026e")
       (LgAnd
          (LgConnector
-            (LgConnectorNode "Wd")
+            (LgConnNode "Wd")
             (LgConnDirNode "-")
          )
          (LgConnector
-            (LgConnectorNode "Ss")
+            (LgConnNode "Ss")
             (LgConnDirNode "+")
          )
       )
@@ -524,11 +524,11 @@
    (LgLinkInstanceLink
       (LgLinkInstanceNode "Wd@300b04c0-6ae7-4a71-ac23-c62e61692bff")
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "-")
       )
    )
@@ -556,11 +556,11 @@
       (WordInstanceNode ".@fc6cbade-1348-4605-b53f-90ae18c4d27a")
       (LgAnd
          (LgConnector
-            (LgConnectorNode "Xp")
+            (LgConnNode "Xp")
             (LgConnDirNode "-")
          )
          (LgConnector
-            (LgConnectorNode "RW")
+            (LgConnNode "RW")
             (LgConnDirNode "+")
          )
       )
@@ -593,11 +593,11 @@
    (LgLinkInstanceLink
       (LgLinkInstanceNode "WV@6ac25c9e-ee93-4154-9a78-20a27ec3ed51")
       (LgConnector
-         (LgConnectorNode "hWV")
+         (LgConnNode "hWV")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "dWV")
+         (LgConnNode "dWV")
          (LgConnDirNode "-")
       )
    )
@@ -638,11 +638,11 @@
    (LgLinkInstanceLink
       (LgLinkInstanceNode "Ss@1405d3c2-3c83-4cf5-a23c-e71589157ce8")
       (LgConnector
-         (LgConnectorNode "Ss")
+         (LgConnNode "Ss")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "S")
+         (LgConnNode "S")
          (LgConnDirNode "-")
       )
    )
@@ -662,7 +662,7 @@
       (WordInstanceNode "the@411f0d45-e34e-47ea-8c0e-02152fa2a557")
       (LgAnd
          (LgConnector
-            (LgConnectorNode "D")
+            (LgConnNode "D")
             (LgConnDirNode "+")
          )
       )
@@ -700,22 +700,22 @@
    (LgLinkInstanceLink
       (LgLinkInstanceNode "Wd@c19e5274-010c-4a9a-8272-94b1bf8361ee")
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Wd")
+         (LgConnNode "Wd")
          (LgConnDirNode "-")
       )
    )
    (LgLinkInstanceLink
       (LgLinkInstanceNode "Dmc@322eed3f-ab0e-46d3-80d5-642ce68bed14")
       (LgConnector
-         (LgConnectorNode "D")
+         (LgConnNode "D")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Dmc")
+         (LgConnNode "Dmc")
          (LgConnDirNode "-")
       )
    )
@@ -781,15 +781,15 @@
       (WordInstanceNode "LEFT-WALL@sentence@33d31c08-7578-4047-9f65-3a35ad3c4bf0_parse_0")
       (LgAnd
          (LgConnector
-            (LgConnectorNode "Wd")
+            (LgConnNode "Wd")
             (LgConnDirNode "+")
          )
          (LgConnector
-            (LgConnectorNode "hWV")
+            (LgConnNode "hWV")
             (LgConnDirNode "+")
          )
          (LgConnector
-            (LgConnectorNode "Xp")
+            (LgConnNode "Xp")
             (LgConnDirNode "+")
          )
       )
@@ -845,11 +845,11 @@
       (WordInstanceNode "cakes@5810bf19-e13f-414a-85cb-89f71a5c6396")
       (LgAnd
          (LgConnector
-            (LgConnectorNode "Dmc")
+            (LgConnNode "Dmc")
             (LgConnDirNode "-")
          )
          (LgConnector
-            (LgConnectorNode "Op")
+            (LgConnNode "Op")
             (LgConnDirNode "-")
          )
       )
@@ -858,11 +858,11 @@
       (WordInstanceNode "he@7ee93111-9b6f-4bf8-8374-2ccb898e9f88")
       (LgAnd
          (LgConnector
-            (LgConnectorNode "Wd")
+            (LgConnNode "Wd")
             (LgConnDirNode "-")
          )
          (LgConnector
-            (LgConnectorNode "Ss")
+            (LgConnNode "Ss")
             (LgConnDirNode "+")
          )
       )
@@ -901,15 +901,15 @@
       (WordInstanceNode "ate@b59a8efb-34c3-42c6-bd03-e21f8fa88bf8")
       (LgAnd
          (LgConnector
-            (LgConnectorNode "S")
+            (LgConnNode "S")
             (LgConnDirNode "-")
          )
          (LgConnector
-            (LgConnectorNode "dWV")
+            (LgConnNode "dWV")
             (LgConnDirNode "-")
          )
          (LgConnector
-            (LgConnectorNode "O")
+            (LgConnNode "O")
             (LgConnDirNode "+")
          )
       )
@@ -952,11 +952,11 @@
       (WordInstanceNode ".@4feeaa10-ae39-42d1-8bd6-8b4742318952")
       (LgAnd
          (LgConnector
-            (LgConnectorNode "Xp")
+            (LgConnNode "Xp")
             (LgConnDirNode "-")
          )
          (LgConnector
-            (LgConnectorNode "RW")
+            (LgConnNode "RW")
             (LgConnDirNode "+")
          )
       )
@@ -980,22 +980,22 @@
    (LgLinkInstanceLink
       (LgLinkInstanceNode "Xp@05679a2a-ca09-4a6c-921a-99771dacdc55")
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Xp")
+         (LgConnNode "Xp")
          (LgConnDirNode "-")
       )
    )
    (LgLinkInstanceLink
       (LgLinkInstanceNode "Op@97272f51-5647-4919-b122-93da5f8b4ec6")
       (LgConnector
-         (LgConnectorNode "O")
+         (LgConnNode "O")
          (LgConnDirNode "+")
       )
       (LgConnector
-         (LgConnectorNode "Op")
+         (LgConnNode "Op")
          (LgConnDirNode "-")
       )
    )


### PR DESCRIPTION
Appearantly, there was a long-standing atom naming conflict,
where there was both an LgConnectorLink and a LgConnectorNode.
Appearently, this used to work ... and recently broke, both for
unknown reasons. Rather than tracking down the breakage, it seems
like the correct solution is to fix the actual naming conflict.
    
This is especially the case, as this code seems mostly unused, and
therefore unlikely to break anyone.
